### PR TITLE
Update api.md to clarify renderPriority usage

### DIFF
--- a/markdown/api.md
+++ b/markdown/api.md
@@ -379,7 +379,7 @@ const Controls = () => {
 }
 ```
 
-Once you supply a non-zero render priority, this will cause react-three-fiber to disable its automatic rendering, and it will be your responsibility to render explicitly. This gives you immediate control over the order in which callbacks and rendering are executed:
+Using a non-zero render priority will cause react-three-fiber to disable its automatic rendering, and it will be your responsibility to render explicitly. This gives you immediate control over the order in which callbacks and rendering are executed:
 
 ```jsx
 useFrame(({ gl, scene, camera }) => gl.render(scene, camera), 1)

--- a/markdown/api.md
+++ b/markdown/api.md
@@ -362,7 +362,7 @@ forceResize()
 useFrame((callback: (state, delta) => void), (renderPriority: number = 0))
 ```
 
-This hook calls you back every frame, which is good for running effects, updating controls, etc. You receive the state (same as useThree) and a clock delta. If you supply a render priority greater than zero it will switch off automatic rendering entirely, you can then control rendering yourself. If you have multiple frames with a render priority then they are ordered highest priority last, similar to the web's z-index. Frames are managed, three-fiber will remove them automatically when the component that holds them is unmounted.
+Allows you to execute code on every frame rendered, like running effects, updating controls, and so on. You receive the state (same as useThree) and a clock delta. In addition to the callback function itself, you may pass a numerical `renderPriority` value; callbacks will be executed in order of ascending priority values (lowest first, highest last.) 
 
 Updating controls:
 
@@ -374,7 +374,9 @@ useFrame((state) => controls.current.update())
 return <orbitControls ref={controls} />
 ```
 
-Taking over the render-loop:
+Once you supply a non-zero render priority, this will cause react-three-fiber to disable its automatic rendering, and it will be your responsibility to render explicitly. This gives you immediate control over the order in which callbacks and rendering are executed.
+
+For example:
 
 ```jsx
 useFrame(({ gl, scene, camera }) => gl.render(scene, camera), 1)

--- a/markdown/api.md
+++ b/markdown/api.md
@@ -362,9 +362,7 @@ forceResize()
 useFrame((callback: (state, delta) => void), (renderPriority: number = 0))
 ```
 
-Allows you to execute code on every frame rendered, like running effects, updating controls, and so on. You receive the state (same as useThree) and a clock delta. In addition to the callback function itself, you may pass a numerical `renderPriority` value; callbacks will be executed in order of ascending priority values (lowest first, highest last.) 
-
-Example:
+Allows you to execute code on every frame rendered, like running effects, updating controls, and so on. You receive the state (same as `useThree`) and a clock delta. Your callback function will be invoked just before a frame is rendered.
 
 ```jsx
 import { useFrame } from 'react-three-fiber'
@@ -379,7 +377,9 @@ const Controls = () => {
 }
 ```
 
-Using a non-zero render priority will cause react-three-fiber to disable its automatic rendering, and it will be your responsibility to render explicitly. This gives you immediate control over the order in which callbacks and rendering are executed:
+If you need more control over the order in which `useFrame` callbacks are executed (and frames are rendered), you may pass a numerical `renderPriority` value; callbacks will be executed in order of ascending priority values (lowest first, highest last.) 
+
+Using a non-zero render priority will cause react-three-fiber to disable its automatic rendering, and it will be your responsibility to render explicitly:
 
 ```jsx
 useFrame(({ gl, scene, camera }) => gl.render(scene, camera), 1)

--- a/markdown/api.md
+++ b/markdown/api.md
@@ -364,19 +364,22 @@ useFrame((callback: (state, delta) => void), (renderPriority: number = 0))
 
 Allows you to execute code on every frame rendered, like running effects, updating controls, and so on. You receive the state (same as useThree) and a clock delta. In addition to the callback function itself, you may pass a numerical `renderPriority` value; callbacks will be executed in order of ascending priority values (lowest first, highest last.) 
 
-Updating controls:
+Example:
 
 ```jsx
 import { useFrame } from 'react-three-fiber'
 
-const controls = useRef()
-useFrame((state) => controls.current.update())
-return <orbitControls ref={controls} />
+const Controls = () => {
+  const controls = useRef()
+  
+  /* Invoke the OrbitControls' update function on every frame */
+  useFrame(() => controls.current.update())
+  
+  return <orbitControls ref={controls} />
+}
 ```
 
-Once you supply a non-zero render priority, this will cause react-three-fiber to disable its automatic rendering, and it will be your responsibility to render explicitly. This gives you immediate control over the order in which callbacks and rendering are executed.
-
-For example:
+Once you supply a non-zero render priority, this will cause react-three-fiber to disable its automatic rendering, and it will be your responsibility to render explicitly. This gives you immediate control over the order in which callbacks and rendering are executed:
 
 ```jsx
 useFrame(({ gl, scene, camera }) => gl.render(scene, camera), 1)


### PR DESCRIPTION
As discussed on Discord, here's a small update to api.md to clarify the `useFrame` documentation a little.

- Specifically noted that _any_ non-zero priority will disable the automatic rendering
- Changed wording around a bit to make things a bit more straight-forward to grok
- Tweaked the main example given to be closer to valid component code