### PR TITLE
Update the clock when `frameloop = "never"`

### DIFF
--- a/packages/fiber/src/core/loop.ts
+++ b/packages/fiber/src/core/loop.ts
@@ -23,7 +23,13 @@ function run(effects: GlobalRenderCallback[], timestamp: number) {
 
 function render(timestamp: number, state: RootState) {
   // Run local effects
-  const delta = state.clock.getDelta()
+  let delta = state.clock.getDelta()
+  // In frameloop='never' mode, clock times are updated using the provided timestamp
+  if (state.frameloop === 'never' && typeof timestamp === 'number') {
+    delta = timestamp - state.clock.elapsedTime
+    state.clock.oldTime = state.clock.elapsedTime
+    state.clock.elapsedTime = timestamp
+  }
   // Call subscribers (useFrame)
   for (i = 0; i < state.internal.subscribers.length; i++) state.internal.subscribers[i].ref.current(state, delta)
   // Render content

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -165,6 +165,12 @@ const createStore = (
     gl.outputEncoding = THREE.sRGBEncoding
   }
 
+  // clock.elapsedTime is updated using advance(timestamp)
+  if (frameloop === 'never') {
+    clock.stop()
+    clock.elapsedTime = 0
+  }
+
   const rootState = create<RootState>((set, get) => {
     // Create custom raycaster
     const raycaster = new THREE.Raycaster() as Raycaster


### PR DESCRIPTION
Background: https://github.com/pmndrs/react-three-fiber/issues/1294

This change uses the `timestamp` argument in `advance(timestamp)` to update the clock when `frameloop = "never"`

Given the [implementation](https://github.com/mrdoob/three.js/blob/master/src/core/Clock.js#L40) of `THREE.Clock.getDelta()`, there isn't a way to have `getDelta()` return a value that is independent of `performance.now()`. So even with these changes, `clock.getDelta()` will always return 0. However, the delta provided in the `useFrame()` callback will be equal to the current timestamp minus the previous one.

With these changes, calling `advance(timestamp)` successively will look like this:
```js
advance(0)

useFrame(({ clock }, delta) => {
  console.log(clock.getElapsedTime())   // 0
  console.log(clock.getDelta())         // 0
  console.log(delta)                    // 0
})
```
```js
advance(0.5)

useFrame(({ clock }, delta) => {
  console.log(clock.getElapsedTime())   // 0.5
  console.log(clock.getDelta())         // 0
  console.log(delta)                    // 0.5
})
```
```js
advance(1)

useFrame(({ clock }, delta) => {
  console.log(clock.getElapsedTime())   // 1
  console.log(clock.getDelta())         // 0
  console.log(delta)                    // 0.5
})
```

