### PR TITLE
fix(core): attach handlers on mount to prevent duplication from Suspense

### DIFF
--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -243,6 +243,14 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>) {
       invalidateInstance(instance)
     })
 
+    if (localState.parent && rootState.internal && instance.raycast && prevHandlers !== localState.eventCount) {
+      // Pre-emptively remove the instance from the interaction manager
+      const index = rootState.internal.interaction.indexOf(instance as unknown as THREE.Object3D)
+      if (index > -1) rootState.internal.interaction.splice(index, 1)
+      // Add the instance to the interaction manager only when it has handlers
+      if (localState.eventCount) rootState.internal.interaction.push(instance as unknown as THREE.Object3D)
+    }
+
     // Call the update lifecycle when it is being updated
     if (changes.length && instance.__r3f?.parent) updateInstance(instance)
     return instance

--- a/packages/fiber/tests/web/web.core.test.tsx
+++ b/packages/fiber/tests/web/web.core.test.tsx
@@ -355,6 +355,48 @@ describe('web core', () => {
     expect(log).toEqual(['render Foo', 'render Foo', 'mount Foo', 'unmount Foo'])
   })
 
+  it('will mount/unmount event handlers correctly', async () => {
+    let state: RootState = null!
+    let mounted = false
+    let attachEvents = false
+
+    const EventfulComponent = () => (mounted ? <group onClick={attachEvents ? () => void 0 : undefined} /> : null)
+
+    // Test initial mount without events
+    mounted = true
+    await act(async () => {
+      state = render(<EventfulComponent />, canvas).getState()
+    })
+    expect(state.internal.interaction.length).toBe(0)
+
+    // Test initial mount with events
+    attachEvents = true
+    await act(async () => {
+      state = render(<EventfulComponent />, canvas).getState()
+    })
+    expect(state.internal.interaction.length).not.toBe(0)
+
+    // Test events update
+    attachEvents = false
+    await act(async () => {
+      state = render(<EventfulComponent />, canvas).getState()
+    })
+    expect(state.internal.interaction.length).toBe(0)
+
+    attachEvents = true
+    await act(async () => {
+      state = render(<EventfulComponent />, canvas).getState()
+    })
+    expect(state.internal.interaction.length).not.toBe(0)
+
+    // Test unmount with events
+    mounted = false
+    await act(async () => {
+      state = render(<EventfulComponent />, canvas).getState()
+    })
+    expect(state.internal.interaction.length).toBe(0)
+  })
+
   it('will make an Orthographic Camera & set the position', async () => {
     let camera: Camera = null!
 


### PR DESCRIPTION
As described in #1802, objects' event listeners can linger within the internal state despite never being mounted.

In [this example](https://codesandbox.io/s/r3f-duplicate-intersections-bug-8eq96?file=/src/App.js), `suspend` throws a promise that will revert the render, and the created instances are never mounted. However, event listeners are still attached as a side-effect, leading to duplication when React re-renders the suspended scene graph.

I undid some [reconciler changes](https://github.com/pmndrs/react-three-fiber/compare/5c4454...538c7c#diff-6dac2c0a764f293350e278dc10e97336f1d4b81379d1492eabf50462fe4d5752) from v7.0.8, moving initial attaching of handlers from `applyProps` (called by `createInstance`) back to `commitMount` -- reverting the regression. Events will only be updated in `applyProps` if the instance is mounted.