### PR TITLE
invalidate - prevent raf to keep running

### DIFF
--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -112,6 +112,8 @@ function renderLoop(timestamp: number) {
       (!state.current.invalidateFrameloop || state.current.frames > 0)
     ) {
       repeat = renderGl(state, timestamp, repeat)
+    } else {
+      repeat = 0
     }
   })
 


### PR DESCRIPTION
@drcmda the addTail is broken since v5.0.0. The RAF would keep running with invalidateFrameLoop because the addTail hook was never invoked since repeat was always > 0.

This fixes the issue. 

Here is an example of the current issue :
https://codesandbox.io/s/r3f-invalidate-frameloop-fps-forked-ziep9?file=/src/Fps.js

