### PR TITLE
[v8] refactor(core): move dpr calculation to targets

### DIFF
--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -5,7 +5,6 @@ import create, { GetState, SetState, UseStore } from 'zustand'
 import shallow from 'zustand/shallow'
 import { prepare, Instance, InstanceProps } from './renderer'
 import { DomEvent, EventManager, ThreeEvent } from './events'
-import { calculateDpr } from './utils'
 
 export interface Intersection extends THREE.Intersection {
   eventObject: THREE.Object3D
@@ -111,6 +110,7 @@ export type StoreProps = {
   frameloop?: 'always' | 'demand' | 'never'
   performance?: Partial<Omit<Performance, 'regress'>>
   dpr?: Dpr
+  calculateDpr: (dpr: Dpr) => number
   clock?: THREE.Clock
   raycaster?: Partial<Raycaster>
   camera?:
@@ -143,6 +143,7 @@ const createStore = (
     orthographic = false,
     frameloop = 'always',
     dpr = 1,
+    calculateDpr,
     performance,
     clock = new THREE.Clock(),
     raycaster: raycastOptions,

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -89,7 +89,7 @@ export type RootState = {
   invalidate: () => void
   advance: (timestamp: number, runGlobalEffects?: boolean) => void
   setSize: (width: number, height: number) => void
-  setDpr: (dpr: Dpr) => void
+  setDpr: (dpr: number) => void
   onPointerMissed?: (event: ThreeEvent<PointerEvent>) => void
 
   events: EventManager<any>
@@ -109,8 +109,7 @@ export type StoreProps = {
   orthographic?: boolean
   frameloop?: 'always' | 'demand' | 'never'
   performance?: Partial<Omit<Performance, 'regress'>>
-  dpr?: Dpr
-  calculateDpr: (dpr: Dpr) => number
+  dpr?: number
   clock?: THREE.Clock
   raycaster?: Partial<Raycaster>
   camera?:
@@ -143,7 +142,6 @@ const createStore = (
     orthographic = false,
     frameloop = 'always',
     dpr = 1,
-    calculateDpr,
     performance,
     clock = new THREE.Clock(),
     raycaster: raycastOptions,
@@ -187,8 +185,6 @@ const createStore = (
       // Always look at center by default
       if (!cameraOptions?.rotation) camera.lookAt(0, 0, 0)
     }
-
-    const initialDpr = calculateDpr(dpr)
 
     const position = new THREE.Vector3()
     const defaultTarget = new THREE.Vector3()
@@ -260,8 +256,8 @@ const createStore = (
 
       size: { width: 0, height: 0 },
       viewport: {
-        initialDpr,
-        dpr: initialDpr,
+        initialDpr: dpr,
+        dpr,
         width: 0,
         height: 0,
         aspect: 0,
@@ -274,7 +270,7 @@ const createStore = (
         const size = { width, height }
         set((state) => ({ size, viewport: { ...state.viewport, ...getCurrentViewport(camera, defaultTarget, size) } }))
       },
-      setDpr: (dpr: Dpr) => set((state) => ({ viewport: { ...state.viewport, dpr: calculateDpr(dpr) } })),
+      setDpr: (dpr: number) => set((state) => ({ viewport: { ...state.viewport, dpr } })),
 
       events: { connected: false },
       internal: {

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three'
 import { UseStore } from 'zustand'
 import { EventHandlers } from './events'
 import { Instance, InstanceProps, LocalState } from './renderer'
-import { Dpr, RootState } from './store'
+import { RootState } from './store'
 
 export const DEFAULT = '__default'
 
@@ -17,10 +17,6 @@ export type ClassConstructor = { new (): void }
 export type ObjectMap = {
   nodes: { [name: string]: THREE.Object3D }
   materials: { [name: string]: THREE.Material }
-}
-
-export function calculateDpr(dpr: Dpr) {
-  return Array.isArray(dpr) ? Math.min(Math.max(dpr[0], window.devicePixelRatio), dpr[1]) : dpr
 }
 
 // A collection of compare functions

--- a/packages/fiber/src/web/index.tsx
+++ b/packages/fiber/src/web/index.tsx
@@ -4,8 +4,8 @@ import * as React from 'react'
 import { ConcurrentRoot } from 'react-reconciler/constants'
 import { UseStore } from 'zustand'
 
-import { dispose, calculateDpr } from '../core/utils'
-import { Renderer, createStore, StoreProps, isRenderer, context, RootState, Size } from '../core/store'
+import { dispose } from '../core/utils'
+import { Renderer, Dpr, createStore, StoreProps, isRenderer, context, RootState, Size } from '../core/store'
 import { createRenderer, extend, Root } from '../core/renderer'
 import { createLoop, addEffect, addAfterEffect, addTail } from '../core/loop'
 import { createPointerEvents as events, getEventPriority } from './events'
@@ -24,7 +24,7 @@ type GLProps =
   | Partial<Properties<THREE.WebGLRenderer> | THREE.WebGLRendererParameters>
   | undefined
 
-export type RenderProps<TCanvas extends Element> = Omit<StoreProps, 'gl' | 'events' | 'size'> & {
+export type RenderProps<TCanvas extends Element> = Omit<StoreProps, 'gl' | 'events' | 'size' | 'calculateDpr'> & {
   gl?: GLProps
   events?: (store: UseStore<RootState>) => EventManager<TCanvas>
   size?: Size
@@ -47,6 +47,10 @@ const createRendererInstance = <TElement extends Element>(gl: GLProps, canvas: T
   if (gl) applyProps(renderer as any, gl as any)
 
   return renderer
+}
+
+const calculateDpr = (dpr: Dpr) => {
+  return Array.isArray(dpr) ? Math.min(Math.max(dpr[0], window.devicePixelRatio), dpr[1]) : dpr
 }
 
 function createRoot<TCanvas extends Element>(canvas: TCanvas) {
@@ -105,7 +109,7 @@ function render<TCanvas extends Element>(
     }
 
     // Create store
-    store = createStore(applyProps, invalidate, advance, { gl: glRenderer, size, ...props })
+    store = createStore(applyProps, invalidate, advance, { gl: glRenderer, size, calculateDpr, ...props })
     const state = store.getState()
     // Create renderer
     fiber = reconciler.createContainer(store, ConcurrentRoot, false, null)


### PR DESCRIPTION
The introduction of react-native support means that we have to remove all environment-dependent stuff from the core.

Currently, setting `dpr` will break in native because the core tries to access `window.devicePixelRatio` instead of native's `PixelRatio#get`. This PR leaves that responsibility to each target.