### PR TITLE
Use offsetX/offsetY to compute mouse position in default raycaster

### DIFF
--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -354,8 +354,8 @@ export const useCanvas = (props: UseCanvasProps): DomEventHandlers => {
 
   /**  Calculates click deltas */
   const calculateDistance = useCallback((event: DomEvent) => {
-    const dx = event.clientX - state.current.initialClick[0]
-    const dy = event.clientY - state.current.initialClick[1]
+    const dx = event.nativeEvent.offsetX - state.current.initialClick[0]
+    const dy = event.nativeEvent.offsetY - state.current.initialClick[1]
     return Math.round(Math.sqrt(dx * dx + dy * dy))
   }, [])
 
@@ -523,7 +523,7 @@ export const useCanvas = (props: UseCanvasProps): DomEventHandlers => {
       })
       // If a click yields no results, pass it back to the user as a miss
       if (name === 'pointerDown') {
-        state.current.initialClick = [event.clientX, event.clientY]
+        state.current.initialClick = [event.nativeEvent.offsetX, event.nativeEvent.offsetY]
         state.current.initialHits = hits.map((hit: any) => hit.eventObject)
       }
 

--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -301,10 +301,11 @@ export const useCanvas = (props: UseCanvasProps): DomEventHandlers => {
   /** Events ------------------------------------------------------------------------------------------------ */
 
   /** Sets up defaultRaycaster */
-  const prepareRay = useCallback(({ clientX, clientY }) => {
-    if (clientX !== void 0) {
-      const { left, right, top, bottom } = state.current.size
-      mouse.set(((clientX - left) / (right - left)) * 2 - 1, -((clientY - top) / (bottom - top)) * 2 + 1)
+  const prepareRay = useCallback(({ nativeEvent }) => {
+    if (nativeEvent !== void 0) {
+      const { offsetX, offsetY } = nativeEvent
+      const { width, height } = state.current.size
+      mouse.set((offsetX / width) * 2 - 1, -(offsetY / height) * 2 + 1)
       defaultRaycaster.setFromCamera(mouse, state.current.camera)
     }
   }, [])


### PR DESCRIPTION
Fix #350 

The canvas-relative cursor coordinates given to the default raycaster used to be computed based on the position of the cursor in relation to the viewport (`clientX`/`clientY`) and the position of the canvas (`left`/`top`) provided by `useMeasure` (via `ResizeContainer.tsx`).

When the canvas moves on the screen without being resized or without the viewport being scrolled or resized, `useMeasure` has no way of knowing it, so `prepareRay` used to rely on potentially outdated canvas positions.

With this fix, `prepareRay` now uses the cursor's `offsetX` and `offsetY` positions, which are already canvas-relative coordinates, so the position of the canvas in the viewport no longer matters.

---

If I'm not 100% sure, but I think this fix means that raycasting will now work regardless of scroll. So it may be possible to disable scroll detection in `useMeasure` by setting the `scroll` configuration option to `false` by default.