### PR TITLE
fix(core): rebind handlers for swapped instances

### DIFF
--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -491,6 +491,12 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>) {
     removeChild(parent, instance)
     appendChild(parent, newInstance)
 
+    // Re-bind event handlers
+    if (newInstance.raycast && newInstance.__r3f.eventCount) {
+      const rootState = newInstance.__r3f.root.getState()
+      rootState.internal.interaction.push(newInstance as unknown as THREE.Object3D)
+    }
+
     // This evil hack switches the react-internal fiber node
     // https://github.com/facebook/react/issues/14983
     // https://github.com/facebook/react/pull/15021


### PR DESCRIPTION
Fixes #1937 by binding inherited event handlers when swapping instances (when reconstructing due to args change, etc.).

[Issue recreation](https://codesandbox.io/s/loving-tharp-kfksi) | [Fixed w/PR](https://codesandbox.io/s/condescending-spence-cdn3b?file=/src/App.js)