### PR TITLE
chore(core): throw an error if an objects' args is not an array

### DIFF
--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -298,7 +298,7 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>) {
         throw `${name} is not part of the THREE namespace! Did you forget to extend? See: https://github.com/pmndrs/react-three-fiber/blob/master/markdown/api.md#using-3rd-party-objects-declaratively`
 
       // Throw if an object or literal was passed for args
-      if (args && !Array.isArray(args)) throw 'args must be an array!'
+      if (!Array.isArray(args)) throw 'The args prop must be an array!'
 
       // Instanciate new object, link it to the root
       // Append memoized props with args so it's not forgotten
@@ -542,7 +542,7 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>) {
         const { args: argsOld = [], children: cO, ...restOld } = oldProps
 
         // Throw if an object or literal was passed for args
-        if (argsNew && !Array.isArray(argsNew)) throw 'args must be an array!'
+        if (!Array.isArray(argsNew)) throw 'The args prop must be an array!'
 
         // If it has new props or arguments, then it needs to be re-instanciated
         if (argsNew.some((value: any, index: number) => value !== argsOld[index])) return [true]

--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -297,6 +297,9 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>) {
       if (!target)
         throw `${name} is not part of the THREE namespace! Did you forget to extend? See: https://github.com/pmndrs/react-three-fiber/blob/master/markdown/api.md#using-3rd-party-objects-declaratively`
 
+      // Throw if an object or literal was passed for args
+      if (args && !Array.isArray(args)) throw 'args must be an array!'
+
       // Instanciate new object, link it to the root
       // Append memoized props with args so it's not forgotten
       instance = prepare(new target(...args), { root, memoizedProps: { args: args.length === 0 ? null : args } })
@@ -537,6 +540,10 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>) {
         // This is a data object, let's extract critical information about it
         const { args: argsNew = [], children: cN, ...restNew } = newProps
         const { args: argsOld = [], children: cO, ...restOld } = oldProps
+
+        // Throw if an object or literal was passed for args
+        if (argsNew && !Array.isArray(argsNew)) throw 'args must be an array!'
+
         // If it has new props or arguments, then it needs to be re-instanciated
         if (argsNew.some((value: any, index: number) => value !== argsOld[index])) return [true]
         // Create a diff-set, flag if there are any changes


### PR DESCRIPTION
Fixes #1569 by throwing an error if args are specified as anything other than an array. I believe that is the established pattern, unless we want to support something else.

Their example works with this syntax ([sandbox](https://codesandbox.io/s/react-three-mesh-ui-forked-hvcfg?file=/src/index.js)). See the below CSB builds for the error.