### PR TITLE
Add recipe for Safari support

### DIFF
--- a/markdown/api.md
+++ b/markdown/api.md
@@ -80,7 +80,7 @@ A default _shadowMap_ if Canvas.shadowMap is true: `type: PCFSoftShadowMap`
 
 A default _scene_ (into which all the JSX is rendered) and a _raycaster_.
 
-A _wrapping container_ with a [resize observer](https://github.com/react-spring/react-use-measure): `scroll: true, debounce: { scroll: 50, resize: 0 }`. It does not polyfill it. Use [@juggle/resize-observer](https://github.com/juggle/resize-observer) if you must.
+A _wrapping container_ with a [resize observer](https://github.com/react-spring/react-use-measure): `scroll: true, debounce: { scroll: 50, resize: 0 }`. It does not polyfill it (see [Safari support](recipes.md#safari-support))
 
 You do not have to use any of these objects, look under "Recipes" down below if you want to bring your own.
 

--- a/markdown/recipes.md
+++ b/markdown/recipes.md
@@ -13,6 +13,7 @@
 - [Enabling VR](#enabling-vr)
 - [Reducing bundle-size](#reducing-bundle-size)
 - [Usage with React Native](#usage-with-react-native)
+- [Safari support](#safari-support)
 
 ## Animating with react-spring
 
@@ -255,3 +256,16 @@ yarn add expo-gl expo-three three@latest react-three-fiber@beta
 
 yarn start
 ```
+
+## Safari support
+
+Safari does not support `ResizeObserver` out of the box, which causes errors in the `react-use-measure` dependency if you don't polyfill it. [@juggle/resize-observer](https://github.com/juggle/resize-observer) is the recommended `ResizeObserver` polyfill. It can be configured through the [`resize`](api.md#canvas) property on the `<Canvas>`:
+
+```jsx
+import { ResizeObserver } from "@juggle/resize-observer"
+...
+<Canvas resize={{ polyfill: ResizeObserver }}>
+...
+```
+
+[Codesandbox example](https://codesandbox.io/s/pnb9t)


### PR DESCRIPTION
This adds a short explanation and example of how to get `react-three-fiber` working in Safari, since by default r3f will throw an error.
