### PR TITLE
feat: accept renderer properties via `gl`

### DIFF
--- a/packages/fiber/tests/web/web.core.test.tsx
+++ b/packages/fiber/tests/web/web.core.test.tsx
@@ -421,4 +421,15 @@ describe('web core', () => {
       })
     }).not.toThrow()
   })
+
+  it('should set renderer props via gl prop', async () => {
+    let gl: THREE.WebGLRenderer = null!
+    await act(async () => {
+      gl = render(<group />, canvas, {
+        gl: { physicallyCorrectLights: true },
+      }).getState().gl
+    })
+
+    expect(gl.physicallyCorrectLights).toBe(true)
+  })
 })


### PR DESCRIPTION
Fixes #1694 by accepting `WebGLRenderer` properties in addition to constructor args. This makes `gl` consistent with `camera` in practice.