### PR TITLE
perf: cache event handler regexp

### DIFF
--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -104,6 +104,8 @@ function prepare<T = THREE.Object3D>(object: T, state?: Partial<LocalState>) {
   return object
 }
 
+const eventHandlerRegexp = /^on(Pointer|Click|DoubleClick|ContextMenu|Wheel)/
+
 function createRenderer<TCanvas>(roots: Map<TCanvas, Root>) {
   // This function prepares a set of changes to be applied to the instance
   function diffProps(
@@ -130,7 +132,7 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>) {
       if (checkShallow(value, previous[key])) return
 
       // Collect handlers and bail out
-      if (/^on(Pointer|Click|DoubleClick|ContextMenu|Wheel)/.test(key)) return changes.push([key, value, true, []])
+      if (eventHandlerRegexp.test(key)) return changes.push([key, value, true, []])
 
       // Split dashed props
       let entries: string[] = []


### PR DESCRIPTION
Was skimming through the code and found that the event handler regexp was created MANY times. Caching it should improve perf a little bit since it's a hot path. 

V8 apprantely tries to cache compiled regexp's but it's not a guarantee. Not sure how other engines works, so there might be bigger benefits for them.

The change is on micro-optimization territory so let me know if you think it makes sense or not.