### PR TITLE
fix(core): unmounting pointer capture target

### DIFF
--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -4,7 +4,7 @@ import * as ReactThreeFiber from '../three-types'
 import create, { GetState, SetState, UseStore } from 'zustand'
 import shallow from 'zustand/shallow'
 import { prepare, Instance, InstanceProps } from './renderer'
-import { DomEvent, EventManager, ThreeEvent } from './events'
+import { DomEvent, EventManager, PointerCaptureTarget, ThreeEvent } from './events'
 
 export interface Intersection extends THREE.Intersection {
   eventObject: THREE.Object3D
@@ -57,7 +57,7 @@ export type InternalState = {
   interaction: THREE.Object3D[]
   hovered: Map<string, DomEvent>
   subscribers: Subscription[]
-  capturedMap: Map<number, Map<THREE.Object3D, Intersection>>
+  capturedMap: Map<number, Map<THREE.Object3D, PointerCaptureTarget>>
   initialClick: [x: number, y: number]
   initialHits: THREE.Object3D[]
 


### PR DESCRIPTION
Previously, unmounting the pointer capture target would not release its pointer capture. This would obviously cause problems when sending subsequent pointer events to it. This commit fixes the problem by storing the native (DOM) pointer capture target in the capturesMap so that it can be removed in removeInteractivity.

Adding a new test for pointer capture necessitated changing how the event props are copied in handleIntersects. The old code looked at the prototype (which should be PointerEvent) to find the props to copy, but in tests the pointerEventPolyfill is active and the prototype is MouseEvent, which meant none of the PointerEvent properties got copied. I've changed it to use for...in to look at the object's own properties and its inherited properties.