### PR TITLE
#734 patch event.type check

### DIFF
--- a/packages/fiber/src/web/events.ts
+++ b/packages/fiber/src/web/events.ts
@@ -117,7 +117,7 @@ function createEvents(store: UseStore<RootState>): Events {
     // Get fresh intersects
     const intersections: Intersection[] = intersect(filter)
     // If the interaction is captured take that into account, the captured event has to be part of the intersects
-    if (internal.captured && event.type !== 'click' && event.type !== 'wheel') {
+    if (internal.captured && event?.type !== 'click' && event?.type !== 'wheel') {
       internal.captured.forEach((captured) => {
         if (!intersections.find((hit) => hit.eventObject === captured.eventObject)) intersections.push(captured)
       })


### PR DESCRIPTION
event.type *should be* fulfilled on web browsers anyway, but this adds a null check such as here https://github.com/pmndrs/react-three-fiber/pull/1075