### PR TITLE
docs: fix types in typescript example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,8 @@ function Box(props) {
       scale={active ? [1.5, 1.5, 1.5] : [1, 1, 1]}
       onClick={(event) => setActive(!active)}
       onPointerOver={(event) => setHover(true)}
-      onPointerOut={(event) => setHover(false)}>
+      onPointerOut={(event) => setHover(false)}
+    >
       <boxBufferGeometry args={[1, 1, 1]} />
       <meshStandardMaterial color={hovered ? 'hotpink' : 'orange'} />
     </mesh>
@@ -109,7 +110,7 @@ ReactDOM.render(
 import ReactDOM from 'react-dom'
 import React, { useRef, useState } from 'react'
 import { Canvas, MeshProps, useFrame } from 'react-three-fiber'
-import { Mesh } from 'three'
+import type { Mesh } from 'three'
 
 function Box(props: MeshProps) {
   // This reference will give us direct access to the mesh
@@ -131,7 +132,8 @@ function Box(props: MeshProps) {
       scale={active ? [1.5, 1.5, 1.5] : [1, 1, 1]}
       onClick={(_event) => setActive(!active)}
       onPointerOver={(event) => setHover(true)}
-      onPointerOut={(event) => setHover(false)}>
+      onPointerOut={(event) => setHover(false)}
+    >
       <boxBufferGeometry args={[1, 1, 1]} />
       <meshStandardMaterial color={hovered ? 'hotpink' : 'orange'} />
     </mesh>

--- a/readme.md
+++ b/readme.md
@@ -84,8 +84,7 @@ function Box(props) {
       scale={active ? [1.5, 1.5, 1.5] : [1, 1, 1]}
       onClick={(event) => setActive(!active)}
       onPointerOver={(event) => setHover(true)}
-      onPointerOut={(event) => setHover(false)}
-    >
+      onPointerOut={(event) => setHover(false)}>
       <boxBufferGeometry args={[1, 1, 1]} />
       <meshStandardMaterial color={hovered ? 'hotpink' : 'orange'} />
     </mesh>

--- a/readme.md
+++ b/readme.md
@@ -112,7 +112,7 @@ import React, { useRef, useState } from 'react'
 import { Canvas, MeshProps, useFrame } from 'react-three-fiber'
 import type { Mesh } from 'three'
 
-function Box(props: MeshProps) {
+const Box: React.FC<MeshProps> = (props) => {
   // This reference will give us direct access to the mesh
   const mesh = useRef<Mesh>()
 
@@ -130,7 +130,7 @@ function Box(props: MeshProps) {
       {...props}
       ref={mesh}
       scale={active ? [1.5, 1.5, 1.5] : [1, 1, 1]}
-      onClick={(_event) => setActive(!active)}
+      onClick={(event) => setActive(!active)}
       onPointerOver={(event) => setHover(true)}
       onPointerOut={(event) => setHover(false)}
     >

--- a/readme.md
+++ b/readme.md
@@ -132,8 +132,7 @@ const Box: React.FC<MeshProps> = (props) => {
       scale={active ? [1.5, 1.5, 1.5] : [1, 1, 1]}
       onClick={(event) => setActive(!active)}
       onPointerOver={(event) => setHover(true)}
-      onPointerOut={(event) => setHover(false)}
-    >
+      onPointerOut={(event) => setHover(false)}>
       <boxBufferGeometry args={[1, 1, 1]} />
       <meshStandardMaterial color={hovered ? 'hotpink' : 'orange'} />
     </mesh>


### PR DESCRIPTION
- Add `import type` to `Mesh` import in the Typescript example in README
- Fix props and component types
- Align callback `event` naming