### PR TITLE
fix(core): don't overwrite camera rotation

### DIFF
--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -182,7 +182,7 @@ const createStore = (
       camera.position.z = 5
       if (cameraOptions) applyProps(camera as any, cameraOptions as any)
       // Always look at center by default
-      camera.lookAt(0, 0, 0)
+      if (cameraOptions?.position) camera.lookAt(0, 0, 0)
     }
 
     function setDpr(dpr: Dpr) {


### PR DESCRIPTION
This PR fixes default camera behavior where we'll transform the camera rotation to face 0, 0. If a custom rotation was specified via `camera`, it would be overwritten.