### PR TITLE
is.test: 'is equal' test to use already declared obj and array.

### DIFF
--- a/packages/test-renderer/src/__tests__/is.test.ts
+++ b/packages/test-renderer/src/__tests__/is.test.ts
@@ -75,13 +75,8 @@ describe('is', () => {
 
     expect(is.equ('hello', 'hello')).toBe(true)
     expect(is.equ(1, 1)).toBe(true)
-    const obj = {
-      type: 'Mesh',
-    }
-    expect(is.equ(obj, obj)).toBe(true)
-
-    const arr = [1, 2, 3]
-    expect(is.equ(arr, arr)).toBe(true)
+    expect(is.equ(myObj, myObj)).toBe(true)
+    expect(is.equ(myArr, myArr)).toBe(true)
     expect(is.equ([1, 2, 3], [1, 2, 3])).toBe(true)
   })
 })


### PR DESCRIPTION
Using the myObj and MyArr previously created instead of using new ones for the last test.
All tests passing.