### PR TITLE
Better error when using hooks outside of canvas

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -5,9 +5,13 @@ import { useAsset } from 'use-asset'
 
 function useContext<T>(context: React.Context<T>) {
   let result = useContextImpl(context)
-  if (!result) {
-    console.warn('hooks can only be used within the canvas! https://github.com/react-spring/react-three-fiber#hooks')
+
+  if (!('subscribe' in result)) {
+    throw new Error(
+      `⚡️ react-three-fiber hooks can only be used within the Canvas component! https://github.com/pmndrs/react-three-fiber/blob/master/markdown/api.md#hooks`
+    )
   }
+
   return result
 }
 


### PR DESCRIPTION
The previous check wasn't working, since a missing context apparently returns an empty object as a value - which is truthy.
I also fixed the linked doc 

![image](https://user-images.githubusercontent.com/1862172/100250051-8709a980-2f3d-11eb-9c40-3b0f7ca47276.png)
