### PR TITLE
fix: add Object3D to IntrinsicElements

### DIFF
--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -54,6 +54,7 @@ export type BufferGeometryNode<T extends THREE.BufferGeometry, P> = Node<T, P>
 export type MaterialNode<T extends THREE.Material, P> = Node<T, P>
 export type LightNode<T extends THREE.Light, P> = Object3DNode<T, P>
 
+export type Object3DProps = Object3DNode<THREE.Object3D, typeof THREE.Object3D>
 // export type AudioProps = Object3DNode<THREE.Audio, typeof THREE.Audio>
 export type AudioListenerProps = Object3DNode<THREE.AudioListener, typeof THREE.AudioListener>
 export type PositionalAudioProps = Object3DNode<THREE.PositionalAudio, typeof THREE.PositionalAudio>
@@ -236,6 +237,8 @@ export type ShapeProps = Node<THREE.Shape, typeof THREE.Shape>
 declare global {
   namespace JSX {
     interface IntrinsicElements {
+      object3D: Object3DProps
+
       // `audio` works but conflicts with @types/react. Try using Audio from react-three-fiber/components instead
       // audio: AudioProps
       audioListener: AudioListenerProps


### PR DESCRIPTION
TS isn't happy about using `Object3D` as intrinsic element (`Property 'object3D' does not exist on type 'JSX.IntrinsicElements'`), seems to work otherwise 

```tsx
<object3D />
```



