### PR TITLE
[v8] chore: add modes back, remove blocking option

### DIFF
--- a/markdown/api.md
+++ b/markdown/api.md
@@ -50,7 +50,7 @@ The canvas stretches to 100% of the next relative/absolute parent-container. Mak
   linear = false                // True by default for automatic sRGB encoding and gamma correction
   flat = false                  // If true uses THREE.NoToneMapping, otherwise THREE.ACESFilmicToneMapping
   vr = false                    // Switches renderer to VR mode, then uses gl.setAnimationLoop
-  mode = "blocking"             // React mode: legacy | blocking | concurrent
+  mode = "legacy"               // React mode: legacy | concurrent
   resize = undefined            // Resize config, see react-use-measure's options
   orthographic = false          // Creates an orthographic camera if true
   dpr = undefined               // Pixel-ratio, use window.devicePixelRatio, or automatic: [min, max]


### PR DESCRIPTION
Reverts the regression made in 728cb8ae2214c35479609d0ce2571fd77e6ea2d4 where we removed the option to specify R3F's rendering mode.

This can be configured as either `legacy` (default) or `concurrent`.