### PR TITLE
use loader will support both string[] and string ts 

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -116,7 +116,7 @@ function loadingFn<T>(extensions?: Extensions, onProgress?: (event: ProgressEven
   }
 }
 
-export function useLoader<T, U>(
+export function useLoader<T, U extends string | string[]>(
   Proto: new () => LoaderResult<T>,
   input: U,
   extensions?: Extensions,

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -125,7 +125,7 @@ export function useLoader<T, U>(
   // Use suspense to load async assets
   const results = useAsset(loadingFn<T>(extensions, onProgress), [Proto, input])
   // Return the object/s
-  return results as U extends any[] ? T[] : T
+  return (Array.isArray(input) ? results : results[0]) as U extends any[] ? T[] : T
 }
 
 useLoader.preload = function <T>(

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -118,7 +118,7 @@ function loadingFn<T>(extensions?: Extensions, onProgress?: (event: ProgressEven
 
 export function useLoader<T, U>(
   Proto: new () => LoaderResult<T>,
-  input: U extends any[] ? string[] : string,
+  input: U,
   extensions?: Extensions,
   onProgress?: (event: ProgressEvent<EventTarget>) => void
 ): U extends any[] ? T[] : T {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -116,16 +116,16 @@ function loadingFn<T>(extensions?: Extensions, onProgress?: (event: ProgressEven
   }
 }
 
-export function useLoader<T>(
+export function useLoader<T, U>(
   Proto: new () => LoaderResult<T>,
-  input: T extends any[] ? string[] : string,
+  input: U extends any[] ? string[] : string,
   extensions?: Extensions,
   onProgress?: (event: ProgressEvent<EventTarget>) => void
-): T {
+): U extends any[] ? T[] : T {
   // Use suspense to load async assets
   const results = useAsset(loadingFn<T>(extensions, onProgress), [Proto, input])
   // Return the object/s
-  return (Array.isArray(input) ? results : results[0]) as T
+  return results as U extends any[] ? T[] : T
 }
 
 useLoader.preload = function <T>(

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -128,9 +128,9 @@ export function useLoader<T, U extends string | string[]>(
   return (Array.isArray(input) ? results : results[0]) as U extends any[] ? T[] : T
 }
 
-useLoader.preload = function <T>(
+useLoader.preload = function <T, U extends string | string[]>(
   Proto: new () => LoaderResult<T>,
-  url: T extends any[] ? string[] : string,
+  url: U,
   extensions?: Extensions
 ) {
   return useAsset.preload(loadingFn<T>(extensions), Proto, url)


### PR DESCRIPTION
Fixes #810 

This will help useLoader to work with mutiple  url 

Usage: 

`const texture1 = useLoader(THREE.TextureLoader, 'url1')`

`const [texture2, texture3] = useLoader<THREE.Texture, string[]>(THREE.TextureLoader, ['url1', 'url2'])`