### PR TITLE
fix: passive event listener adjustments

### DIFF
--- a/.changeset/popular-ligers-design.md
+++ b/.changeset/popular-ligers-design.md
@@ -1,0 +1,5 @@
+---
+'@react-three/fiber': patch
+---
+
+Only set up pointer/wheel events as passive

--- a/example/src/demos/ContextMenuOverride.tsx
+++ b/example/src/demos/ContextMenuOverride.tsx
@@ -1,0 +1,22 @@
+import React, { useState } from 'react'
+import { Canvas } from '@react-three/fiber'
+
+export default function App() {
+  const [state, set] = useState(false)
+
+  return (
+    <Canvas orthographic camera={{ zoom: 150, fov: 75, position: [0, 0, 25] }}>
+      <ambientLight />
+      <pointLight position={[10, 10, 10]} />
+      <mesh
+        position={[0, 0, 0]}
+        onContextMenu={(ev) => {
+          ev.sourceEvent.preventDefault()
+          set((value) => !value)
+        }}>
+        <boxBufferGeometry args={[1, 1, 1]} />
+        <meshPhysicalMaterial color={state ? 'hotpink' : 'blue'} />
+      </mesh>
+    </Canvas>
+  )
+}

--- a/example/src/demos/ContextMenuOverride.tsx
+++ b/example/src/demos/ContextMenuOverride.tsx
@@ -11,7 +11,7 @@ export default function App() {
       <mesh
         position={[0, 0, 0]}
         onContextMenu={(ev) => {
-          ev.sourceEvent.preventDefault()
+          ev.preventDefault()
           set((value) => !value)
         }}>
         <boxBufferGeometry args={[1, 1, 1]} />

--- a/example/src/demos/index.tsx
+++ b/example/src/demos/index.tsx
@@ -15,6 +15,7 @@ const StopPropagation = {
   dev: true,
   bright: true,
 }
+const ContextMenuOverride = { descr: '', tags: [], Component: lazy(() => import('./ContextMenuOverride')), dev: true }
 const ClickAndHover = { descr: '', tags: [], Component: lazy(() => import('./ClickAndHover')), dev: true, bright: true }
 const SVGRenderer = { descr: '', tags: [], Component: lazy(() => import('./SVGRenderer')), dev: true, bright: true }
 const ResetProps = { descr: '', tags: [], Component: lazy(() => import('./ResetProps')), dev: true, bright: true }
@@ -47,4 +48,5 @@ export {
   Layers,
   Test,
   SuspenseAndErrors,
+  ContextMenuOverride,
 }

--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -183,7 +183,11 @@ export function createEvents(store: UseStore<RootState>) {
         // Add native event props
         let extractEventProps: any = {}
         for (let prop in Object.getPrototypeOf(event)) {
-          extractEventProps[prop] = event[prop as keyof DomEvent]
+          let property = event[prop as keyof DomEvent]
+          if (typeof property === 'function') {
+            property = property.bind(event)
+          }
+          extractEventProps[prop] = property
         }
 
         let raycastEvent: any = {


### PR DESCRIPTION
I noticed that all event listeners are set up as passive. This disallows calling `event.sourceEvent.preventDefault()` for `onContextMenu` listeners. As far as I understood only touch/pointer listeners should be set up as passive.

Some References:

- https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#improving_scrolling_performance_with_passive_listeners
- https://medium.com/@Esakkimuthu/passive-event-listeners-5dbb1b011fb1