### PR TITLE
Give onPointerMissed an event argument

### DIFF
--- a/markdown/api.md
+++ b/markdown/api.md
@@ -277,7 +277,7 @@ Also notice the `onPointerMissed` on the canvas element, which fires on clicks t
   onPointerEnter={(e) => console.log('enter')} // see note 1
   onPointerLeave={(e) => console.log('leave')} // see note 1
   onPointerMove={(e) => console.log('move')}
-  onPointerMissed={() => console.log('missed')}
+  onPointerMissed={(e) => console.log('missed')}
   onUpdate={(self) => console.log('props have been updated')}
 />
 ```
@@ -422,7 +422,7 @@ const {
   advance, // Advance one tick, given that frameloop === 'never', (timestamp: number, runGlobalEffects?: boolean) => void
   setSize, // Resize the canvs, (width: number, height: number) => void
   setDpr, // Reset the pixel-ratio, (dpr: Dpr) => void
-  onPointerMissed, // () => void
+  onPointerMissed, // (event: ThreeEvent<PointerEvent>) => void
   events: {
     connected, // Event-target (for instance a dom node), TTarget | boolean
     handlers, // Pointer-event handlers (pointermove, up, down, etc), Events

--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -325,7 +325,7 @@ export function createEvents(store: UseStore<RootState>) {
       if ((name === 'onClick' || name === 'onContextMenu' || name === 'onDoubleClick') && !hits.length) {
         if (calculateDistance(event) <= 2) {
           pointerMissed(event, internal.interaction)
-          if (onPointerMissed) onPointerMissed()
+          if (onPointerMissed) onPointerMissed(event as ThreeEvent<PointerEvent>)
         }
       }
     }

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -4,7 +4,7 @@ import * as ReactThreeFiber from '../three-types'
 import create, { GetState, SetState, UseStore } from 'zustand'
 import shallow from 'zustand/shallow'
 import { prepare, Instance, InstanceProps } from './renderer'
-import { DomEvent, EventManager } from './events'
+import { DomEvent, EventManager, ThreeEvent } from './events'
 
 export interface Intersection extends THREE.Intersection {
   eventObject: THREE.Object3D
@@ -88,7 +88,7 @@ export type RootState = {
   advance: (timestamp: number, runGlobalEffects?: boolean) => void
   setSize: (width: number, height: number) => void
   setDpr: (dpr: Dpr) => void
-  onPointerMissed?: () => void
+  onPointerMissed?: (event: ThreeEvent<PointerEvent>) => void
 
   events: EventManager<any>
   internal: InternalState
@@ -117,7 +117,7 @@ export type StoreProps = {
           ReactThreeFiber.Object3DNode<THREE.PerspectiveCamera, typeof THREE.PerspectiveCamera> &
           ReactThreeFiber.Object3DNode<THREE.OrthographicCamera, typeof THREE.OrthographicCamera>
       >
-  onPointerMissed?: () => void
+  onPointerMissed?: (event: ThreeEvent<PointerEvent>) => void
 }
 
 export type ApplyProps = (

--- a/packages/fiber/tests/web/web.events.test.tsx
+++ b/packages/fiber/tests/web/web.events.test.tsx
@@ -61,7 +61,31 @@ describe('events ', () => {
     fireEvent(document.querySelector('canvas') as HTMLCanvasElement, evt)
 
     expect(handleClick).not.toHaveBeenCalled()
-    expect(handleMissed).toHaveBeenCalled()
+    expect(handleMissed).toHaveBeenCalledWith(evt)
+  })
+
+  it('can handle onPointerMissed on Canvas', async () => {
+    const handleMissed = jest.fn()
+
+    await act(async () => {
+      render(
+        <Canvas onPointerMissed={handleMissed}>
+          <mesh>
+            <boxGeometry args={[2, 2]} />
+            <meshBasicMaterial />
+          </mesh>
+        </Canvas>,
+      )
+    })
+
+    const evt = new MouseEvent('click')
+    //@ts-ignore
+    evt.offsetX = 0
+    //@ts-ignore
+    evt.offsetY = 0
+
+    fireEvent(document.querySelector('canvas') as HTMLCanvasElement, evt)
+    expect(handleMissed).toHaveBeenCalledWith(evt)
   })
 
   it('can handle onPointerMove', async () => {


### PR DESCRIPTION
It's useful to have the event object for onPointerMissed. Here's a couple of example use cases:

1. You might want to show some click feedback, like a particle effect around the pointer, to show that you saw the click but it didn't do anything. You need the co-ordinates of the event to do this.
2. In an object selection workflow, clicking on empty space might deselect everything - but ctrl-clicking empty space should have no effects. You need the `modifiers` property of the event to know what to do.

The event-handling code has the event object anyway - it passes it to individual objects' `onPointerMissed` handlers - so it's easy to pass it to the canvas as well.