### PR TITLE
Fix eslint for 'exhaustive-rule.

### DIFF
--- a/packages/fiber/src/core/hooks.ts
+++ b/packages/fiber/src/core/hooks.ts
@@ -43,7 +43,7 @@ export function useFrame(callback: RenderCallback, renderPriority: number = 0): 
   const ref = React.useRef<RenderCallback>(callback)
   React.useLayoutEffect(() => void (ref.current = callback), [callback])
   // Subscribe on mount, unsubscribe on unmount
-  React.useLayoutEffect(() => subscribe(ref, renderPriority), [renderPriority])
+  React.useLayoutEffect(() => subscribe(ref, renderPriority), [renderPriority, subscribe])
   return null
 }
 


### PR DESCRIPTION
React Hook React.useLayoutEffect has a missing dependency: 'subscribe'. 
Either include it or remove the dependency array. 
_eslint react-hooks/exhaustive-deps_
