### PR TITLE
add DoubleClick as a valid event handler

### DIFF
--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -124,8 +124,8 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>) {
       // Event-handlers ...
       //   are functions, that
       //   start with "on", and
-      //   contain the name "Pointer", "Click", "ContextMenu", or "Wheel"
-      if (is.fun(newProps[objectKeys[i]]) && /^on(Pointer|Click|ContextMenu|Wheel)/.test(objectKeys[i])) {
+      //   contain the name "Pointer", "Click", "DoubleClick", "ContextMenu", or "Wheel"
+      if (is.fun(newProps[objectKeys[i]]) && /^on(Pointer|Click|DoubleClick|ContextMenu|Wheel)/.test(objectKeys[i])) {
         handlers.push(objectKeys[i])
       }
     }


### PR DESCRIPTION
Fixes issue reported by #1197.

Issue seemed to be caused by the refactoring commit https://github.com/pmndrs/react-three-fiber/commit/e1d5efb4c00df05a89e57a8e8c4520c590d551cd. `"DoubleClick" `was previously covered by:
`objectKeys[i].includes('Click')`.