### PR TITLE
Adding fallbackContent prop for Canvas component

### DIFF
--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -12,6 +12,7 @@ export interface Props
   children: React.ReactNode
   resize?: ResizeOptions
   events?: (store: UseStore<RootState>) => EventManager<any>
+  fallbackContent?: React.ReactNode
 }
 
 // React currently throws a warning when using useLayoutEffect on the server.
@@ -19,7 +20,7 @@ export interface Props
 // useLayoutEffect in the browser.
 const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect
 
-export function Canvas({ children, tabIndex, resize, id, style, className, events, ...props }: Props) {
+export function Canvas({ children, tabIndex, resize, id, style, className, events, fallbackContent, ...props }: Props) {
   const [ref, size] = useMeasure({ scroll: true, debounce: { scroll: 50, resize: 0 }, ...resize })
   const canvas = React.useRef<HTMLCanvasElement>(null!)
   useIsomorphicLayoutEffect(() => {
@@ -38,7 +39,9 @@ export function Canvas({ children, tabIndex, resize, id, style, className, event
       className={className}
       tabIndex={tabIndex}
       style={{ position: 'relative', width: '100%', height: '100%', overflow: 'hidden', ...style }}>
-      <canvas ref={canvas} style={{ display: 'block' }} />
+      <canvas ref={canvas} style={{ display: 'block' }}>
+        {fallbackContent}
+      </canvas>
     </div>
   )
 }

--- a/packages/fiber/tests/web/canvas.test.tsx
+++ b/packages/fiber/tests/web/canvas.test.tsx
@@ -25,6 +25,19 @@ describe('web Canvas', () => {
     expect(renderer.container).toMatchSnapshot()
   })
 
+  it('should correctly mount with fallback content', async () => {
+    let renderer: RenderResult = null!
+    await act(async () => {
+      renderer = render(
+        <Canvas fallbackContent={<div>Canvas is unsupported in this browser</div>}>
+          <group />
+        </Canvas>,
+      )
+    })
+
+    expect(renderer.container).toMatchSnapshot()
+  })
+
   it('should correctly unmount', async () => {
     let renderer: RenderResult = null!
     await act(async () => {


### PR DESCRIPTION
This PR updates the `Canvas` component to accept a new prop `fallbackContent` in order to support adding content for  browsers that do not support canvas (https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_usage#fallback_content). 