### PR TITLE
fix(web): pass legacy attribute to canvas

### DIFF
--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -29,6 +29,7 @@ const CANVAS_PROPS: Array<keyof Props> = [
   'shadows',
   'linear',
   'flat',
+  'legacy',
   'orthographic',
   'frameloop',
   'performance',

--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -28,6 +28,7 @@ const CANVAS_PROPS: Array<keyof Props> = [
   'shadows',
   'linear',
   'flat',
+  'legacy',
   'orthographic',
   'frameloop',
   'dpr',


### PR DESCRIPTION
Without this change the flag will be passed to the `div` element rather than the `Canvas` element. Which means that the flag basically does nothing in production, which is why you see no effect in versions >= 8.0.2 when using this flag on web.