### PR TITLE
Move @types/react-reconciler to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@types/lodash-es": "^4.17.4",
     "@types/react": "^17.0.14",
     "@types/react-dom": "^17.0.9",
-    "@types/react-reconciler": "^0.26.2",
     "@types/react-test-renderer": "^17.0.1",
     "@types/scheduler": "^0.16.2",
     "@types/three": "^0.133.0",

--- a/packages/fiber/package.json
+++ b/packages/fiber/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",
+    "@types/react-reconciler": "^0.26.2",
     "react-merge-refs": "^1.1.0",
     "react-reconciler": "^0.26.2",
     "react-three-fiber": "0.0.0-deprecated",


### PR DESCRIPTION
The built declaration files depend on `@types/react-reconciler`. Here are the build errors without it:

```
.yarn/__virtual__/@react-three-fiber-virtual-af98807581/0/cache/@react-three-fiber-npm-7.0.26-699ff8d26f-72548c6d2a.zip/node_modules/@react-three/fiber/dist/declarations/src/core/renderer.d.ts:2:24 - error TS7016: Could not find a declaration file for module 'react-reconciler'. 'C:/Users/nbier/Documents/stash/test-react-three-fiber/.yarn/__virtual__/react-reconciler-virtual-c1be2dd0c5/0/cache/react-reconciler-npm-0.26.2-284c00acc7-2ebceace56.zip/node_modules/react-reconciler/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/react-reconciler` if it exists or add a new declaration (.d.ts) file containing `declare module 'react-reconciler';`

2 import Reconciler from 'react-reconciler';
                         ~~~~~~~~~~~~~~~~~~

.yarn/__virtual__/@react-three-fiber-virtual-af98807581/0/cache/@react-three-fiber-npm-7.0.26-699ff8d26f-72548c6d2a.zip/node_modules/@react-three/fiber/dist/declarations/src/web/index.d.ts:1:23 - error TS2688: Cannot find type definition file for 'react-reconciler'.

1 /// <reference types="react-reconciler" />
                        ~~~~~~~~~~~~~~~~

.yarn/__virtual__/@react-three-fiber-virtual-af98807581/0/cache/@react-three-fiber-npm-7.0.26-699ff8d26f-72548c6d2a.zip/node_modules/@react-three/fiber/dist/declarations/src/web/index.d.ts:14:34 - error TS7016: Could not find a declaration file for module 'react-reconciler'. 'C:/Users/nbier/Documents/stash/test-react-three-fiber/.yarn/__virtual__/react-reconciler-virtual-c1be2dd0c5/0/cache/react-reconciler-npm-0.26.2-284c00acc7-2ebceace56.zip/node_modules/react-reconciler/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/react-reconciler` if it exists or add a new declaration (.d.ts) file containing `declare module 'react-reconciler';`

14 declare const reconciler: import("react-reconciler").Reconciler<unknown, unknown, unknown, unknown, unknown>, applyProps: (instance: import("../core/renderer").Instance, data: import("../core/renderer").InstanceProps | import("../core/renderer").DiffSet) => import("../core/renderer").Instance;
                                    ~~~~~~~~~~~~~~~~~~

.yarn/__virtual__/@react-three-fiber-virtual-af98807581/0/cache/@react-three-fiber-npm-7.0.26-699ff8d26f-72548c6d2a.zip/node_modules/@react-three/fiber/dist/declarations/src/web/index.d.ts:33:44 - error TS7016: Could not find a declaration file for module 'react-reconciler'. 'C:/Users/nbier/Documents/stash/test-react-three-fiber/.yarn/__virtual__/react-reconciler-virtual-c1be2dd0c5/0/cache/react-reconciler-npm-0.26.2-284c00acc7-2ebceace56.zip/node_modules/react-reconciler/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/react-reconciler` if it exists or add a new declaration (.d.ts) file containing `declare module 'react-reconciler';`

33 declare const act: (callback: () => import("react-reconciler").Thenable<unknown>) => import("react-reconciler").Thenable<void>;
                                              ~~~~~~~~~~~~~~~~~~

.yarn/__virtual__/@react-three-fiber-virtual-af98807581/0/cache/@react-three-fiber-npm-7.0.26-699ff8d26f-72548c6d2a.zip/node_modules/@react-three/fiber/dist/declarations/src/web/index.d.ts:33:93 - error TS7016: Could not find a declaration file for module 'react-reconciler'. 'C:/Users/nbier/Documents/stash/test-react-three-fiber/.yarn/__virtual__/react-reconciler-virtual-c1be2dd0c5/0/cache/react-reconciler-npm-0.26.2-284c00acc7-2ebceace56.zip/node_modules/react-reconciler/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/react-reconciler` if it exists or add a new declaration (.d.ts) file containing `declare module 'react-reconciler';`

33 declare const act: (callback: () => import("react-reconciler").Thenable<unknown>) => import("react-reconciler").Thenable<void>;
                                                                                               ~~~~~~~~~~~~~~~~~~


Found 5 errors.
```