### PR TITLE
fix(fiber): respect `frameloop` when `vr` is specified

### DIFF
--- a/packages/fiber/src/web/index.tsx
+++ b/packages/fiber/src/web/index.tsx
@@ -85,7 +85,6 @@ function render<TCanvas extends Element>(
     // Enable VR if requested
     if (props.vr) {
       glRenderer.xr.enabled = true
-      glRenderer.setAnimationLoop((timestamp) => advance(timestamp, true))
     }
 
     // Create store


### PR DESCRIPTION
Fixes #1428 by subscribing to three's animation loop.

Edit: I'll have to test this with the codesandbox CI.