### PR TITLE
Get touch events working with react native.

### DIFF
--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -617,7 +617,7 @@ export const useCanvas = (props: UseCanvasProps): DomEventHandlers => {
       // onGotPointerCapture is not needed any longer because the behaviour is hacked into
       // the event itself (see handleIntersects). But in order for non-web targets to simulate
       // it we keep the legacy event, which simply flags all current intersects as captured
-      onGotPointerCaptureLegacy: (e: any) => (state.current.captured = intersect(e)),
+      onGotPointerCaptureLegacy: (e: any) => (state.current.captured = intersect()),
       onLostPointerCapture: (e: any) => ((state.current.captured = undefined), handlePointerCancel(e)),
     }
   }, [handlePointer, intersect, handlePointerCancel, handlePointerMove])

--- a/src/targets/native/canvas.tsx
+++ b/src/targets/native/canvas.tsx
@@ -15,9 +15,9 @@ import { useState } from 'react'
 import { useCanvas, CanvasProps, UseCanvasProps } from '../../canvas'
 import { RectReadOnly } from 'react-use-measure'
 
-function clientXY(e: GestureResponderEvent) {
-  ;(e as any).clientX = e.nativeEvent.pageX
-  ;(e as any).clientY = e.nativeEvent.pageY
+function offsetXY(e: GestureResponderEvent) {
+  ;(e as any).nativeEvent.offsetX = e.nativeEvent.pageX
+  ;(e as any).nativeEvent.offsetY = e.nativeEvent.pageY
   return e
 }
 
@@ -38,7 +38,7 @@ const IsReady = React.memo(({ gl, ...props }: NativeCanvasProps & { gl: any; siz
     let pointerDownCoords: null | [number, number] = null
     return PanResponder.create({
       onStartShouldSetPanResponderCapture(e) {
-        events.onGotPointerCaptureLegacy(clientXY(e))
+        events.onGotPointerCaptureLegacy(offsetXY(e))
         return true
       },
       onStartShouldSetPanResponder: () => true,
@@ -47,23 +47,23 @@ const IsReady = React.memo(({ gl, ...props }: NativeCanvasProps & { gl: any; siz
       onPanResponderTerminationRequest: () => true,
       onPanResponderStart: (e) => {
         pointerDownCoords = [e.nativeEvent.locationX, e.nativeEvent.locationY]
-        events.onPointerDown(clientXY(e))
+        events.onPointerDown(offsetXY(e))
       },
-      onPanResponderMove: (e) => events.onPointerMove(clientXY(e)),
+      onPanResponderMove: (e) => events.onPointerMove(offsetXY(e)),
       onPanResponderEnd: (e) => {
-        events.onPointerUp(clientXY(e))
+        events.onPointerUp(offsetXY(e))
         if (pointerDownCoords) {
           const xDelta = pointerDownCoords[0] - e.nativeEvent.locationX
           const yDelta = pointerDownCoords[1] - e.nativeEvent.locationY
           if (Math.sqrt(Math.pow(xDelta, 2) + Math.pow(yDelta, 2)) < CLICK_DELTA) {
-            events.onClick(clientXY(e))
+            events.onClick(offsetXY(e))
           }
         }
         pointerDownCoords = null
       },
-      onPanResponderRelease: (e) => events.onPointerLeave(clientXY(e)),
-      onPanResponderTerminate: (e) => events.onLostPointerCapture(clientXY(e)),
-      onPanResponderReject: (e) => events.onLostPointerCapture(clientXY(e)),
+      onPanResponderRelease: (e) => events.onPointerLeave(offsetXY(e)),
+      onPanResponderTerminate: (e) => events.onLostPointerCapture(offsetXY(e)),
+      onPanResponderReject: (e) => events.onLostPointerCapture(offsetXY(e)),
     })
   }, [events])
 


### PR DESCRIPTION
Two issues found and fixed:
1. *Drop event arg from intersect() for onGotPointerCaptureLegacy* - The signature of `intersect` changed to remove the event arg but the legacy method `onGotPointerCaptureLegacy` for react native never got updated. This causes all touch events in native to fail.
2. *Replace `clientXY` with `offsetXY`* - There was a [helper function](https://github.com/pmndrs/react-three-fiber/pull/1020/files#diff-3e27362a51b34828c8b8cc6d91a746001f8615b8dadf942c1f74b01919c9a210L18) designed to shim the missing position properties on react native events but unfortunately it was shimming `clientY` and `clientY` whereas r3f [uses the offset coordinates](https://github.com/pmndrs/react-three-fiber/blob/d101f49f438aa2f485185fa9214a1c65957f483d/src/canvas.tsx#L357)