### PR TITLE
Fix missing type for Float32BufferAttribute

### DIFF
--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -241,6 +241,7 @@ export type Matrix3Props = Node<THREE.Matrix3, typeof THREE.Matrix3>
 export type Matrix4Props = Node<THREE.Matrix4, typeof THREE.Matrix4>
 export type QuaternionProps = Node<THREE.Quaternion, typeof THREE.Quaternion>
 export type BufferAttributeProps = Node<THREE.BufferAttribute, typeof THREE.BufferAttribute>
+export type Float32BufferAttributeProps = Node<THREE.Float32BufferAttribute, typeof THREE.Float32BufferAttribute>
 export type InstancedBufferAttributeProps = Node<THREE.InstancedBufferAttribute, typeof THREE.InstancedBufferAttribute>
 export type ColorProps = Node<THREE.Color, ColorArray>
 export type FogProps = Node<THREE.Fog, typeof THREE.Fog>
@@ -396,6 +397,7 @@ declare global {
       matrix4: Matrix4Props
       quaternion: QuaternionProps
       bufferAttribute: BufferAttributeProps
+      float32BufferAttribute: Float32BufferAttributeProps                   
       instancedBufferAttribute: InstancedBufferAttributeProps
       color: ColorProps
       fog: FogProps


### PR DESCRIPTION
Missing Float32BufferAttriute type causes Typescript error:

 "Property 'float32BufferAttribute' does not exist on type 'JSX.IntrinsicElements'.ts(2339)"

similar issue as described in https://github.com/pmndrs/react-three-fiber/issues/238

Example of use of float32BufferAttribute
```jsx
<instancedBufferGeometry attach="geometry" instanceCount={count}>
        <float32BufferAttribute
          attachObject={['attributes', 'position']}
          args={[positionArray, 3]}
        />
        <instancedBufferAttribute
          attachObject={['attributes', 'offset']}
          args={[offsetArray, 3]}
        />
</instancedBufferGeometry>
```

