### PR TITLE
Corrected spelling of 'instantiated'

### DIFF
--- a/markdown/api.md
+++ b/markdown/api.md
@@ -112,7 +112,7 @@ You can use [Threejs's entire object catalogue and all properties](https://three
 
 #### Constructor arguments
 
-In threejs objects are classes that are instanciated. These classes can receive one-time constructor arguments (`new THREE.SphereBufferGeometry(1, 32)`), and properties (`someObject.visible = true`). In three-fiber constructor arguments are always passed as an array via `args`. If args change later on, the object must naturally get re-constructed from scratch!
+In threejs objects are classes that are instantiated. These classes can receive one-time constructor arguments (`new THREE.SphereBufferGeometry(1, 32)`), and properties (`someObject.visible = true`). In three-fiber constructor arguments are always passed as an array via `args`. If args change later on, the object must naturally get re-constructed from scratch!
 
 ```jsx
 <sphereBufferGeometry args={[1, 32]} />


### PR DESCRIPTION
The spelling of `instantiated` was incorrectly written as `instanciated`.
Verified here: https://en.wiktionary.org/wiki/instanciated