### PR TITLE
Patch event.type check for react native

### DIFF
--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -443,7 +443,7 @@ export const useCanvas = (props: UseCanvasProps): DomEventHandlers => {
       // Get fresh intersects
       const intersections: Intersection[] = intersect(filter)
       // If the interaction is captured take that into account, the captured event has to be part of the intersects
-      if (state.current.captured && event.type !== 'click' && event.type !== 'wheel') {
+      if (state.current.captured && event.type && event.type !== 'click' && event.type !== 'wheel') {
         state.current.captured.forEach((captured) => {
           if (!intersections.find((hit) => hit.eventObject === captured.eventObject)) intersections.push(captured)
         })


### PR DESCRIPTION
This _patches_ https://github.com/pmndrs/react-three-fiber/issues/734.  I tested this on a physical Android and iOS device (can provide specs if needed) and the duplicate events are removed.  

"_explanation_"
for some reason, `event.type` is `undefined` on react-native.  this could make the conditional check falsely return positive for `event.type !== 'click'`, when in fact the event should have otherwise been a click (this is what happens for the bug ticket case).

since i'm not very clear on what this particular code chunk is doing - for example, what are we checking `state.current.captured` for?  & what is `state.current.captured` even doing? -  this could be a fix in the totally wrong place, i don't know.