### PR TITLE
🐛 Fix type imports in Test Renderer

### DIFF
--- a/packages/fiber/src/index.tsx
+++ b/packages/fiber/src/index.tsx
@@ -2,6 +2,7 @@
 export * from './three-types'
 import * as ReactThreeFiber from './three-types'
 export { ReactThreeFiber }
+export type { BaseInstance, LocalState } from './core/renderer'
 export type {
   Intersection,
   Subscription,

--- a/packages/test-renderer/src/types/internal.ts
+++ b/packages/test-renderer/src/types/internal.ts
@@ -1,8 +1,7 @@
 import * as THREE from 'three'
 import { UseStore } from 'zustand'
 
-import type { BaseInstance, LocalState } from '@react-three/fiber/src/core/renderer'
-import type { RootState } from '@react-three/fiber/src/core/store'
+import type { BaseInstance, LocalState, RootState } from '@react-three/fiber'
 
 export type MockUseStoreState = UseStore<RootState>
 


### PR DESCRIPTION
Fix type imports (`BaseInstance`, `LocalState` and `RootState`) from **@react-three/fiber** in **@react-three/test-renderer**.

See: https://github.com/pmndrs/react-three-fiber/discussions/2061
