### PR TITLE
useFrame now throws an error if used outside of the Canvas component

### DIFF
--- a/packages/fiber/src/core/hooks.ts
+++ b/packages/fiber/src/core/hooks.ts
@@ -25,17 +25,21 @@ export type ObjectMap = {
   materials: { [name: string]: THREE.Material }
 }
 
+export function useStore() {
+  const store = React.useContext(context)
+  if (!store) throw `R3F hooks can only be used within the Canvas component!`
+  return store
+}
+
 export function useThree<T = RootState>(
   selector: StateSelector<RootState, T> = (state) => state as unknown as T,
   equalityFn?: EqualityChecker<T>,
 ) {
-  const useStore = React.useContext(context)
-  if (!useStore) throw `R3F hooks can only be used within the Canvas component!`
-  return useStore(selector, equalityFn)
+  return useStore()(selector, equalityFn)
 }
 
 export function useFrame(callback: RenderCallback, renderPriority: number = 0): null {
-  const { subscribe } = React.useContext(context).getState().internal
+  const { subscribe } = useStore().getState().internal
   // Update ref
   const ref = React.useRef<RenderCallback>(callback)
   React.useLayoutEffect(() => void (ref.current = callback), [callback])


### PR DESCRIPTION
Stemming from a [discord discussion](https://discord.com/channels/740090768164651008/745777196911689748/880429912295624714), we should probably throw an error if `useFrame` is used outside of a Canvas component if it throws an error anyway.