### PR TITLE
change onPointerMissed behaviour

### DIFF
--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -343,7 +343,7 @@ export function createEvents(store: UseStore<RootState>) {
               handler(data as ThreeEvent<PointerEvent>)
               pointerMissed(
                 event,
-                internal.interaction.filter((object) => object !== eventObject),
+                internal.interaction.filter((object) => !internal.initialHits.includes(object)),
               )
             }
           }

--- a/packages/fiber/tests/web/web.events.test.tsx
+++ b/packages/fiber/tests/web/web.events.test.tsx
@@ -64,6 +64,90 @@ describe('events ', () => {
     expect(handleMissed).toHaveBeenCalledWith(evt)
   })
 
+  it('should not fire onPointerMissed when same element is clicked', async () => {
+    const handleClick = jest.fn()
+    const handleMissed = jest.fn()
+
+    await act(async () => {
+      render(
+        <Canvas>
+          <mesh onPointerMissed={handleMissed} onClick={handleClick}>
+            <boxGeometry args={[2, 2]} />
+            <meshBasicMaterial />
+          </mesh>
+        </Canvas>,
+      )
+    })
+
+    const down = new PointerEvent('pointerdown')
+    //@ts-ignore
+    down.offsetX = 577
+    //@ts-ignore
+    down.offsetY = 480
+
+    fireEvent(document.querySelector('canvas') as HTMLCanvasElement, down)
+
+    const up = new PointerEvent('pointerup')
+    //@ts-ignore
+    up.offsetX = 577
+    //@ts-ignore
+    up.offsetY = 480
+
+    const evt = new MouseEvent('click')
+    //@ts-ignore
+    evt.offsetX = 577
+    //@ts-ignore
+    evt.offsetY = 480
+
+    fireEvent(document.querySelector('canvas') as HTMLCanvasElement, evt)
+
+    expect(handleClick).toHaveBeenCalled()
+    expect(handleMissed).not.toHaveBeenCalled()
+  })
+
+  it('should not fire onPointerMissed on parent when child element is clicked', async () => {
+    const handleClick = jest.fn()
+    const handleMissed = jest.fn()
+
+    await act(async () => {
+      render(
+        <Canvas>
+          <group onPointerMissed={handleMissed}>
+            <mesh onClick={handleClick}>
+              <boxGeometry args={[2, 2]} />
+              <meshBasicMaterial />
+            </mesh>
+          </group>
+        </Canvas>,
+      )
+    })
+
+    const down = new PointerEvent('pointerdown')
+    //@ts-ignore
+    down.offsetX = 577
+    //@ts-ignore
+    down.offsetY = 480
+
+    fireEvent(document.querySelector('canvas') as HTMLCanvasElement, down)
+
+    const up = new PointerEvent('pointerup')
+    //@ts-ignore
+    up.offsetX = 577
+    //@ts-ignore
+    up.offsetY = 480
+
+    const evt = new MouseEvent('click')
+    //@ts-ignore
+    evt.offsetX = 577
+    //@ts-ignore
+    evt.offsetY = 480
+
+    fireEvent(document.querySelector('canvas') as HTMLCanvasElement, evt)
+
+    expect(handleClick).toHaveBeenCalled()
+    expect(handleMissed).not.toHaveBeenCalled()
+  })
+
   it('can handle onPointerMissed on Canvas', async () => {
     const handleMissed = jest.fn()
 


### PR DESCRIPTION
now when parent has OPM handler, child click won't trigger it