### PR TITLE
Fix SSR warning with useLayoutEffect

### DIFF
--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -8,10 +8,16 @@ export interface Props extends Omit<RenderProps<HTMLCanvasElement>, 'size'>, Rea
   resize?: ResizeOptions
 }
 
+// React currently throws a warning when using useLayoutEffect on the server.
+// To get around it, we can conditionally useEffect on the server (no-op) and
+// useLayoutEffect in the browser.
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect
+
 export function Canvas({ children, resize, style, className, ...props }: Props) {
   const [ref, size] = useMeasure({ scroll: true, debounce: { scroll: 50, resize: 0 }, ...resize })
   const canvas = React.useRef<HTMLCanvasElement>(null!)
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (size.width > 0 && size.height > 0) {
       render(children, canvas.current, { ...props, size, events })
     }


### PR DESCRIPTION
Anywhere we use `useLayoutEffect` will print some warnings when rendered server-side. See https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85.