### PR TITLE
refactor(core): create an array when indexing with attach

### DIFF
--- a/example/src/demos/MultiMaterial.tsx
+++ b/example/src/demos/MultiMaterial.tsx
@@ -35,7 +35,7 @@ function TestMultiMaterial(props: any) {
     console.log(ref.current.material)
   }, [ok])
   return (
-    <mesh ref={ref} material={useRef([]).current} {...props}>
+    <mesh ref={ref} {...props}>
       <boxGeometry args={[0.75, 0.75, 0.75]} />
       <meshBasicMaterial attach="material-0" color="hotpink" />
       <meshBasicMaterial attach="material-1" color="lightgreen" />
@@ -58,7 +58,7 @@ function TestMultiDelete(props: any) {
     console.log(ref.current.material)
   }, [ok])
   return (
-    <mesh ref={ref} material={useRef([]).current} {...props}>
+    <mesh ref={ref} {...props}>
       <boxGeometry args={[0.75, 0.75, 0.75]} />
       <meshBasicMaterial attach="material-0" color="hotpink" side={THREE.DoubleSide} />
       <meshBasicMaterial attach="material-1" color="lightgreen" side={THREE.DoubleSide} />

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -150,8 +150,17 @@ function resolve(instance: Instance, key: string) {
   } else return { target, key }
 }
 
+const INDEX_REGEX = /-\d+?$/
+
 export function attach(parent: Instance, child: Instance, type: AttachType) {
   if (is.str(type)) {
+    // If attaching into an array (foo-0), create one
+    if (INDEX_REGEX.test(type)) {
+      const root = type.replace(INDEX_REGEX, '')
+      const { target, key } = resolve(parent, root)
+      if (!Array.isArray(target[key])) target[key] = []
+    }
+
     const { target, key } = resolve(parent, type)
     child.__r3f.previousAttach = target[key]
     target[key] = child

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -150,7 +150,8 @@ function resolve(instance: Instance, key: string) {
   } else return { target, key }
 }
 
-const INDEX_REGEX = /-\d+?$/
+// Checks if a dash-cased string ends with an integer
+const INDEX_REGEX = /-\d+$/
 
 export function attach(parent: Instance, child: Instance, type: AttachType) {
   if (is.str(type)) {


### PR DESCRIPTION
Restores v7's `attachArray` behavior with unified attach (see #1912).