### PR TITLE
Event layers

### DIFF
--- a/packages/fiber/src/core/hooks.ts
+++ b/packages/fiber/src/core/hooks.ts
@@ -34,6 +34,9 @@ export function useThree<T = RootState>(
   return useStore()(selector, equalityFn)
 }
 
+/**
+ * Returns [eventLayer, objectRef], and sets eventLayer to the event layer associated with the object referenced by objectRef.
+ */
 export function useEventLayer() {
   const defaultEventLayer = useThree((store) => store.defaultEventLayer)
   const [eventLayer, setEventLayer] = React.useState<EventLayer>(defaultEventLayer)

--- a/packages/fiber/src/core/hooks.ts
+++ b/packages/fiber/src/core/hooks.ts
@@ -5,6 +5,7 @@ import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader'
 import { suspend, preload, clear } from 'suspend-react'
 import { context, RootState, RenderCallback } from './store'
 import { buildGraph, ObjectMap, is } from './utils'
+import { EventLayer, getEventLayerForObject } from './events'
 
 export interface Loader<T> extends THREE.Loader {
   load(
@@ -31,6 +32,20 @@ export function useThree<T = RootState>(
   equalityFn?: EqualityChecker<T>,
 ) {
   return useStore()(selector, equalityFn)
+}
+
+export function useEventLayer() {
+  const defaultEventLayer = useThree((store) => store.defaultEventLayer)
+  const [eventLayer, setEventLayer] = React.useState<EventLayer>(defaultEventLayer)
+  const objectRef = React.useRef<THREE.Object3D>()
+
+  React.useLayoutEffect(() => {
+    if (objectRef.current) {
+      setEventLayer(getEventLayerForObject(objectRef.current) ?? defaultEventLayer)
+    }
+  }, [defaultEventLayer])
+
+  return [eventLayer, objectRef] as const
 }
 
 export function useFrame(callback: RenderCallback, renderPriority: number = 0): null {

--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -324,6 +324,7 @@ reconciler.injectIntoDevTools({
 })
 
 export * from './hooks'
+export { EventLayer } from '../core/events'
 export {
   context,
   render,

--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -194,8 +194,8 @@ function createRoot<TCanvas extends Element>(canvas: TCanvas): ReconcilerRoot<TC
       if (performance && !is.equ(performance, state.performance, shallowLoose))
         state.set((state) => ({ performance: { ...state.performance, ...performance } }))
       // Configure default event layer using the raycaster and onPointerMissed props
-      state.set((state) => ({
-        defaultEventLayer: new EventLayer(
+      state.set((state) => {
+        const defaultEventLayer = new EventLayer(
           0,
           (self, event) => {
             const { mouse, camera, size } = state
@@ -216,10 +216,16 @@ function createRoot<TCanvas extends Element>(canvas: TCanvas): ReconcilerRoot<TC
             raycaster,
             onPointerMissed,
           },
-        ),
-      }))
-      state.internal.hovered.set(state.defaultEventLayer, new Map())
-      state.internal.initialHits.set(state.defaultEventLayer, [])
+        )
+        return {
+          defaultEventLayer,
+          internal: {
+            ...state.internal,
+            hovered: new Map([[defaultEventLayer, new Map()]]),
+            initialHits: new Map([[defaultEventLayer, []]]),
+          },
+        }
+      })
 
       // Set locals
       onCreated = onCreatedCallback

--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -16,7 +16,7 @@ import {
   detach,
 } from './utils'
 import { RootState } from './store'
-import { EventHandlers, removeInteractivity } from './events'
+import { EventHandlers, EventLayer, removeInteractivity } from './events'
 
 export type Root = { fiber: Reconciler.FiberRoot; store: UseStore<RootState> }
 
@@ -28,6 +28,7 @@ export type LocalState = {
   primitive?: boolean
   eventCount: number
   handlers: Partial<EventHandlers>
+  eventLayer?: EventLayer
   attach?: AttachType
   previousAttach?: any
   memoizedProps: {

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -302,6 +302,7 @@ export function applyProps(instance: Instance, data: InstanceProps | DiffSet) {
     if (key === 'eventLayer') {
       if (value) {
         localState.eventLayer = value as EventLayer
+        // Initialize the hovered map with the received event layer
         if (!rootState.internal.hovered.get(localState.eventLayer)) {
           rootState.internal.hovered.set(localState.eventLayer, new Map())
         }

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three'
 import { UseStore } from 'zustand'
-import { EventHandlers } from './events'
+import { EventHandlers, EventLayer } from './events'
 import { AttachType, Instance, InstanceProps, LocalState } from './renderer'
 import { Dpr, RootState } from './store'
 
@@ -299,7 +299,17 @@ export function applyProps(instance: Instance, data: InstanceProps | DiffSet) {
       }
     }
 
+    if (key === 'eventLayer') {
+      if (value) {
+        localState.eventLayer = value as EventLayer
+        if (!rootState.internal.hovered.get(localState.eventLayer)) {
+          rootState.internal.hovered.set(localState.eventLayer, new Map())
+        }
+      } else delete localState.eventLayer
+    }
+
     invalidateInstance(instance)
+    // FIXME: Why return here?
     return instance
   })
 

--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three'
-import { EventHandlers } from './core/events'
+import { EventHandlers, EventLayer } from './core/events'
 import { AttachType } from './core/renderer'
 
 export type NonFunctionKeys<T> = { [K in keyof T]: T[K] extends Function ? never : K }[keyof T]
@@ -23,6 +23,7 @@ export type Quaternion = THREE.Quaternion | Parameters<THREE.Quaternion['set']>
 export type AttachCallback = string | ((child: any, parentInstance: any) => void)
 
 export interface NodeProps<T, P> {
+  eventLayer?: EventLayer
   attach?: AttachType
   /** Constructor arguments */
   args?: Args<P>


### PR DESCRIPTION
NB: The current implementation is in a working state, however for now I made the API and the design intentionally unopinionated, minimal, and as close to the old system as possible in order to allow for greater community involvement in the design. It is not meant to be final.

This PR is a draft implementation of a new, more flexible event system. In the current event system, ThreeEvents are generated in response to dom/native events in a predefined way, which are then propagated through the scene graph. It has the weakness that it bakes in a single way to generate ThreeEvents for all the objects in the react tree, and treats all objects as if they belonged to the same scene graph. Both of these assumptions lead to errors when dealing with for example portals or overlay scenes, like a viewport gizmo (see #2117).

This draft aims to fix this by allowing users to sort objects into different _event layers_, each of which can define their own way of generating events, and treat the objects belonging to them as an isolated "layer", separate from other layers. These layers are not necessarily all activated for all native events, e.g. an event layer assigned to a portal should only activate when hovering over the portal. In case multiple layers would be activated by a certain native event, layers are evaluated from highest priority to lowest, and can define whether or under what conditions lower priority layers should be activated.

The event layer logic is opt-in, builds upon the existing system, and uses the existing propagation logic. R3f creates a default event layer to which all objects are assigned for which a manual event layer couldn't be found. The point of the event layer system is not to redefine the event propagation logic, but to provide people a way to specify their own logic for generating ThreeEvents from native events.

Event layers are assigned as props to react elements, just like event handlers, and are represented by the EventLayer class:
```ts
/**
 * Class representing event layers. Event layers define how events are generated. Instances can be passed to the
 * eventLayer prop of elements to specify the event layer for it and its descendants.
 */
export class EventLayer {
  /**
   * The raycaster associated with the event layer.
   */
  raycaster: THREE.Raycaster
  /**
   * The condition for allowing events to pas through the event layer to layers with lower priority.
   *
   * 'never': events will never pass through
   * 'nohits': events will pass through when no object was intersected on the event layer
   * 'always': events will always pass through
   */
  allowPassthrough: 'never' | 'nohits' | 'always'
  /**
   * Allows disabling the event layer, in which case events won't be generated.
   */
  enabled: boolean
  /**
   * Allow custom userland intersection sort ordering.
   *
   * https://github.com/mrdoob/three.js/issues/16031
   */
  filter?: FilterFunction
  /**
   * Allows calculating custom offsets instead of the event's offsets.
   *
   * https://github.com/pmndrs/react-three-fiber/pull/782
   */
  computeOffsets?: ComputeOffsetsFunction
  /**
   * Called when no object was hit.
   */
  onPointerMissed?: (event: MouseEvent) => void

  /**
   * Updates the event layer with the newest event data.
   *
   * @param event
   */
  readonly update = (event: DomEvent) => {
    return this.onUpdate(this, event)
  }

  /**
   * Constructs a new EventLayer.
   *
   * @param priority - The priority of the event layer. Higher priority layers are processed first, which may stop events
   * from being processed by lower priority layers.
   * @param onUpdate - Callback which executes before every ray-cast. Used to determine if the layer is active, and set up the raycaster with the event data if yes.
   * @param options - Optional parameters corresponding to the rest of EventLayer's fields.
   */
  constructor(
    public priority: number,
    public onUpdate: (thisEventLayer: EventLayer, event: DomEvent) => boolean,
    options: {
      enabled?: boolean
      allowPassthrough?: 'never' | 'nohits' | 'always'
      filter?: FilterFunction
      computeOffsets?: ComputeOffsetsFunction
      onPointerMissed?: (event: MouseEvent) => void
      raycaster?: THREE.Raycaster
    } = {},
  ) {
    this.raycaster = options.raycaster ?? new THREE.Raycaster()
    this.enabled = options.enabled ?? true
    this.allowPassthrough = options.allowPassthrough ?? 'nohits'
    this.filter = options.filter
    this.computeOffsets = options.computeOffsets
    this.onPointerMissed = options.onPointerMissed
  }
}
```

`EventLayer`'s `onUpdate` callback, which is called every time events need to be generated in response to a native event, roughly corresponds to the old system's `prepareRay`, but adapted to the event layer logic. Its job is to determine whether the layer is active by returning `true` if yes, and setting up the raycaster. The rest of the fields correspond to existing raycaster-related parameters present in the old system, like `onPointerMissed`, `filter` and `computeOffsets`, which are can be used by `onUpdate`, and the event layer logic used by the new event system, which for now is limited to `allowPassthrough`, which defines under what conditions lower priority layers are allowed to be evaluated if this layer is active.

Event layers are inherited through the scene graph. When iterating through interactive objects in `store.internal.interaction`, the event system determines to which layer they belong by walking up through its ancestors until it encounters one.

The event propagation logic is unchanged, the only part that needed to be adapted was the state used by it, since objects in one layer shouldn't interfere with others. Hence the `hovered` and `initialHits` objects are for example mapped to the event layers present in the scene. When a native event fires, the event logic aggregates all the event layers defined for the current set of interactive objects and iterates through them based on their priority. Each iteration happens according to the same propagation logic as the current system. The only way layers interact with each other is through the pass-through logic defined by `allowPassthrough: 'never' | 'nohits' | 'always'`.

### Added API
`EventLayer`: lets users create event layers
`useEventLayer`: lets users get the event layer for a given object in the scene. It is useful for making event layers composable, and for example this is what enables embedding portals within portals within portals.
`eventLayer` prop in `NodeProps`: lets users assign event layers

### Usage example
Adapted from https://codesandbox.io/s/magic-mirror-ddk57

Note how we use the "outer" event layer to raycast the point on the portal plane, which we then use to set up the portal's event layer. This lets us make composable components that can define their own event layer logic without knowledge of the outside world.

```ts
function MagicMirror({ children, ...props }: any) {
  // old magic mirror stuff from the existing demo
  const cam = useRef<Camera>()
  const fbo = useFBO()
  const [scene] = useState(() => new THREE.Scene())
  const [clearColor] = useState(() => new Color(Math.random(), Math.random(), Math.random()))
  useFrame((state) => {
    cam.current?.position.copy(state.camera.position)
    cam.current?.rotation.copy(state.camera.rotation)
    cam.current?.scale.copy(state.camera.scale)
    state.gl.setClearColor(clearColor)
    state.gl.clearColor()
    state.gl.setRenderTarget(fbo)
    state.gl.render(scene, cam.current!)
    state.gl.setRenderTarget(null)
  })

  // interesting part begins here
  // We get the event layer of the mirror plane. useEventLayer is an r3f builtin hook.
  // We pass the ref to the object we need the event layer of.
  const [currentEventLayer, eventLayerObjectRef] = useEventLayer()
  const mirrorRef = useRef<Object3D>()
  // We create a new event layer. We will pass it to the root object of the portaled scene.
  const eventLayer = useMemo(
    () =>
      new EventLayer(
        // The priority of the event layer, in case we got overlaps with other layers
        currentEventLayer.priority + 1,
        // Define an onUpdate function for the event layer that is called before every raycast.
        (self, event) => {
          if (!mirrorRef.current || !cam.current) {
            // Returning false means that the event layer is inactive
            return false
          }
          // Update the current event layer with the dom event received and use it to raycast the mirror plane.
          currentEventLayer.update(event)
          const [intersection] = currentEventLayer.raycaster.intersectObject(mirrorRef.current)
          if (!intersection) {
            // The event layer should be inactive when the mirror plane is not hovered.
            return false
          }

          // Use the intersected UV of the mirror plane and the portal camera to configure the raycaster.
          const uv = intersection.uv!
          const coords = { x: uv.x * 2 - 1, y: uv.y * 2 - 1 }
          self.raycaster.setFromCamera(coords, cam.current)

          //  Return true to indicate that the event layer is active.
          return true
        },
      ),
    [currentEventLayer],
  )

  return (
    <group>
      {/* We get the mirror plane's event layer by passing the eventLayerObjectRef to it that we got earlier. */}
      <mesh {...props} ref={mergeRefs([mirrorRef, eventLayerObjectRef])}>
        <planeGeometry args={[2.5, 5]} />
        <meshBasicMaterial map={fbo.texture} />
      </mesh>
      <PerspectiveCamera manual ref={cam} fov={50} aspect={2.5 / 5} onUpdate={(c) => c.updateProjectionMatrix()} />
      {/* Create the portal and pass the created event layer object to its root. */}
      {createPortal(<group eventLayer={eventLayer}>{children}</group>, scene)}
    </group>
  )
}
```