### PR TITLE
refactor: add ReactNode as return type to createPortal

### DIFF
--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -605,7 +605,12 @@ export function unmountComponentAtNode(container: THREE.Object3D, callback?: (c:
   }
 }
 
-export function createPortal(children: React.ReactNode, containerInfo: any, implementation?: any, key: any = null) {
+export function createPortal(
+  children: React.ReactNode,
+  containerInfo: any,
+  implementation?: any,
+  key: any = null
+): React.ReactNode {
   if (!containerInfo.__objects) containerInfo.__objects = []
   return {
     $$typeof: REACT_PORTAL_TYPE,


### PR DESCRIPTION
resolves #925

The JS impl is correct & is identical to `ReactDOM.createPortal` however the type return from said func is `ReactPortal` which extends `ReactElement` there's debate  in https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20942 as their impl being incorrect.