### PR TITLE
fix(native): move expo-gl to peer dep, add complete expo modules instructions for RN and expo-cli

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -112,21 +112,34 @@ ReactDOM.render(
 
 ## React Native
 
-This example relies on react 18 and uses `expo-cli`, but you can create a bare project with their template or with the `react-native` CLI. For the latter, see [expo modules installation](https://docs.expo.dev/bare/installing-expo-modules).
+R3F v8 adds support for react-native and can be imported from `@react-three/fiber/native`. We use `expo-gl` and `expo-asset` under the hood for WebGL2 bindings and ensuring interplay between Metro and threejs loaders.
+
+To get started, create an app via `expo-cli` or `react-native`:
 
 ```bash
-# Install expo-cli, this will create our app
-npm install expo-cli -g
-
-# Create app and cd into it
-expo init my-app
+# Create a managed/bare app and cd into it
+npx expo-cli init my-app
 cd my-app
 
-# Install dependencies
-npm install three @react-three/fiber react
+# or
 
-# Start
-expo start
+# Create bare app and cd into it
+npx react-native init my-app
+cd my-app
+```
+
+Then install dependencies (for manual installation or migration, see [expo modules installation](https://docs.expo.dev/bare/installing-expo-modules)):
+
+```bash
+# Automatically install expo modules core
+npx install-expo-modules
+
+# Install expo dependencies (expo-asset is a core lib, so we skip it)
+expo install expo-gl
+expo install expo-gl-cpp
+
+# Install NPM dependencies
+npm install three @react-three/fiber
 ```
 
 Some configuration may be required to tell the Metro bundler about your assets if you use `useLoader` or Drei abstractions like `useGLTF` and `useTexture`:
@@ -136,12 +149,14 @@ Some configuration may be required to tell the Metro bundler about your assets i
 module.exports = {
   resolver: {
     sourceExts: ['js', 'jsx', 'json', 'ts', 'tsx', 'cjs'],
-    assetExts: ['glb', 'png', 'jpg'],
+    assetExts: ['glb', 'gltf', 'png', 'jpg'],
   },
 }
 ```
 
-Just import from native targets and that's it!
+R3F's API is completely x-platform, so you can use [events](https://docs.pmnd.rs/react-three-fiber/api/events) and [hooks](https://docs.pmnd.rs/react-three-fiber/api/hooks) just as you would on the web.
+
+Just make sure to import from `@react-three/fiber/native` or `@react-three/drei/native` to use their native targets.
 
 ```jsx
 import React, { Suspense } from 'react'

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -131,12 +131,9 @@ cd my-app
 Then install dependencies (for manual installation or migration, see [expo modules installation](https://docs.expo.dev/bare/installing-expo-modules)):
 
 ```bash
-# Automatically install expo modules core
+# Automatically install & link expo modules
 npx install-expo-modules
-
-# Install expo dependencies (expo-asset is a core lib, so we skip it)
 expo install expo-gl
-expo install expo-gl-cpp
 
 # Install NPM dependencies
 npm install three @react-three/fiber
@@ -159,25 +156,36 @@ R3F's API is completely x-platform, so you can use [events](https://docs.pmnd.rs
 Just make sure to import from `@react-three/fiber/native` or `@react-three/drei/native` to use their native targets.
 
 ```jsx
-import React, { Suspense } from 'react'
-import { useGLTF } from '@react-three/drei/native'
-import { Canvas } from '@react-three/fiber/native'
-import modelPath from './assets/model.glb'
+import React, { useRef, useState } from 'react'
+import { Canvas, useFrame } from '@react-three/fiber/native'
 
-function Model(props) {
-  const { scene } = useGLTF(modelPath)
-  return <primitive {...props} object={scene} />
-}
-
-function App() {
+function Box(props) {
+  const mesh = useRef(null)
+  const [hovered, setHover] = useState(false)
+  const [active, setActive] = useState(false)
+  useFrame((state, delta) => (mesh.current.rotation.x += 0.01))
   return (
-    <Canvas>
-      <Suspense fallback={null}>
-        <Model />
-      </Suspense>
-    </Canvas>
+    <mesh
+      {...props}
+      ref={mesh}
+      scale={active ? 1.5 : 1}
+      onClick={(event) => setActive(!active)}
+      onPointerOver={(event) => setHover(true)}
+      onPointerOut={(event) => setHover(false)}>
+      <boxGeometry args={[1, 1, 1]} />
+      <meshStandardMaterial color={hovered ? 'hotpink' : 'orange'} />
+    </mesh>
   )
 }
 
-export default App
+export default function App() {
+  return (
+    <Canvas>
+      <ambientLight />
+      <pointLight position={[10, 10, 10]} />
+      <Box position={[-1.2, 0, 0]} />
+      <Box position={[1.2, 0, 0]} />
+    </Canvas>
+  )
+}
 ```

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -129,36 +129,9 @@ Live demo: https://codesandbox.io/s/icy-tree-brnsm?file=/src/App.tsx
 <details>
   <summary>Show React Native example</summary>
 
-This example relies on react 18 and uses `expo-cli`, but you can create a bare project with their template or with the `react-native` CLI.
+For installation instructions see [react native installation instructions](https://docs.pmnd.rs/react-three-fiber/getting-started/installation#react-native).
 
-```bash
-# Install expo-cli, this will create our app
-npm install expo-cli -g
-
-# Create app and cd into it
-expo init my-app
-cd my-app
-
-# Install dependencies
-npm install three @react-three/fiber react
-
-# Start
-expo start
-```
-
-Some configuration may be required to tell the Metro bundler about your assets if you use `useLoader` or Drei abstractions like `useGLTF` and `useTexture`:
-
-```js
-// metro.config.js
-module.exports = {
-  resolver: {
-    sourceExts: ['js', 'jsx', 'json', 'ts', 'tsx', 'cjs'],
-    assetExts: ['glb', 'png', 'jpg'],
-  },
-}
-```
-
-```tsx
+```jsx
 import React, { useRef, useState } from 'react'
 import { Canvas, useFrame } from '@react-three/fiber/native'
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-react": "^7.27.1",
     "eslint-plugin-react-hooks": "^4.3.0",
     "expo-asset": "^8.4.6",
-    "expo-gl": "^11.0.3",
+    "expo-gl": "^11.1.1",
     "husky": "^7.0.4",
     "jest": "^27.4.4",
     "jest-cli": "^27.4.4",

--- a/packages/fiber/package.json
+++ b/packages/fiber/package.json
@@ -43,7 +43,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.15.4",
-    "expo-gl": "^11.0.3",
     "react-merge-refs": "^1.1.0",
     "react-reconciler": "^0.27.0-rc.0",
     "react-use-measure": "^2.1.1",
@@ -59,6 +58,7 @@
     "react-native": ">=0.64",
     "expo": ">=43.0",
     "expo-asset": ">=8.4",
+    "expo-gl": ">=11.0",
     "three": ">=0.133"
   },
   "peerDependenciesMeta": {
@@ -72,6 +72,9 @@
       "optional": true
     },
     "expo-asset": {
+      "optional": true
+    },
+    "expo-gl": {
       "optional": true
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3536,11 +3536,6 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
-compare-versions@^3.4.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
-  integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
-
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -4403,26 +4398,17 @@ expo-asset@^8.4.6:
     path-browserify "^1.0.0"
     url-parse "^1.4.4"
 
-expo-gl-cpp@~11.0.1:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/expo-gl-cpp/-/expo-gl-cpp-11.0.1.tgz#1d90283bb6d013847622d293c5c8071d02158a4d"
-  integrity sha512-+h0OVlJVtZRPHCU8ZF/owplMo1Kn8ixKnwTHOD9cAZht1dM/q7xLJBncxy1ItbGvC3LqfT7Dm+Vet7LnI3mo+g==
+expo-gl-cpp@~11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/expo-gl-cpp/-/expo-gl-cpp-11.1.0.tgz#84c8f688b7009ca8944523866fd8e16bc195889d"
+  integrity sha512-tIbMex36+pn81cuPatWfLMkOcqUTiBOEQg3NJrp1XGio7xqDQga1OKk1vaYsxrGPhZHNx3Qv5iS83t4EGJ1RTw==
 
-expo-gl@^11.0.3:
-  version "11.0.3"
-  resolved "https://registry.yarnpkg.com/expo-gl/-/expo-gl-11.0.3.tgz#5e0e02f1033a53d47001a2273a380a3c5149cac6"
-  integrity sha512-dIVQh4T4IY++jFs+wepx4xA9F3e7pwwWPpuRHh/BaMGPEHb1bITD8sgJENP6iFTD1IlV6308+q4PQcdq7w+4Jg==
+expo-gl@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/expo-gl/-/expo-gl-11.1.1.tgz#2d611f3cff7422e591274d8b91334b2973a7132b"
+  integrity sha512-1bpPGmLnn6H4vs9X019zxMAlOdSqIyyWAT/yJC7f/qGzs9lTPM6STN3N+7fVMtPkXaCMyvyJL8vFJQ75+YmGpQ==
   dependencies:
-    expo-gl-cpp "~11.0.1"
-    expo-modules-core "~0.4.4"
-    invariant "^2.2.4"
-
-expo-modules-core@~0.4.4:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-0.4.7.tgz#1ea4de95bb4ac1ee125efe50b6f25055c36d86c6"
-  integrity sha512-boEbB3tAYO7WkgcaXToQLY8IUeEGOZeDF+StTL38FA0l8jzJwwQLU7TaWjWEMGfxvvn7KP7V7kFudJKc7dak3g==
-  dependencies:
-    compare-versions "^3.4.0"
+    expo-gl-cpp "~11.1.0"
     invariant "^2.2.4"
 
 extend-shallow@^2.0.1:


### PR DESCRIPTION
Fixes #2013 and #1858.

Expo libraries should not be included as NPM dependencies but be installed after `expo` modules and before R3F (so NPM doesn't auto-install peer deps). I've updated the docs to reflect and include a workflow for expo-cli and react-native CLI.