### PR TITLE
tests(web):  `web.core.tests` updates

### DIFF
--- a/packages/fiber/tests/web/web.core.test.tsx
+++ b/packages/fiber/tests/web/web.core.test.tsx
@@ -93,6 +93,11 @@ describe('web core', () => {
     })
 
     expect(scene.children[0].type).toEqual('Mesh')
+    expect((scene.children[0] as ComponentMesh).geometry.type).toEqual('BoxGeometry')
+    expect((scene.children[0] as ComponentMesh).material.type).toEqual('MeshBasicMaterial')
+    expect((scene.children[0] as THREE.Mesh<THREE.BoxGeometry, MeshStandardMaterial>).material.type).toEqual(
+      'MeshBasicMaterial',
+    )
   })
 
   it('renders an empty scene', async () => {
@@ -138,6 +143,9 @@ describe('web core', () => {
     expect(scene.children[0].children[0].type).toEqual('Mesh')
     expect((scene.children[0].children[0] as ComponentMesh).geometry.type).toEqual('BoxGeometry')
     expect((scene.children[0].children[0] as ComponentMesh).material.type).toEqual('MeshBasicMaterial')
+    expect(
+      (scene.children[0].children[0] as THREE.Mesh<THREE.BoxGeometry, MeshStandardMaterial>).material.type,
+    ).toEqual('MeshBasicMaterial')
   })
 
   it('renders some basics with an update', async () => {
@@ -274,10 +282,10 @@ describe('web core', () => {
           <hasObject3dMethods>
             <mesh
               attachFns={[
-                (mesh: Mesh, parentInstance: HasObject3dMethods) => {
+                (mesh: Mesh) => {
                   attachedMesh = mesh
                 },
-                (mesh: Mesh, parentInstance: HasObject3dMethods) => {
+                (mesh: Mesh) => {
                   detachedMesh = mesh
                 },
               ]}
@@ -404,7 +412,7 @@ describe('web core', () => {
       }
     }
 
-    await expect(async () => {
+    expect(async () => {
       await act(async () => {
         extend({ MyColor })
 


### PR DESCRIPTION
Updates to  `web.core.tests`.

- [x] Adds expectations to `renders a simple component` and `renders a simple component`
- [x] Removes unused vars from `attachFns as functions`
- [x] Removes unnecessary `await` from `will render components that are extended` _('await' has no effect on the type of this expression.ts(80007))_
