### PR TITLE
Fix the capture check for click events

### DIFF
--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -201,7 +201,7 @@ export function createEvents(store: UseStore<RootState>) {
           stopPropagation: () => {
             // https://github.com/pmndrs/react-three-fiber/issues/596
             // Events are not allowed to stop propagation if the pointer has been captured
-            if ('pointerId' in event && !internal.capturedMap.has(event.pointerId)) {
+            if (!('pointerId' in event && internal.capturedMap.has(event.pointerId))) {
               raycastEvent.stopped = localState.stopped = true
 
               // Propagation is stopped, remove all other hover records

--- a/packages/fiber/tests/web/web.events.test.tsx
+++ b/packages/fiber/tests/web/web.events.test.tsx
@@ -173,4 +173,51 @@ describe('events ', () => {
 
     expect(handlePointerLeave).toHaveBeenCalled()
   })
+
+  it('should handle stopPropagation on click events', async () => {
+    const handleClickFront = jest.fn((e) => e.stopPropagation())
+    const handleClickRear = jest.fn()
+
+    await act(async () => {
+      render(
+        <Canvas>
+          <mesh onClick={handleClickFront}>
+            <boxGeometry args={[2, 2]} />
+            <meshBasicMaterial />
+          </mesh>
+          <mesh onClick={handleClickRear} position-z={-3}>
+            <boxGeometry args={[2, 2]} />
+            <meshBasicMaterial />
+          </mesh>
+        </Canvas>,
+      )
+    })
+
+    const down = new PointerEvent('pointerdown')
+    //@ts-ignore
+    down.offsetX = 577
+    //@ts-ignore
+    down.offsetY = 480
+
+    fireEvent(document.querySelector('canvas') as HTMLCanvasElement, down)
+
+    const up = new PointerEvent('pointerup')
+    //@ts-ignore
+    up.offsetX = 577
+    //@ts-ignore
+    up.offsetY = 480
+
+    fireEvent(document.querySelector('canvas') as HTMLCanvasElement, up)
+
+    const event = new MouseEvent('click')
+    //@ts-ignore
+    event.offsetX = 577
+    //@ts-ignore
+    event.offsetY = 480
+
+    fireEvent(document.querySelector('canvas') as HTMLCanvasElement, event)
+
+    expect(handleClickFront).toHaveBeenCalled()
+    expect(handleClickRear).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
Clicks are MouseEvent, not PointerEvent, so they don't contain a pointerId at all, but they still need stopPropagation to work, to prevent clicks going to occluded objects. I've also added a test for using stopPropagation to stop a click event going to the occluded object.

See this discussion https://github.com/pmndrs/react-three-fiber/commit/d260376145c16f43fed97227a4f2e7d56a9dbbfa#r50677047 on the commit that introduced this bug.