### PR TITLE
fix: if children is undefined return an array to map with

### DIFF
--- a/packages/test-renderer/src/createTestInstance.ts
+++ b/packages/test-renderer/src/createTestInstance.ts
@@ -12,7 +12,7 @@ export class ReactThreeTestInstance<TInstance extends Object3D = Object3D> {
   }
 
   public get instance(): Object3D {
-    return (this._fiber as unknown) as TInstance
+    return this._fiber as unknown as TInstance
   }
 
   public get type(): string {
@@ -53,7 +53,7 @@ export class ReactThreeTestInstance<TInstance extends Object3D = Object3D> {
         ...fiber.__r3f.objects.map((fib) => wrapFiber(fib as MockInstance)),
       ]
     } else {
-      return fiber.children.map((fib) => wrapFiber(fib as MockInstance))
+      return (fiber.children || []).map((fib) => wrapFiber(fib as MockInstance))
     }
   }
 

--- a/packages/test-renderer/src/helpers/testInstance.ts
+++ b/packages/test-renderer/src/helpers/testInstance.ts
@@ -1,5 +1,5 @@
 import { ReactThreeTestInstance } from '../createTestInstance'
-import type { MockInstance, Obj } from '../types/internal'
+import type { Obj } from '../types/internal'
 
 export const expectOne = <TItem>(items: TItem[], msg: string) => {
   if (items.length === 1) {


### PR DESCRIPTION
resolves #1250 

We werent checking if `fiber.children` is defined. If it isn't we now just give an empty array to map over.