### PR TITLE
Fix: better management of captured events

### DIFF
--- a/example/src/styles.tsx
+++ b/example/src/styles.tsx
@@ -64,6 +64,10 @@ const Global = createGlobalStyle`
     color: black;
     background: white;
   }
+
+  canvas {
+    touch-action: none;
+  }
 `
 
 export { Global, Page }

--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -214,8 +214,9 @@ export function createEvents(store: UseStore<RootState>) {
               }
             }
           },
-          target: { ...event.target, setPointerCapture, releasePointerCapture },
-          currentTarget: { ...event.currentTarget, setPointerCapture, releasePointerCapture },
+          // there should be a distinction between target and currentTarget
+          target: { setPointerCapture, releasePointerCapture },
+          currentTarget: { setPointerCapture, releasePointerCapture },
           sourceEvent: event,
         }
 

--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -146,8 +146,13 @@ export function createEvents(store: UseStore<RootState>) {
   function patchIntersects(intersections: Intersection[], event: DomEvent) {
     const { internal } = store.getState()
     // If the interaction is captured take that into account, the captured event has to be part of the intersects
-    if ('pointerId' in event && internal.capturedMap.has(event.pointerId))
+    if (
+      'pointerId' in event &&
+      internal.capturedMap.has(event.pointerId) &&
+      !intersections.find((hit) => hit.eventObject === internal.capturedMap.get(event.pointerId)?.eventObject)
+    ) {
       intersections.push(internal.capturedMap.get(event.pointerId)!)
+    }
     return intersections
   }
 

--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -173,7 +173,8 @@ export function createEvents(store: UseStore<RootState>) {
         const hasPointerCapture = (id: number) => internal.capturedMap.get(id)?.eventObject === hit.eventObject
 
         const setPointerCapture = (id: number) => {
-          // Maybe we should set a warning if the eventId was already captured
+          // A target can steal the pointer capture from another one, so there
+          // is no need to check whether the pointerId was already set.
           internal.capturedMap.set(id, hit)
           // Call the original event now
           ;(event.target as Element).setPointerCapture(id)
@@ -257,7 +258,9 @@ export function createEvents(store: UseStore<RootState>) {
         return () => cancelPointer([])
       case 'onLostPointerCapture':
         return (event: DomEvent) => {
-          if ('pointerId' in event) store.getState().internal.capturedMap.delete(event.pointerId)
+          if ('pointerId' in event) {
+            store.getState().internal.capturedMap.delete(event.pointerId)
+          }
           cancelPointer([])
         }
     }

--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -163,6 +163,8 @@ export function createEvents(store: UseStore<RootState>) {
       const localState = { stopped: false }
 
       for (const hit of intersections) {
+        const hasPointerCapture = (id: number) => internal.capturedMap.get(id)?.eventObject === hit.eventObject
+
         const setPointerCapture = (id: number) => {
           // Maybe we should set a warning if the eventId was already captured
           internal.capturedMap.set(id, hit)
@@ -205,8 +207,8 @@ export function createEvents(store: UseStore<RootState>) {
             }
           },
           // there should be a distinction between target and currentTarget
-          target: { setPointerCapture, releasePointerCapture },
-          currentTarget: { setPointerCapture, releasePointerCapture },
+          target: { hasPointerCapture, setPointerCapture, releasePointerCapture },
+          currentTarget: { hasPointerCapture, setPointerCapture, releasePointerCapture },
           sourceEvent: event,
         }
 

--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -16,6 +16,8 @@ export interface IntesectionEvent<TSourceEvent> extends Intersection {
   stopPropagation: () => void
   sourceEvent: TSourceEvent
   delta: number
+  spaceX: number
+  spaceY: number
 }
 
 export type Camera = THREE.OrthographicCamera | THREE.PerspectiveCamera
@@ -186,6 +188,8 @@ export function createEvents(store: UseStore<RootState>) {
         let raycastEvent: any = {
           ...hit,
           ...extractEventProps,
+          spaceX: mouse.x,
+          spaceY: mouse.y,
           intersections,
           stopped: localState.stopped,
           delta,

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -56,7 +56,7 @@ export type InternalState = {
   interaction: THREE.Object3D[]
   hovered: Map<string, DomEvent>
   subscribers: Subscription[]
-  captured: Intersection[] | undefined
+  capturedMap: Map<number, Intersection>
   initialClick: [x: number, y: number]
   initialHits: THREE.Object3D[]
 
@@ -282,9 +282,9 @@ const createStore = (
         interaction: [],
         hovered: new Map<string, DomEvent>(),
         subscribers: [],
-        captured: undefined,
         initialClick: [0, 0],
         initialHits: [],
+        capturedMap: new Map(),
 
         subscribe: (ref: React.MutableRefObject<RenderCallback>, priority = 0) => {
           set(({ internal }) => ({


### PR DESCRIPTION
Allows a mesh to properly handle capturing of several events.

### Before
Notice that only the first pointer is released.
https://user-images.githubusercontent.com/5003380/116914741-6d3a6400-ac4b-11eb-8907-814ba7baf8a9.mp4

### After
Notice that all pointers are released.
https://user-images.githubusercontent.com/5003380/116914716-601d7500-ac4b-11eb-92e9-a2ed29a784e8.mp4

### Collateral

- add support for `event.target.hasPointerCapture`
- add `event.spaceX` and `event.spaceY` showing `state.mouse` THREE coordinates.
