### PR TITLE
Fix crash in applyProps when event is missing

### DIFF
--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -187,7 +187,7 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>) {
           // with their respective constructor/set arguments
           // For removed props, try to set default values, if possible
           if (value === DEFAULT + 'remove') {
-            if (targetProp.constructor) {
+            if (targetProp && targetProp.constructor) {
               // use the prop constructor to find the default it should be
               value = new targetProp.constructor(newMemoizedProps.args)
             } else if (currentInstance.constructor) {


### PR DESCRIPTION
This PR fixes a new crash in v6 that happens in conjunction with `react-use-gesture` and an `onPointerCancel` event that's not defined on the mesh. I noticed that all of the other branches first check for the existence of `targetProp`, so it seems like the right thing to do here.

![image](https://user-images.githubusercontent.com/1865957/113428429-cb51fe00-93a4-11eb-8dc5-783cc727cfcb.png)
