### PR TITLE
Clear prettier warning on events.ts

### DIFF
--- a/packages/fiber/src/web/events.ts
+++ b/packages/fiber/src/web/events.ts
@@ -20,10 +20,7 @@ export function createPointerEvents(store: UseStore<RootState>): EventManager<HT
 
   return {
     connected: false,
-    handlers: (Object.keys(names).reduce(
-      (acc, key) => ({ ...acc, [key]: handlePointer(key) }),
-      {},
-    ) as unknown) as Events,
+    handlers: Object.keys(names).reduce((acc, key) => ({ ...acc, [key]: handlePointer(key) }), {}) as unknown as Events,
     connect: (target: HTMLElement) => {
       const { set, events } = store.getState()
       events.disconnect?.()


### PR DESCRIPTION
I get a prettier warning on `events.ts`

`Replace `(Object.keys(names).reduce(⏎······(acc,·key)·=>·({·...acc,·[key]:·handlePointer(key)·}),⏎······{},⏎····)·as·unknown)` with `Object.keys(names).reduce((acc,·key)·=>·({·...acc,·[key]:·handlePointer(key)·}),·{})·as·unknown``

This update clears the prettier warning. All tests pass.