### PR TITLE
chore: remove unused RenderProps and 'events'.

### DIFF
--- a/packages/fiber/tests/web/web.events.test.tsx
+++ b/packages/fiber/tests/web/web.events.test.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { render, fireEvent } from '@testing-library/react'
 import { createWebGLContext } from '@react-three/test-renderer/src/createWebGLContext'
 
-import { Canvas, events, act } from '../../src/web/index'
+import { Canvas, act } from '../../src/web/index'
 
 // @ts-ignore
 HTMLCanvasElement.prototype.getContext = function () {

--- a/packages/test-renderer/src/index.tsx
+++ b/packages/test-renderer/src/index.tsx
@@ -7,7 +7,6 @@ import {
   unmountComponentAtNode as unmount,
   act as _act,
 } from '@react-three/fiber'
-import type { RenderProps } from '@react-three/fiber'
 
 import { toTree } from './helpers/tree'
 import { toGraph } from './helpers/graph'


### PR DESCRIPTION
'RenderProps' is declared but its value is never read.ts(6133)
'events' is declared but its value is never read.ts(6133)

