### PR TITLE
complete the fix for attaching to non-Object3D

### DIFF
--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -419,7 +419,7 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>) {
         } else if (is.fun(detachFn)) {
           detachFn(child, parentInstance)
         }
-      } else if (child.isObject3D) {
+      } else if (child.isObject3D && parentInstance.isObject3D) {
         parentInstance.remove(child)
         // Remove interactivity
         if (child.__r3f?.root) {


### PR DESCRIPTION
When I added the extra checks for parentInstance.isObject3D, I only added them when mounting the object and missed out the case in removeChild. It seemed to work when I tested against my application, but now removeChild throws an error  in my application, trying to call remove on something that is not Object3D. This change fixes that, making the conditions for calling add and remove the same.