### PR TITLE
Add optional cache-key function to useLoader

### DIFF
--- a/packages/fiber/src/core/hooks.ts
+++ b/packages/fiber/src/core/hooks.ts
@@ -96,9 +96,10 @@ export function useLoader<T, U extends string | string[]>(
   input: U,
   extensions?: Extensions,
   onProgress?: (event: ProgressEvent<EventTarget>) => void,
+  keyFn?: (input: U) => string[],
 ): U extends any[] ? BranchingReturn<T, GLTF, GLTF & ObjectMap>[] : BranchingReturn<T, GLTF, GLTF & ObjectMap> {
   // Use suspense to load async assets
-  const keys = (Array.isArray(input) ? input : [input]) as string[]
+  const keys = typeof keyFn === 'function' ? keyFn(input) : ((Array.isArray(input) ? input : [input]) as string[])
   const results = useAsset(loadingFn<T>(extensions, onProgress), Proto, ...keys)
   // Return the object/s
   return (Array.isArray(input) ? results : results[0]) as U extends any[]


### PR DESCRIPTION
Adds an optional last parameter to `useLoader` , a function that can define the cache-keys which are used internally by `use-asset`. This will allow fixing situations with loaders + dynamic paths.
Example: https://github.com/pmndrs/drei/issues/453