### PR TITLE
feat: add attach-func and detach-func callbacks

### DIFF
--- a/markdown/api.md
+++ b/markdown/api.md
@@ -197,12 +197,17 @@ You can also attach to named parent properties using `attachObject={[target, nam
   <bufferAttribute attachObject={['attributes', 'position']} count={v.length / 3} array={v} itemSize={3} />
 ```
 
-Another option is to specify custom attach and detach functions. Either by specifying the name of the method from the parent or by specifying a function. Whereby the specification of a detach method is optional.
+Another option is to specify custom attach and detach functions. Either by specifying the name of the method from the parent or by specifying a function.
 
 ```jsx
 <scene>
-  <mesh attachFunc="attach" detachFunc="remove" />
-  <mesh attachFunc={(mesh, scene) => scene.add(mesh)} detachFunc={(mesh, scene) => mesh.removeFromParent()} />
+  <mesh attachFns={["add", "remove"]} />
+  <mesh
+    attachFns={[
+      (mesh, scene) => scene.add(mesh),
+      (mesh, scene) => mesh.removeFromParent(),
+    }]
+  />
 ```
 
 As of version 5 all elements ending with "Material" receive `attach="material"`, and all elements ending with "Geometry" receive `attach="geometry"` automatically. Of course you can still overwrite it, but it isn't necessary to type out any longer.

--- a/markdown/api.md
+++ b/markdown/api.md
@@ -197,6 +197,14 @@ You can also attach to named parent properties using `attachObject={[target, nam
   <bufferAttribute attachObject={['attributes', 'position']} count={v.length / 3} array={v} itemSize={3} />
 ```
 
+Another option is to specify custom attach and detach functions. Either by specifying the name of the method from the parent or by specifying a function. Whereby the specification of a detach method is optional.
+
+```jsx
+<scene>
+  <mesh attachFunc="attach" detachFunc="remove" />
+  <mesh attachFunc={(mesh, scene) => scene.add(mesh)} detachFunc={(mesh, scene) => mesh.removeFromParent()} />
+```
+
 As of version 5 all elements ending with "Material" receive `attach="material"`, and all elements ending with "Geometry" receive `attach="geometry"` automatically. Of course you can still overwrite it, but it isn't necessary to type out any longer.
 
 ```jsx
@@ -301,7 +309,7 @@ Also notice the `onPointerMissed` on the canvas element, which fires on clicks t
 
 <details>
 <summary>How the event-system works, bubbling and capture</summary>
-  
+
 Note 1: the pointerenter and pointerleave events work exactly the same as pointerover and pointerout. The pointerenter and pointerleave semantics are not implemented.
 
 Note 2: Some events (such as pointerout) happen when there is no intersection between `eventObject` and the ray. When this happens, the event will contain intersection data from a previous event with this object.

--- a/packages/fiber/src/core/is.ts
+++ b/packages/fiber/src/core/is.ts
@@ -1,8 +1,8 @@
 export const is = {
   obj: (a: any) => a === Object(a) && !is.arr(a) && typeof a !== 'function',
-  fun: (a: any) => typeof a === 'function',
-  str: (a: any) => typeof a === 'string',
-  num: (a: any) => typeof a === 'number',
+  fun: (a: any): a is Function => typeof a === 'function',
+  str: (a: any): a is string => typeof a === 'string',
+  num: (a: any): a is number => typeof a === 'number',
   und: (a: any) => a === void 0,
   arr: (a: any) => Array.isArray(a),
   equ(a: any, b: any) {

--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -30,6 +30,8 @@ export type BaseInstance = Omit<THREE.Object3D, 'parent' | 'children' | 'attach'
   parent: Instance | null
   children: Instance[]
   attach?: string
+  attachFunc?: string | Function
+  detachFunc?: string | Function
   remove: (...object: Instance[]) => Instance
   add: (...object: Instance[]) => Instance
   raycast?: (raycaster: THREE.Raycaster, intersects: THREE.Intersection[]) => void
@@ -350,6 +352,10 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>) {
         parentInstance[child.attachObject[0]][child.attachObject[1]] = child
       } else if (child.attach && !is.fun(child.attach)) {
         parentInstance[child.attach] = child
+      } else if (is.str(child.attachFunc) && is.fun(parentInstance[child.attachFunc])) {
+        parentInstance[child.attachFunc as string](child)
+      } else if (is.fun(child.attachFunc)) {
+        child.attachFunc(child, parentInstance)
       } else if (child.isObject3D) {
         // add in the usual parent-child way
         parentInstance.add(child)
@@ -419,6 +425,10 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>) {
         delete parentInstance[child.attachObject[0]][child.attachObject[1]]
       } else if (child.attach && !is.fun(child.attach)) {
         parentInstance[child.attach] = null
+      } else if (child.attachFunc && is.str(child.detachFunc) && is.fun(parentInstance[child.detachFunc])) {
+        parentInstance[child.detachFunc](child)
+      } else if (child.attachFunc && is.fun(child.detachFunc)) {
+        child.detachFunc(child, parentInstance)
       } else if (child.isObject3D) {
         parentInstance.remove(child)
         // Remove interactivity

--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -22,7 +22,8 @@ export type ClassConstructor = {
   new (): void
 }
 
-export type AttachFnsType = [attach: string | Function, detach: string | Function]
+export type AttachFnType = (self: Instance, parent: Instance) => void
+export type AttachFnsType = [attach: string | AttachFnType, detach: string | AttachFnType]
 
 // This type clamps down on a couple of assumptions that we can make regarding native types, which
 // could anything from scene objects, THREE.Objects, JSM, user-defined classes and non-scene objects.

--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -22,7 +22,7 @@ export type ClassConstructor = {
   new (): void
 }
 
-export type AttachFnsType = [string | Function, string | Function]
+export type AttachFnsType = [attach: string | Function, detach: string | Function]
 
 // This type clamps down on a couple of assumptions that we can make regarding native types, which
 // could anything from scene objects, THREE.Objects, JSM, user-defined classes and non-scene objects.

--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -353,7 +353,7 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>) {
       } else if (child.attach && !is.fun(child.attach)) {
         parentInstance[child.attach] = child
       } else if (is.str(child.attachFunc) && is.fun(parentInstance[child.attachFunc])) {
-        parentInstance[child.attachFunc as string](child)
+        parentInstance[child.attachFunc](child)
       } else if (is.fun(child.attachFunc)) {
         child.attachFunc(child, parentInstance)
       } else if (child.isObject3D) {

--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -327,10 +327,12 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>) {
     }
 
     // Auto-attach geometries and materials
-    if (name.endsWith('Geometry')) {
-      props = { attach: 'geometry', ...props }
-    } else if (name.endsWith('Material')) {
-      props = { attach: 'material', ...props }
+    if (!('attachFunc' in props)) {
+      if (name.endsWith('Geometry')) {
+        props = { attach: 'geometry', ...props }
+      } else if (name.endsWith('Material')) {
+        props = { attach: 'material', ...props }
+      }
     }
 
     // It should NOT call onUpdate on object instanciation, because it hasn't been added to the

--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -19,7 +19,7 @@ export type ColorArray = typeof THREE.Color | Parameters<THREE.Color['set']>
 export type Layers = THREE.Layers | Parameters<THREE.Layers['set']>[0]
 export type Quaternion = THREE.Quaternion | Parameters<THREE.Quaternion['set']>
 
-export type AttachCallback = (child: Object, parentInstance: Object) => void
+export type AttachCallback = (child: any, parentInstance: any) => void
 
 export interface NodeProps<T, P> {
   /** Attaches this class onto the parent under the given name and nulls it on unmount */

--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -19,6 +19,8 @@ export type ColorArray = typeof THREE.Color | Parameters<THREE.Color['set']>
 export type Layers = THREE.Layers | Parameters<THREE.Layers['set']>[0]
 export type Quaternion = THREE.Quaternion | Parameters<THREE.Quaternion['set']>
 
+export type AttachCallback = (child: Object, parentInstance: Object) => void
+
 export interface NodeProps<T, P> {
   /** Attaches this class onto the parent under the given name and nulls it on unmount */
   attach?: string
@@ -26,6 +28,16 @@ export interface NodeProps<T, P> {
   attachArray?: string
   /** Adds this class to an object on the parent under the given name and deletes it on unmount */
   attachObject?: [target: string, name: string]
+  /**
+   * Appends this class to the parent by calling a callback function
+   * or when the given name is a string by calling a method on the parent
+   */
+  attachFunc?: string | AttachCallback
+  /**
+   * Remove this class from the parent by calling a callback function
+   * or when the given name is a string by calling a method on the parent
+   */
+  detachFunc?: string | AttachCallback
   /** Constructor arguments */
   args?: Args<P>
   children?: React.ReactNode

--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -19,7 +19,7 @@ export type ColorArray = typeof THREE.Color | Parameters<THREE.Color['set']>
 export type Layers = THREE.Layers | Parameters<THREE.Layers['set']>[0]
 export type Quaternion = THREE.Quaternion | Parameters<THREE.Quaternion['set']>
 
-export type AttachCallback = (child: any, parentInstance: any) => void
+export type AttachCallback = string | ((child: any, parentInstance: any) => void)
 
 export interface NodeProps<T, P> {
   /** Attaches this class onto the parent under the given name and nulls it on unmount */
@@ -29,15 +29,10 @@ export interface NodeProps<T, P> {
   /** Adds this class to an object on the parent under the given name and deletes it on unmount */
   attachObject?: [target: string, name: string]
   /**
-   * Appends this class to the parent by calling a callback function
+   * Appends and removes this class to the parent by calling a callback function
    * or when the given name is a string by calling a method on the parent
    */
-  attachFunc?: string | AttachCallback
-  /**
-   * Remove this class from the parent by calling a callback function
-   * or when the given name is a string by calling a method on the parent
-   */
-  detachFunc?: string | AttachCallback
+  attachFns?: [AttachCallback, AttachCallback]
   /** Constructor arguments */
   args?: Args<P>
   children?: React.ReactNode

--- a/packages/fiber/tests/web/web.core.test.tsx
+++ b/packages/fiber/tests/web/web.core.test.tsx
@@ -235,13 +235,13 @@ describe('web core', () => {
     expect(scene.children[0].children.length).toBe(0)
   })
 
-  describe('attaches Object3D children that use attachFunc', () => {
-    it('attachFunc as string', async () => {
+  describe('attaches Object3D children that use attachFns', () => {
+    it('attachFns as strings', async () => {
       let scene: Scene = null!
       await act(async () => {
         scene = render(
           <hasObject3dMethods>
-            <mesh attachFunc="customAttach" detachFunc="detach" />
+            <mesh attachFns={['customAttach', 'detach']} />
           </hasObject3dMethods>,
           canvas,
         ).getState().scene
@@ -264,7 +264,7 @@ describe('web core', () => {
       expect(detachedMesh).toBe(attachedMesh)
     })
 
-    it('attachFunc as function', async () => {
+    it('attachFns as functions', async () => {
       let scene: Scene = null!
       let attachedMesh: Mesh = null!
       let detachedMesh: Mesh = null!
@@ -273,12 +273,14 @@ describe('web core', () => {
         scene = render(
           <hasObject3dMethods>
             <mesh
-              attachFunc={(mesh: Mesh, parentInstance: HasObject3dMethods) => {
-                attachedMesh = mesh
-              }}
-              detachFunc={(mesh: Mesh, parentInstance: HasObject3dMethods) => {
-                detachedMesh = mesh
-              }}
+              attachFns={[
+                (mesh: Mesh, parentInstance: HasObject3dMethods) => {
+                  attachedMesh = mesh
+                },
+                (mesh: Mesh, parentInstance: HasObject3dMethods) => {
+                  detachedMesh = mesh
+                },
+              ]}
             />
           </hasObject3dMethods>,
           canvas,

--- a/packages/fiber/tests/web/web.core.test.tsx
+++ b/packages/fiber/tests/web/web.core.test.tsx
@@ -13,7 +13,6 @@ import {
   PCFSoftShadowMap,
   ACESFilmicToneMapping,
   sRGBEncoding,
-  CameraHelper,
   Object3D,
 } from 'three'
 import { createCanvas } from '@react-three/test-renderer/src/createTestCanvas'
@@ -31,12 +30,27 @@ class HasObject3dMember extends Object3D {
   public attachment?: Object3D = undefined
 }
 
-extend({ HasObject3dMember })
+/* This class is used for one of the tests */
+class HasObject3dMethods extends Object3D {
+  attachedObj3d?: Object3D
+  detachedObj3d?: Object3D
+
+  customAttach(obj3d: Object3D) {
+    this.attachedObj3d = obj3d
+  }
+
+  detach(obj3d: Object3D) {
+    this.detachedObj3d = obj3d
+  }
+}
+
+extend({ HasObject3dMember, HasObject3dMethods })
 
 declare global {
   namespace JSX {
     interface IntrinsicElements {
       hasObject3dMember: ReactThreeFiber.Node<HasObject3dMember, typeof HasObject3dMember>
+      hasObject3dMethods: ReactThreeFiber.Node<HasObject3dMethods, typeof HasObject3dMethods>
     }
   }
 }
@@ -219,6 +233,69 @@ describe('web core', () => {
     expect(attachedMesh?.type).toBe('Mesh')
     // attaching is *instead of* being a regular child
     expect(scene.children[0].children.length).toBe(0)
+  })
+
+  describe('attaches Object3D children that use attachFunc', () => {
+    it('attachFunc as string', async () => {
+      let scene: Scene = null!
+      await act(async () => {
+        scene = render(
+          <hasObject3dMethods>
+            <mesh attachFunc="customAttach" detachFunc="detach" />
+          </hasObject3dMethods>,
+          canvas,
+        ).getState().scene
+      })
+
+      const attachedMesh = (scene.children[0] as HasObject3dMethods).attachedObj3d
+      expect(attachedMesh).toBeDefined()
+      expect(attachedMesh?.type).toBe('Mesh')
+      // attaching is *instead of* being a regular child
+      expect(scene.children[0].children.length).toBe(0)
+
+      // and now detach ..
+      expect((scene.children[0] as HasObject3dMethods).detachedObj3d).toBeUndefined()
+
+      await act(async () => {
+        render(<hasObject3dMethods />, canvas)
+      })
+
+      const detachedMesh = (scene.children[0] as HasObject3dMethods).detachedObj3d
+      expect(detachedMesh).toBe(attachedMesh)
+    })
+
+    it('attachFunc as function', async () => {
+      let scene: Scene = null!
+      let attachedMesh: Mesh = null!
+      let detachedMesh: Mesh = null!
+
+      await act(async () => {
+        scene = render(
+          <hasObject3dMethods>
+            <mesh
+              attachFunc={(mesh: Mesh, parentInstance: HasObject3dMethods) => {
+                attachedMesh = mesh
+              }}
+              detachFunc={(mesh: Mesh, parentInstance: HasObject3dMethods) => {
+                detachedMesh = mesh
+              }}
+            />
+          </hasObject3dMethods>,
+          canvas,
+        ).getState().scene
+      })
+
+      expect(attachedMesh).toBeDefined()
+      expect(attachedMesh?.type).toBe('Mesh')
+      // attaching is *instead of* being a regular child
+      expect(scene.children[0].children.length).toBe(0)
+
+      await act(async () => {
+        render(<hasObject3dMethods />, canvas)
+      })
+
+      expect(detachedMesh).toBe(attachedMesh)
+    })
   })
 
   it('does the full lifecycle', async () => {


### PR DESCRIPTION
In addition to the `attach`, `attachArray` and `attachObject` properties it can be helpful if you can specify your own method. Either as a name of a method of the _parent instance_ or as a concrete function.

```jsx
<scene>
  <mesh attachFunc="attach" detachFunc="remove" />
  <mesh
    attachFunc={(mesh, scene) => scene.add(mesh)}
    detachFunc={(mesh, scene) => mesh.removeFromParent()}
  />
</scene>
```

I admit that this example is a bit weak in content - but it illustrates the API very well.
The usage scenarios are manifold, especially where objects that are not part of the scene are composed.

What do you think about it? 😃 