### PR TITLE
Fix/RTTR: find manually managed three components

### DIFF
--- a/packages/test-renderer/src/__tests__/RTTR.methods.test.tsx
+++ b/packages/test-renderer/src/__tests__/RTTR.methods.test.tsx
@@ -134,4 +134,11 @@ describe('ReactThreeTestRenderer instance methods', () => {
     const instance = scene.findByProps({ name: MANUALLY_MOUNTED_COMPONENT_NAME }).instance
     expect(instance).toBeDefined()
   })
+
+  it('should find the parent of a three component that is mounted not via r3f', async () => {
+    const { scene } = await ReactThreeTestRenderer.create(<WithManuallyManagedComponent />)
+    const testInstance = scene.findByProps({ name: MANUALLY_MOUNTED_COMPONENT_NAME })
+    expect(() => testInstance.parent).not.toThrow()
+    expect(() => testInstance.parent).not.toThrow("Cannot read properties of undefined (reading 'parent')")
+  })
 })

--- a/packages/test-renderer/src/createTestInstance.ts
+++ b/packages/test-renderer/src/createTestInstance.ts
@@ -12,7 +12,7 @@ export class ReactThreeTestInstance<TInstance extends Object3D = Object3D> {
   }
 
   public get instance(): Object3D {
-    return (this._fiber as unknown) as TInstance
+    return this._fiber as unknown as TInstance
   }
 
   public get type(): string {
@@ -20,7 +20,7 @@ export class ReactThreeTestInstance<TInstance extends Object3D = Object3D> {
   }
 
   public get props(): Obj {
-    return this._fiber.__r3f.memoizedProps
+    return this._fiber.__r3f?.memoizedProps ?? this._fiber
   }
 
   public get parent(): ReactThreeTestInstance | null {
@@ -50,7 +50,7 @@ export class ReactThreeTestInstance<TInstance extends Object3D = Object3D> {
        */
       return [
         ...(fiber.children || []).map((fib) => wrapFiber(fib as MockInstance)),
-        ...fiber.__r3f.objects.map((fib) => wrapFiber(fib as MockInstance)),
+        ...(fiber.__r3f?.objects ?? []).map((fib) => wrapFiber(fib as MockInstance)),
       ]
     } else {
       return (fiber.children || []).map((fib) => wrapFiber(fib as MockInstance))

--- a/packages/test-renderer/src/createTestInstance.ts
+++ b/packages/test-renderer/src/createTestInstance.ts
@@ -24,7 +24,7 @@ export class ReactThreeTestInstance<TInstance extends Object3D = Object3D> {
   }
 
   public get parent(): ReactThreeTestInstance | null {
-    const parent = this._fiber.__r3f.parent
+    const parent = this._fiber.__r3f?.parent ?? this._fiber.parent
     if (parent !== null) {
       return wrapFiber(parent)
     }


### PR DESCRIPTION
We came across a missing feature/bug(?) in test renderer where it would throw when using r3f together with manually instantiated and managed three components:
![image](https://user-images.githubusercontent.com/12626798/148650700-977e2b61-c2fd-4795-a7fb-c3c1de7a5774.png)

#### Feedback required:
* was this feature missing intentionally?
* did I overlook any cases that should be tested too?