### PR TITLE
feat: forward ref to canvas element

### DIFF
--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -44,11 +44,11 @@ class ErrorBoundary extends React.Component<{ set: React.Dispatch<any> }, { erro
 }
 
 export const Canvas = React.forwardRef<HTMLCanvasElement, Props>(function Canvas(
-  { children, fallback, tabIndex, resize, id, style, className, events, ...props }: Props,
+  { children, fallback, tabIndex, resize, id, style, className, events, ...props },
   forwardedRef,
 ) {
   const [containerRef, size] = useMeasure({ scroll: true, debounce: { scroll: 50, resize: 0 }, ...resize })
-  const canvasRef = React.useRef<HTMLCanvasElement>(null)
+  const canvasRef = React.useRef<HTMLCanvasElement>(null!)
   const [block, setBlock] = React.useState<SetBlock>(false)
   const [error, setError] = React.useState<any>(false)
   // Suspend this component if block is a promise (2nd run)
@@ -70,7 +70,7 @@ export const Canvas = React.forwardRef<HTMLCanvasElement, Props>(function Canvas
   }, [size, children])
 
   useIsomorphicLayoutEffect(() => {
-    const container = canvasRef.current!
+    const container = canvasRef.current
     return () => unmountComponentAtNode(container)
   }, [])
 

--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -42,9 +42,12 @@ class ErrorBoundary extends React.Component<{ set: React.Dispatch<any> }, { erro
   }
 }
 
-export function Canvas({ children, fallback, tabIndex, resize, id, style, className, events, ...props }: Props) {
-  const [ref, size] = useMeasure({ scroll: true, debounce: { scroll: 50, resize: 0 }, ...resize })
-  const canvas = React.useRef<HTMLCanvasElement>(null!)
+export const Canvas = React.forwardRef<HTMLCanvasElement, Props>(function Canvas(
+  { children, fallback, tabIndex, resize, id, style, className, events, ...props }: Props,
+  ref,
+) {
+  const [containerRef, size] = useMeasure({ scroll: true, debounce: { scroll: 50, resize: 0 }, ...resize })
+  const canvasRef = React.useRef<HTMLCanvasElement>(null)
   const [block, setBlock] = React.useState<SetBlock>(false)
   const [error, setError] = React.useState<any>(false)
   // Suspend this component if block is a promise (2nd run)
@@ -59,27 +62,36 @@ export function Canvas({ children, fallback, tabIndex, resize, id, style, classN
         <ErrorBoundary set={setError}>
           <React.Suspense fallback={<Block set={setBlock} />}>{children}</React.Suspense>
         </ErrorBoundary>,
-        canvas.current,
+        canvasRef.current,
         { ...props, size, events: events || createPointerEvents },
       )
     }
   }, [size, children])
 
   useIsomorphicLayoutEffect(() => {
-    const container = canvas.current
+    const container = canvasRef.current!
     return () => unmountComponentAtNode(container)
   }, [])
 
   return (
     <div
-      ref={ref}
+      ref={containerRef}
       id={id}
       className={className}
       tabIndex={tabIndex}
       style={{ position: 'relative', width: '100%', height: '100%', overflow: 'hidden', ...style }}>
-      <canvas ref={canvas} style={{ display: 'block' }}>
+      <canvas
+        ref={(node) => {
+          ;(canvasRef as React.MutableRefObject<HTMLCanvasElement | null>).current = node
+          if (typeof ref === 'function') {
+            ref(node)
+          } else if (ref) {
+            ref.current = node
+          }
+        }}
+        style={{ display: 'block' }}>
         {fallback}
       </canvas>
     </div>
   )
-}
+})

--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import mergeRefs from 'react-merge-refs'
 import useMeasure, { Options as ResizeOptions } from 'react-use-measure'
 import { render, unmountComponentAtNode, RenderProps } from './index'
 import { createPointerEvents } from './events'
@@ -44,7 +45,7 @@ class ErrorBoundary extends React.Component<{ set: React.Dispatch<any> }, { erro
 
 export const Canvas = React.forwardRef<HTMLCanvasElement, Props>(function Canvas(
   { children, fallback, tabIndex, resize, id, style, className, events, ...props }: Props,
-  ref,
+  forwardedRef,
 ) {
   const [containerRef, size] = useMeasure({ scroll: true, debounce: { scroll: 50, resize: 0 }, ...resize })
   const canvasRef = React.useRef<HTMLCanvasElement>(null)
@@ -80,16 +81,7 @@ export const Canvas = React.forwardRef<HTMLCanvasElement, Props>(function Canvas
       className={className}
       tabIndex={tabIndex}
       style={{ position: 'relative', width: '100%', height: '100%', overflow: 'hidden', ...style }}>
-      <canvas
-        ref={(node) => {
-          ;(canvasRef as React.MutableRefObject<HTMLCanvasElement | null>).current = node
-          if (typeof ref === 'function') {
-            ref(node)
-          } else if (ref) {
-            ref.current = node
-          }
-        }}
-        style={{ display: 'block' }}>
+      <canvas ref={mergeRefs([canvasRef, forwardedRef])} style={{ display: 'block' }}>
         {fallback}
       </canvas>
     </div>

--- a/packages/fiber/tests/web/canvas.test.tsx
+++ b/packages/fiber/tests/web/canvas.test.tsx
@@ -25,7 +25,7 @@ describe('web Canvas', () => {
     expect(renderer.container).toMatchSnapshot()
   })
 
-  it('should set ref', async () => {
+  it('should forward ref', async () => {
     const ref = React.createRef<HTMLCanvasElement>()
 
     await act(async () => {
@@ -36,7 +36,7 @@ describe('web Canvas', () => {
       )
     })
 
-    expect(ref).toBeDefined()
+    expect(ref.current).toBeDefined()
   })
 
   it('should correctly unmount', async () => {

--- a/packages/fiber/tests/web/canvas.test.tsx
+++ b/packages/fiber/tests/web/canvas.test.tsx
@@ -25,6 +25,20 @@ describe('web Canvas', () => {
     expect(renderer.container).toMatchSnapshot()
   })
 
+  it('should set ref', async () => {
+    const ref = React.createRef<HTMLCanvasElement>()
+
+    await act(async () => {
+      render(
+        <Canvas ref={ref}>
+          <group />
+        </Canvas>,
+      )
+    })
+
+    expect(ref).toBeDefined()
+  })
+
   it('should correctly unmount', async () => {
     let renderer: RenderResult = null!
     await act(async () => {


### PR DESCRIPTION
This will allow a user of the library to get a reference to the rendered `canvas` so that they can do e.g. `canvas.captureStream()`.

Note: I'm not sure if the test is correct as I'm getting the following error when I try to run `yarn test` from the root. It's not entirely clear how to set the project up for development; maybe add some instructions to readme.md or contributing.md?

```
      Warning: It looks like you're using the wrong act() around your test interactions.
      Be sure to use the matching version of act() corresponding to your renderer:
      
      // for react-dom:
      import {act} from 'react-dom/test-utils';
      // ...
      act(() => ...);
      
      // for react-test-renderer:
      import TestRenderer from react-test-renderer';
      const {act} = TestRenderer;
      // ...
      act(() => ...);
```