### PR TITLE
Fix example in api.md

### DIFF
--- a/markdown/api.md
+++ b/markdown/api.md
@@ -487,7 +487,7 @@ function Asset({ url }) {
   return <primitive object={gltf.scene} />
 }
 
-;<Suspense fallback={<Cube />}>
+<Suspense fallback={<Cube />}>
   <Asset url="/spaceship.gltf" />
 </Suspense>
 ```


### PR DESCRIPTION
Remove unnecessary `;` in useLoader example.