### PR TITLE
chore: deprecate props removed in v8

### DIFF
--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -73,6 +73,9 @@ export type RootState = {
   mouse: THREE.Vector2
   clock: THREE.Clock
 
+  /**
+   * @deprecated Removed in R3F v8. With R3F v8, WebXR features will automatically enable as you enter a session.
+   */
   vr: boolean
   linear: boolean
   flat: boolean
@@ -103,6 +106,9 @@ export type ComputeOffsetsFunction = (event: any, state: RootState) => { offsetX
 export type StoreProps = {
   gl: THREE.WebGLRenderer
   size: Size
+  /**
+   * @deprecated Removed in R3F v8. With R3F v8, WebXR features will automatically enable as you enter a session.
+   */
   vr?: boolean
   shadows?: boolean | Partial<THREE.WebGLShadowMap>
   linear?: boolean

--- a/packages/fiber/src/web/index.tsx
+++ b/packages/fiber/src/web/index.tsx
@@ -28,6 +28,9 @@ export type RenderProps<TCanvas extends Element> = Omit<StoreProps, 'gl' | 'even
   gl?: GLProps
   events?: (store: UseStore<RootState>) => EventManager<TCanvas>
   size?: Size
+  /**
+   * @deprecated Removed in R3F v8. React 18 will render in blocking mode by default and switch to concurrent via `startTransition`.
+   */
   mode?: typeof modes[number]
   onCreated?: (state: RootState) => void
 }


### PR DESCRIPTION
Continues #1976 by deprecating the `vr` and `modes` props as their respective features will work automatically with R3F v8 and React 18.