### PR TITLE
delete redundant typescript exclamation mark

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ import React, { useRef, useState } from 'react'
 import { Canvas, useFrame } from '@react-three/fiber'
 
 function Box(props: JSX.IntrinsicElements['mesh']) {
-  const mesh = useRef<THREE.Mesh>(null!)
+  const mesh = useRef<THREE.Mesh>(null)
   const [hovered, setHover] = useState(false)
   const [active, setActive] = useState(false)
   useFrame((state, delta) => (mesh.current.rotation.x += 0.01))


### PR DESCRIPTION
there's no need for this exclamation mark as it's a valid TS syntax.