### PR TITLE
Pass ResizeOptions direct from react-use-measure

### DIFF
--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -4,7 +4,7 @@ import { render, invalidate, applyProps, unmountComponentAtNode, renderGl } from
 import { TinyEmitter } from 'tiny-emitter'
 import { NamedArrayTuple } from './three-types'
 import { ReactThreeFiber } from '.'
-import { RectReadOnly } from 'react-use-measure'
+import { RectReadOnly, Options as ResizeOptions } from 'react-use-measure'
 
 export type Camera = THREE.OrthographicCamera | THREE.PerspectiveCamera
 
@@ -84,11 +84,6 @@ export type ComputeOffsetsFunction = (
   event: DomEvent,
   state: SharedCanvasContext
 ) => { offsetX: number; offsetY: number }
-
-export type ResizeOptions = {
-  debounce?: number | { scroll: number; resize: number }
-  scroll?: boolean
-}
 
 export interface CanvasProps {
   children: React.ReactNode


### PR DESCRIPTION
Instead of duplicating the options type, this passes it direct from `react-use-measure`.

