### PR TITLE
Chore: Add more visible deprecation notice

### DIFF
--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three'
 import type { UseStore } from 'zustand'
 import type { Instance } from './renderer'
-import type { InternalState, RootState } from './store'
+import type { RootState } from './store'
 
 export interface Intersection extends THREE.Intersection {
   eventObject: THREE.Object3D
@@ -14,7 +14,10 @@ export interface IntesectionEvent<TSourceEvent> extends Intersection {
   ray: THREE.Ray
   camera: Camera
   stopPropagation: () => void
-  sourceEvent: TSourceEvent // deprecated
+  /**
+   * @deprecated in favour of nativeEvent. Please use that instead.
+   */
+  sourceEvent: TSourceEvent
   nativeEvent: TSourceEvent
   delta: number
   spaceX: number

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -52,7 +52,7 @@ export type InternalState = {
   priority: number
   frames: number
   lastProps: StoreProps
-  lastEvent: React.MutableRefObject<DomEvent>
+  lastEvent: React.MutableRefObject<DomEvent | null>
 
   interaction: THREE.Object3D[]
   hovered: Map<string, DomEvent>
@@ -284,7 +284,7 @@ const createStore = (
         priority: 0,
         frames: 0,
         lastProps: props,
-        lastEvent: React.createRef(null),
+        lastEvent: React.createRef(),
 
         interaction: [],
         hovered: new Map<string, DomEvent>(),


### PR DESCRIPTION
I was trying to solve #1863 and came across certain polishing that could be done quickly hence this PR which has the following changes:

1. Removes unused import of `InternalState` in events.ts 
2. Adds a better deprecation notice so it's more visible to people using the `sourceEvent` which is deprecated. 
3. Fix ts errors in store.ts for `lastEvent`


