### PR TITLE
[v8] refactor(core): use-asset => suspend-react

### DIFF
--- a/packages/fiber/package.json
+++ b/packages/fiber/package.json
@@ -52,7 +52,7 @@
     "react-use-measure": "^2.0.4",
     "resize-observer-polyfill": "^1.5.1",
     "scheduler": "0.0.0-experimental-031abd24b-20210907",
-    "use-asset": "2.0.0-alpha-00",
+    "suspend-react": "^0.0.8",
     "utility-types": "^3.10.0",
     "zustand": "^3.5.10"
   },

--- a/packages/fiber/src/core/hooks.ts
+++ b/packages/fiber/src/core/hooks.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three'
 import * as React from 'react'
 import { StateSelector, EqualityChecker } from 'zustand'
 import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader'
-import { useAsset } from 'use-asset'
+import { suspend, preload, clear } from 'suspend-react'
 import { context, RootState, RenderCallback } from './store'
 import { buildGraph, ObjectMap } from './utils'
 
@@ -80,23 +80,19 @@ export function useLoader<T, U extends string | string[]>(
 ): U extends any[] ? BranchingReturn<T, GLTF, GLTF & ObjectMap>[] : BranchingReturn<T, GLTF, GLTF & ObjectMap> {
   // Use suspense to load async assets
   const keys = (Array.isArray(input) ? input : [input]) as string[]
-  const results = useAsset(loadingFn<T>(extensions, onProgress), Proto, ...keys)
+  const results = suspend(loadingFn<T>(extensions, onProgress), [Proto, ...keys])
   // Return the object/s
   return (Array.isArray(input) ? results : results[0]) as U extends any[]
     ? BranchingReturn<T, GLTF, GLTF & ObjectMap>[]
     : BranchingReturn<T, GLTF, GLTF & ObjectMap>
 }
 
-useLoader.preload = function <T, U extends string | string[]>(
-  Proto: new () => LoaderResult<T>,
-  input: U,
-  extensions?: Extensions,
-) {
+useLoader.preload = function <T, U extends string | string[]>(Proto: new () => LoaderResult<T>, input: U) {
   const keys = (Array.isArray(input) ? input : [input]) as string[]
-  return useAsset.preload(loadingFn<T>(extensions), Proto, ...keys)
+  return preload(Proto, ...keys)
 }
 
 useLoader.clear = function <T, U extends string | string[]>(Proto: new () => LoaderResult<T>, input: U) {
   const keys = (Array.isArray(input) ? input : [input]) as string[]
-  return useAsset.clear(Proto, ...keys)
+  return clear(Proto, ...keys)
 }

--- a/packages/fiber/src/core/hooks.ts
+++ b/packages/fiber/src/core/hooks.ts
@@ -87,12 +87,16 @@ export function useLoader<T, U extends string | string[]>(
     : BranchingReturn<T, GLTF, GLTF & ObjectMap>
 }
 
-useLoader.preload = function <T, U extends string | string[]>(Proto: new () => LoaderResult<T>, input: U) {
+useLoader.preload = function <T, U extends string | string[]>(
+  Proto: new () => LoaderResult<T>,
+  input: U,
+  extensions?: Extensions,
+) {
   const keys = (Array.isArray(input) ? input : [input]) as string[]
-  return (preload as any)(Proto, ...keys)
+  return preload(loadingFn<T>(extensions), [Proto, ...keys])
 }
 
 useLoader.clear = function <T, U extends string | string[]>(Proto: new () => LoaderResult<T>, input: U) {
   const keys = (Array.isArray(input) ? input : [input]) as string[]
-  return (clear as any)(Proto, ...keys)
+  return clear([Proto, ...keys])
 }

--- a/packages/fiber/src/core/hooks.ts
+++ b/packages/fiber/src/core/hooks.ts
@@ -4,7 +4,7 @@ import { StateSelector, EqualityChecker } from 'zustand'
 import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader'
 import { suspend, preload, clear } from 'suspend-react'
 import { context, RootState, RenderCallback } from './store'
-import { buildGraph, ObjectMap } from './utils'
+import { buildGraph, ObjectMap, is } from './utils'
 
 export interface Loader<T> extends THREE.Loader {
   load(
@@ -80,7 +80,7 @@ export function useLoader<T, U extends string | string[]>(
 ): U extends any[] ? BranchingReturn<T, GLTF, GLTF & ObjectMap>[] : BranchingReturn<T, GLTF, GLTF & ObjectMap> {
   // Use suspense to load async assets
   const keys = (Array.isArray(input) ? input : [input]) as string[]
-  const results = suspend(loadingFn<T>(extensions, onProgress), [Proto, ...keys])
+  const results = suspend(loadingFn<T>(extensions, onProgress), [Proto, ...keys], { equal: is.equ })
   // Return the object/s
   return (Array.isArray(input) ? results : results[0]) as U extends any[]
     ? BranchingReturn<T, GLTF, GLTF & ObjectMap>[]

--- a/packages/fiber/src/core/hooks.ts
+++ b/packages/fiber/src/core/hooks.ts
@@ -89,10 +89,10 @@ export function useLoader<T, U extends string | string[]>(
 
 useLoader.preload = function <T, U extends string | string[]>(Proto: new () => LoaderResult<T>, input: U) {
   const keys = (Array.isArray(input) ? input : [input]) as string[]
-  return preload(Proto, ...keys)
+  return (preload as any)(Proto, ...keys)
 }
 
 useLoader.clear = function <T, U extends string | string[]>(Proto: new () => LoaderResult<T>, input: U) {
   const keys = (Array.isArray(input) ? input : [input]) as string[]
-  return clear(Proto, ...keys)
+  return (clear as any)(Proto, ...keys)
 }

--- a/packages/fiber/src/native/hooks.ts
+++ b/packages/fiber/src/native/hooks.ts
@@ -119,14 +119,18 @@ function useLoader<T, U extends string | string[]>(
     : BranchingReturn<T, GLTF, GLTF & ObjectMap>
 }
 
-useLoader.preload = function <T, U extends string | string[]>(Proto: new () => LoaderResult<T>, input: U) {
+useLoader.preload = function <T, U extends string | string[]>(
+  Proto: new () => LoaderResult<T>,
+  input: U,
+  extensions?: Extensions,
+) {
   const keys = (Array.isArray(input) ? input : [input]) as string[]
-  return (preload as any)(Proto, ...keys)
+  return preload(loadingFn<T>(extensions), [Proto, ...keys])
 }
 
 useLoader.clear = function <T, U extends string | string[]>(Proto: new () => LoaderResult<T>, input: U) {
   const keys = (Array.isArray(input) ? input : [input]) as string[]
-  return (clear as any)(Proto, ...keys)
+  return clear([Proto, ...keys])
 }
 
 export { useStore, useThree, useFrame, useGraph, useLoader }

--- a/packages/fiber/src/native/hooks.ts
+++ b/packages/fiber/src/native/hooks.ts
@@ -4,7 +4,7 @@ import { Asset } from 'expo-asset'
 import { readAsStringAsync } from 'expo-file-system'
 import { decode } from 'base64-arraybuffer'
 import { suspend, preload, clear } from 'suspend-react'
-import { buildGraph, ObjectMap } from '../core/utils'
+import { buildGraph, ObjectMap, is } from '../core/utils'
 import { Extensions, LoaderResult, BranchingReturn, useStore, useThree, useFrame, useGraph } from '../core/hooks'
 
 /**
@@ -112,7 +112,7 @@ function useLoader<T, U extends string | string[]>(
 ): U extends any[] ? BranchingReturn<T, GLTF, GLTF & ObjectMap>[] : BranchingReturn<T, GLTF, GLTF & ObjectMap> {
   // Use suspense to load async assets
   const keys = (Array.isArray(input) ? input : [input]) as string[]
-  const results = suspend(loadingFn<T>(extensions, onProgress), [Proto, ...keys])
+  const results = suspend(loadingFn<T>(extensions, onProgress), [Proto, ...keys], { equal: is.equ })
   // Return the object/s
   return (Array.isArray(input) ? results : results[0]) as U extends any[]
     ? BranchingReturn<T, GLTF, GLTF & ObjectMap>[]

--- a/packages/fiber/src/native/hooks.ts
+++ b/packages/fiber/src/native/hooks.ts
@@ -3,7 +3,7 @@ import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader'
 import { Asset } from 'expo-asset'
 import { readAsStringAsync } from 'expo-file-system'
 import { decode } from 'base64-arraybuffer'
-import { suspend, preload, clear } from 'use-asset'
+import { suspend, preload, clear } from 'suspend-react'
 import { buildGraph, ObjectMap } from '../core/utils'
 import { Extensions, LoaderResult, BranchingReturn, useStore, useThree, useFrame, useGraph } from '../core/hooks'
 

--- a/packages/fiber/src/native/hooks.ts
+++ b/packages/fiber/src/native/hooks.ts
@@ -121,12 +121,12 @@ function useLoader<T, U extends string | string[]>(
 
 useLoader.preload = function <T, U extends string | string[]>(Proto: new () => LoaderResult<T>, input: U) {
   const keys = (Array.isArray(input) ? input : [input]) as string[]
-  return preload(Proto, ...keys)
+  return (preload as any)(Proto, ...keys)
 }
 
 useLoader.clear = function <T, U extends string | string[]>(Proto: new () => LoaderResult<T>, input: U) {
   const keys = (Array.isArray(input) ? input : [input]) as string[]
-  return clear(Proto, ...keys)
+  return (clear as any)(Proto, ...keys)
 }
 
 export { useStore, useThree, useFrame, useGraph, useLoader }

--- a/packages/fiber/src/native/hooks.ts
+++ b/packages/fiber/src/native/hooks.ts
@@ -3,7 +3,7 @@ import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader'
 import { Asset } from 'expo-asset'
 import { readAsStringAsync } from 'expo-file-system'
 import { decode } from 'base64-arraybuffer'
-import { useAsset } from 'use-asset'
+import { suspend, preload, clear } from 'use-asset'
 import { buildGraph, ObjectMap } from '../core/utils'
 import { Extensions, LoaderResult, BranchingReturn, useStore, useThree, useFrame, useGraph } from '../core/hooks'
 
@@ -112,25 +112,21 @@ function useLoader<T, U extends string | string[]>(
 ): U extends any[] ? BranchingReturn<T, GLTF, GLTF & ObjectMap>[] : BranchingReturn<T, GLTF, GLTF & ObjectMap> {
   // Use suspense to load async assets
   const keys = (Array.isArray(input) ? input : [input]) as string[]
-  const results = useAsset(loadingFn<T>(extensions, onProgress), Proto, ...keys)
+  const results = suspend(loadingFn<T>(extensions, onProgress), [Proto, ...keys])
   // Return the object/s
   return (Array.isArray(input) ? results : results[0]) as U extends any[]
     ? BranchingReturn<T, GLTF, GLTF & ObjectMap>[]
     : BranchingReturn<T, GLTF, GLTF & ObjectMap>
 }
 
-useLoader.preload = function <T, U extends string | string[]>(
-  Proto: new () => LoaderResult<T>,
-  input: U,
-  extensions?: Extensions,
-) {
+useLoader.preload = function <T, U extends string | string[]>(Proto: new () => LoaderResult<T>, input: U) {
   const keys = (Array.isArray(input) ? input : [input]) as string[]
-  return useAsset.preload(loadingFn<T>(extensions), Proto, ...keys)
+  return preload(Proto, ...keys)
 }
 
 useLoader.clear = function <T, U extends string | string[]>(Proto: new () => LoaderResult<T>, input: U) {
   const keys = (Array.isArray(input) ? input : [input]) as string[]
-  return useAsset.clear(Proto, ...keys)
+  return clear(Proto, ...keys)
 }
 
 export { useStore, useThree, useFrame, useGraph, useLoader }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6181,6 +6181,11 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
+suspend-react@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/suspend-react/-/suspend-react-0.0.8.tgz#b0740c1386b4eb652f17affe4339915ee268bd31"
+  integrity sha512-ZC3r8Hu1y0dIThzsGw0RLZplnX9yXwfItcvaIzJc2VQVi8TGyGDlu92syMB5ulybfvGLHAI5Ghzlk23UBPF8xg==
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -6488,13 +6493,6 @@ url-parse@^1.4.4:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
-
-use-asset@2.0.0-alpha-00:
-  version "2.0.0-alpha-00"
-  resolved "https://registry.yarnpkg.com/use-asset/-/use-asset-2.0.0-alpha-00.tgz#8a9be97a035fb48dacc38fd2bd21c3b0e867c0c1"
-  integrity sha512-PdXDkyDacwvgsBzL2MLqK1UXNnLBULtIAUB5Hv8HpoIdtv/5nIvLEeZiy6dfrui0GbPNL/RjEo3Ciav0gE7tvg==
-  dependencies:
-    fast-deep-equal "^3.1.3"
 
 utility-types@^3.10.0:
   version "3.10.0"


### PR DESCRIPTION
With the release of [`suspend-react`](https://github.com/pmndrs/suspend-react), [`use-asset`](https://github.com/pmndrs/use-asset) is effectively deprecated. This PR does some minor refactoring when switching to it.

@drcmda, any planned changes I should know about? Should we publish & use an alpha with react-experimental's Cache?