### PR TITLE
fix: incorrect event handler names in test-renderer

### DIFF
--- a/packages/test-renderer/src/helpers/object.ts
+++ b/packages/test-renderer/src/helpers/object.ts
@@ -1,0 +1,6 @@
+export const invert = <T extends string | number | symbol>(obj: Record<string, T>) => {
+  return Object.entries<T>(obj).reduce((inverted, [key, val]) => {
+    inverted[val] = key
+    return inverted
+  }, {} as Record<T, string>)
+}

--- a/packages/test-renderer/src/helpers/strings.ts
+++ b/packages/test-renderer/src/helpers/strings.ts
@@ -1,3 +1,29 @@
+// import type { EventHandlers } from "../types/internal";
+import { EventHandlers } from 'packages/fiber/src/core/events'
+import { invert } from './object'
+
+const EVENT_HANDLER_TO_NAME: Record<keyof EventHandlers, string> = {
+  onClick: 'click',
+  onContextMenu: 'contextmenu',
+  onDoubleClick: 'doubleclick',
+  onPointerUp: 'pointerup',
+  onPointerDown: 'pointerdown',
+  onPointerOver: 'pointerover',
+  onPointerOut: 'pointerout',
+  onPointerEnter: 'pointerenter',
+  onPointerLeave: 'pointerleave',
+  onPointerMove: 'pointermove',
+  onPointerMissed: 'pointermissed',
+  onPointerCancel: 'pointercancel',
+  onWheel: 'wheel',
+}
+
 export const lowerCaseFirstLetter = (str: string) => `${str.charAt(0).toLowerCase()}${str.slice(1)}`
 
-export const toEventHandlerName = (eventName: string) => `on${eventName.charAt(0).toUpperCase()}${eventName.slice(1)}`
+export const toEventHandlerName = (eventName: string) => {
+  const eventNameToHandler = invert(EVENT_HANDLER_TO_NAME)
+
+  if (!(eventName in eventNameToHandler)) throw new Error(`Unsupported event name: ${eventName}`)
+
+  return eventNameToHandler[eventName]
+}

--- a/packages/test-renderer/src/helpers/strings.ts
+++ b/packages/test-renderer/src/helpers/strings.ts
@@ -1,5 +1,4 @@
-// import type { EventHandlers } from "../types/internal";
-import { EventHandlers } from 'packages/fiber/src/core/events'
+import type { EventHandlers } from '../types/internal'
 import { invert } from './object'
 
 const EVENT_HANDLER_TO_NAME: Record<keyof EventHandlers, string> = {

--- a/packages/test-renderer/src/types/internal.ts
+++ b/packages/test-renderer/src/types/internal.ts
@@ -3,6 +3,7 @@ import { UseStore } from 'zustand'
 
 import type { BaseInstance, LocalState } from '@react-three/fiber/src/core/renderer'
 import type { RootState } from '@react-three/fiber/src/core/store'
+export type { EventHandlers } from '@react-three/fiber/src/core/events'
 
 export type MockUseStoreState = UseStore<RootState>
 


### PR DESCRIPTION
In Test Renderer, some names of event handlers was incorrectly computed from event names. It didn't work for names such as `pointermove` and etc.

Explicit map of event names and their event handlers solves this problem, since not all event handler names can be easily computed from their respective events.

Fixes #1354