### PR TITLE
feat: remove vr prop for dynamic render switching

### DIFF
--- a/markdown/api.md
+++ b/markdown/api.md
@@ -49,7 +49,6 @@ The canvas stretches to 100% of the next relative/absolute parent-container. Mak
   shadows                       // Props that go into gl.shadowMap, can also be set true for PCFsoft
   linear = false                // True by default for automatic sRGB encoding and gamma correction
   flat = false                  // If true uses THREE.NoToneMapping, otherwise THREE.ACESFilmicToneMapping
-  vr = false                    // Switches renderer to VR mode, then uses gl.setAnimationLoop
   mode = "blocking"             // React mode: legacy | blocking | concurrent
   resize = undefined            // Resize config, see react-use-measure's options
   orthographic = false          // Creates an orthographic camera if true
@@ -405,7 +404,6 @@ const {
   raycaster, // Raycaster
   mouse, // THREE.Vector2
   clock, // THREE.Clock
-  vr, // boolean
   linear, // Colorspace, boolean
   frameloop, // 'always' | 'demand' | 'never'
   performance: {

--- a/markdown/recipes.md
+++ b/markdown/recipes.md
@@ -224,12 +224,14 @@ const Controls = () => {
 
 ## Enabling VR
 
-Supplying the `vr` flag enables Three's VR mode and switches the render-loop to gl.setAnimationLoop [as described in Three's docs](https://threejs.org/docs/index.html#manual/en/introduction/How-to-create-VR-content).
+React-Three-Fiber automatically switches rendering modes when you enter a WebXR session.
+
+To request one, create a `VRButton` [as described in Three's docs](https://threejs.org/docs/index.html#manual/en/introduction/How-to-create-VR-content).
 
 ```jsx
-import * as VR from '!exports-loader?WEBVR!three/examples/js/vr/WebVR'
-import { Canvas } from 'react-three-fiber'
-;<Canvas vr onCreated={({ gl }) => document.body.appendChild(VR.createButton(gl))} />
+import { VRButton } from 'three/examples/jsm/webxr/VRButton'
+import { Canvas } from '@react-three/fiber'
+;<Canvas onCreated={({ gl }) => void document.body.appendChild(VRButton.createButton(gl))} />
 ```
 
 ## Reducing bundle-size

--- a/packages/fiber/src/core/loop.ts
+++ b/packages/fiber/src/core/loop.ts
@@ -52,7 +52,11 @@ export function createLoop<TCanvas>(roots: Map<TCanvas, Root>) {
     roots.forEach((root) => {
       const state = root.store.getState()
       // If the frameloop is invalidated, do not run another frame
-      if (state.internal.active && (state.frameloop === 'always' || state.internal.frames > 0))
+      if (
+        state.internal.active &&
+        (state.frameloop === 'always' || state.internal.frames > 0) &&
+        !state.gl.xr.isPresenting
+      )
         repeat += render(timestamp, state)
     })
     // Run after-effects
@@ -69,7 +73,7 @@ export function createLoop<TCanvas>(roots: Map<TCanvas, Root>) {
 
   function invalidate(state?: RootState): void {
     if (!state) return roots.forEach((root) => invalidate(root.store.getState()))
-    if (state.vr || !state.internal.active || state.frameloop === 'never') return
+    if (state.gl.xr.isPresenting || !state.internal.active || state.frameloop === 'never') return
     // Increase frames, do not go higher than 60
     state.internal.frames = Math.min(60, state.internal.frames + 1)
     // If the render-loop isn't active, start it

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -72,7 +72,6 @@ export type RootState = {
   mouse: THREE.Vector2
   clock: THREE.Clock
 
-  vr: boolean
   linear: boolean
   flat: boolean
   frameloop: 'always' | 'demand' | 'never'
@@ -101,7 +100,6 @@ export type ComputeOffsetsFunction = (event: any, state: RootState) => { offsetX
 export type StoreProps = {
   gl: THREE.WebGLRenderer
   size: Size
-  vr?: boolean
   shadows?: boolean | Partial<THREE.WebGLShadowMap>
   linear?: boolean
   flat?: boolean
@@ -137,7 +135,6 @@ const createStore = (
     shadows = false,
     linear = false,
     flat = false,
-    vr = false,
     orthographic = false,
     frameloop = 'always',
     dpr = 1,
@@ -217,6 +214,22 @@ const createStore = (
     const setPerformanceCurrent = (current: number) =>
       set((state) => ({ performance: { ...state.performance, current } }))
 
+    const handleXRFrame = (timestamp: number) => {
+      const state = get()
+      if (state.frameloop === 'never') return
+
+      advance(timestamp, true)
+    }
+
+    const handleSessionChange = () => {
+      gl.xr.enabled = gl.xr.isPresenting
+      gl.setAnimationLoop(gl.xr.isPresenting ? handleXRFrame : null)
+    }
+
+    // Update render mode on session change
+    gl.xr.addEventListener('sessionstart', handleSessionChange)
+    gl.xr.addEventListener('sessionend', handleSessionChange)
+
     return {
       gl,
 
@@ -234,7 +247,6 @@ const createStore = (
       clock,
       mouse: new THREE.Vector2(),
 
-      vr,
       frameloop,
       onPointerMissed,
 

--- a/packages/fiber/src/web/index.tsx
+++ b/packages/fiber/src/web/index.tsx
@@ -88,12 +88,6 @@ function render<TCanvas extends Element>(
     // Create gl
     const glRenderer = createRendererInstance(gl, canvas)
 
-    // Enable VR if requested
-    if (props.vr) {
-      glRenderer.xr.enabled = true
-      glRenderer.setAnimationLoop((timestamp) => advance(timestamp, true))
-    }
-
     // Create store
     store = createStore(applyProps, invalidate, advance, { gl: glRenderer, size, ...props })
     const state = store.getState()

--- a/packages/fiber/tests/web/canvas.test.tsx
+++ b/packages/fiber/tests/web/canvas.test.tsx
@@ -51,24 +51,4 @@ describe('web Canvas', () => {
 
     expect(() => renderer.unmount()).not.toThrow()
   })
-
-  it('should render with vr prop set', async () => {
-    let xrEnabled = false
-
-    const Component = () => {
-      const gl = useThree((state) => state.gl)
-      xrEnabled = gl.xr.enabled
-      return null
-    }
-
-    await act(async () => {
-      render(
-        <Canvas vr={true}>
-          <Component />
-        </Canvas>,
-      )
-    })
-
-    expect(xrEnabled).toBe(true)
-  })
 })

--- a/packages/fiber/tests/web/web.core.test.tsx
+++ b/packages/fiber/tests/web/web.core.test.tsx
@@ -18,7 +18,7 @@ import {
 import { createCanvas } from '@react-three/test-renderer/src/createTestCanvas'
 import { createWebGLContext } from '@react-three/test-renderer/src/createWebGLContext'
 
-import { render, act, unmountComponentAtNode, extend } from '../../src/web/index'
+import { render, act, unmountComponentAtNode, useFrame, extend } from '../../src/web/index'
 import { UseStore } from 'zustand'
 import { RootState } from '../../src/core/store'
 import { ReactThreeFiber } from '../../src'
@@ -395,6 +395,41 @@ describe('web core', () => {
 
     expect(state.getState().gl.toneMapping).toBe(ACESFilmicToneMapping)
     expect(state.getState().gl.outputEncoding).toBe(sRGBEncoding)
+  })
+
+  it('should toggle render mode in xr', async () => {
+    let state: RootState = null!
+
+    await act(async () => {
+      state = render(<group />, canvas).getState()
+      state.gl.xr.isPresenting = true
+      state.gl.xr.dispatchEvent({ type: 'sessionstart' })
+    })
+
+    expect(state.gl.xr.enabled).toEqual(true)
+
+    await act(async () => {
+      state.gl.xr.isPresenting = false
+      state.gl.xr.dispatchEvent({ type: 'sessionend' })
+    })
+
+    expect(state.gl.xr.enabled).toEqual(false)
+  })
+
+  it('should respect frameloop="never" in xr', async () => {
+    let respected = true
+
+    await act(async () => {
+      const TestGroup = () => {
+        useFrame(() => (respected = false))
+        return <group />
+      }
+      const state = render(<TestGroup />, canvas, { frameloop: 'never' }).getState()
+      state.gl.xr.isPresenting = true
+      state.gl.xr.dispatchEvent({ type: 'sessionstart' })
+    })
+
+    expect(respected).toEqual(true)
   })
 
   it('will render components that are extended', async () => {


### PR DESCRIPTION
An alternative to #1693.

Removes the `vr` prop entirely (based on #1177 and https://github.com/pmndrs/react-three-fiber/pull/1693#issuecomment-932617209) and toggles render switching on session.

This introduction of dynamic render switching fixes #1428 by only requesting WebXR features when needed.