### PR TITLE
fix(core): update internals on dpr change

### DIFF
--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -70,6 +70,7 @@ export type RootState = {
   controls: THREE.EventDispatcher | null
   raycaster: Raycaster
   mouse: THREE.Vector2
+  dpr: Dpr
   clock: THREE.Clock
 
   vr: boolean
@@ -185,10 +186,10 @@ const createStore = (
       camera.lookAt(0, 0, 0)
     }
 
-    function setDpr(dpr: Dpr) {
+    function calculateDpr(dpr: Dpr) {
       return Array.isArray(dpr) ? Math.min(Math.max(dpr[0], window.devicePixelRatio), dpr[1]) : dpr
     }
-    const initialDpr = setDpr(dpr)
+    const initialDpr = calculateDpr(dpr)
 
     const position = new THREE.Vector3()
     const defaultTarget = new THREE.Vector3()
@@ -256,6 +257,7 @@ const createStore = (
       },
 
       size: { width: 0, height: 0 },
+      dpr,
       viewport: {
         initialDpr,
         dpr: initialDpr,
@@ -271,7 +273,27 @@ const createStore = (
         const size = { width, height }
         set((state) => ({ size, viewport: { ...state.viewport, ...getCurrentViewport(camera, defaultTarget, size) } }))
       },
-      setDpr: (dpr: Dpr) => set((state) => ({ viewport: { ...state.viewport, dpr: setDpr(dpr) } })),
+      setDpr: (dpr: Dpr) =>
+        set(({ viewport, internal }) => {
+          const newState = {
+            dpr,
+            viewport: {
+              ...viewport,
+              dpr: calculateDpr(dpr),
+            },
+          }
+
+          return {
+            ...newState,
+            internal: {
+              ...internal,
+              lastProps: {
+                ...internal.lastProps,
+                ...newState,
+              },
+            },
+          }
+        }),
 
       events: { connected: false },
       internal: {

--- a/packages/fiber/tests/web/web.core.test.tsx
+++ b/packages/fiber/tests/web/web.core.test.tsx
@@ -397,6 +397,17 @@ describe('web core', () => {
     expect(state.getState().gl.outputEncoding).toBe(sRGBEncoding)
   })
 
+  it('should update internals when dpr is set', async () => {
+    let state: UseStore<RootState> = null!
+    await act(async () => {
+      state = render(<group />, canvas, {
+        dpr: [1, 2],
+      })
+    })
+
+    expect(state.getState().dpr).toBe(state.getState().internal.lastProps.dpr)
+  })
+
   it('will render components that are extended', async () => {
     class MyColor extends Color {
       constructor(col: number) {

--- a/packages/fiber/tests/web/web.core.test.tsx
+++ b/packages/fiber/tests/web/web.core.test.tsx
@@ -405,6 +405,12 @@ describe('web core', () => {
       })
     })
 
+    expect(state.getState().dpr).toStrictEqual([1, 2])
+    expect(state.getState().dpr).toBe(state.getState().internal.lastProps.dpr)
+
+    state.getState().setDpr(3)
+
+    expect(state.getState().dpr).toBe(3)
     expect(state.getState().dpr).toBe(state.getState().internal.lastProps.dpr)
   })
 


### PR DESCRIPTION
Fixes #1662 by passing `dpr` to store (`[min, max] | number`), with `viewport.dpr` being the calculated result (`number`).