### PR TITLE
fix store subscription argument order

### DIFF
--- a/docs/advanced/pitfalls.mdx
+++ b/docs/advanced/pitfalls.mdx
@@ -121,8 +121,8 @@ const ref = useRef()
 useEffect(
   () =>
     api.subscribe(
-      (x) => (ref.current.position.x = x),
       (state) => state.x,
+      (x) => (ref.current.position.x = x),
     ),
   [],
 )


### PR DESCRIPTION
State slicing happens in the first argument, not the second.