### PR TITLE
refactor expensive copy & loop inside Web Canvas & Native Canvas

### DIFF
--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -345,7 +345,7 @@ type CanvasProps<T extends Platform> = Omit<
   T extends 'web' ? WebCanvasProps : NativeCanvasProps,
   'children' | 'fallback' | 'resize' | 'style' | 'events'
 >
-export function extractCanvasProps<T extends Platform>(target: T, props: CanvasProps<T>) {
+export function extractCanvasProps<T extends Platform>(platform: T, props: CanvasProps<T>) {
   let {
     gl,
     shadows,
@@ -377,7 +377,7 @@ export function extractCanvasProps<T extends Platform>(target: T, props: CanvasP
     onCreated,
   }
 
-  if (target === 'web') {
+  if (platform === 'web') {
     let { dpr } = wrapperProps
     canvasProps.dpr = dpr
   }

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -1,5 +1,7 @@
 import * as THREE from 'three'
 import { UseBoundStore } from 'zustand'
+import type { Props as NativeCanvasProps } from '../native'
+import type { Props as WebCanvasProps } from '../web/Canvas'
 import { EventHandlers } from './events'
 import { AttachType, Instance, InstanceProps, LocalState } from './renderer'
 import { Dpr, RootState } from './store'
@@ -336,4 +338,52 @@ export function invalidateInstance(instance: Instance) {
 
 export function updateInstance(instance: Instance) {
   instance.onUpdate?.(instance)
+}
+
+type Platform = 'web' | 'native'
+type CanvasProps<T extends Platform> = Omit<
+  T extends 'web' ? WebCanvasProps : NativeCanvasProps,
+  'children' | 'fallback' | 'resize' | 'style' | 'events'
+>
+export function extractCanvasProps<T extends Platform>(target: T, props: CanvasProps<T>) {
+  let {
+    gl,
+    shadows,
+    linear,
+    flat,
+    legacy,
+    orthographic,
+    frameloop,
+    performance,
+    raycaster,
+    camera,
+    onPointerMissed,
+    onCreated,
+    ...wrapperProps
+  } = props
+
+  let canvasProps: CanvasProps<'web'> = {
+    gl,
+    shadows,
+    linear,
+    flat,
+    legacy,
+    orthographic,
+    frameloop,
+    performance,
+    raycaster,
+    camera,
+    onPointerMissed,
+    onCreated,
+  }
+
+  if (target === 'web') {
+    let { dpr } = wrapperProps
+    canvasProps.dpr = dpr
+  }
+
+  return {
+    canvasProps,
+    wrapperProps,
+  }
 }

--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -4,7 +4,7 @@ import mergeRefs from 'react-merge-refs'
 import { View, ViewProps, ViewStyle, LayoutChangeEvent, StyleSheet, PixelRatio } from 'react-native'
 import { ExpoWebGLRenderingContext, GLView } from 'expo-gl'
 import { UseBoundStore } from 'zustand'
-import { pick, omit } from '../core/utils'
+import { extractCanvasProps } from '../core/utils'
 import { extend, createRoot, unmountComponentAtNode, RenderProps, ReconcilerRoot, useMemoizedFn } from '../core'
 import { createTouchEvents } from './events'
 import { RootState } from '../core/store'
@@ -59,19 +59,18 @@ class ErrorBoundary extends React.Component<{ set: React.Dispatch<any> }, { erro
 }
 
 export const Canvas = /*#__PURE__*/ React.forwardRef<View, Props>(
-  ({ children, fallback, style, events, ...props }, forwardedRef) => {
+  ({ children, fallback, style, events, onPointerMissed: _onPointerMissed, ...props }, forwardedRef) => {
     // Create a known catalogue of Threejs-native elements
     // This will include the entire THREE namespace by default, users can extend
     // their own elements by using the createRoot API instead
     React.useMemo(() => extend(THREE), [])
-    const onPointerMissed = useMemoizedFn(props.onPointerMissed)
+    const onPointerMissed = useMemoizedFn(_onPointerMissed)
 
     const [{ width, height }, setSize] = React.useState({ width: 0, height: 0 })
     const [canvas, setCanvas] = React.useState<HTMLCanvasElement | null>(null)
     const [bind, setBind] = React.useState<any>()
 
-    const canvasProps = pick<Props>({ ...props, onPointerMissed }, CANVAS_PROPS)
-    const viewProps = omit<Props>({ ...props, onPointerMissed }, CANVAS_PROPS)
+    const { canvasProps, wrapperProps: viewProps } = extractCanvasProps('native', { ...props, onPointerMissed })
     const [block, setBlock] = React.useState<SetBlock>(false)
     const [error, setError] = React.useState<any>(false)
 

--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -23,22 +23,6 @@ type UnblockProps = {
   children: React.ReactNode
 }
 
-const CANVAS_PROPS: Array<keyof Props> = [
-  'gl',
-  'events',
-  'shadows',
-  'linear',
-  'flat',
-  'legacy',
-  'orthographic',
-  'frameloop',
-  'performance',
-  'raycaster',
-  'camera',
-  'onPointerMissed',
-  'onCreated',
-]
-
 function Block({ set }: Omit<UnblockProps, 'children'>) {
   React.useLayoutEffect(() => {
     set(new Promise(() => null))

--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -8,6 +8,7 @@ import { ReconcilerRoot, extend, createRoot, unmountComponentAtNode, RenderProps
 import { createPointerEvents } from './events'
 import { RootState } from '../core/store'
 import { EventManager } from '../core/events'
+import { extractCanvasProps } from '../core/utils'
 
 export interface Props
   extends Omit<RenderProps<HTMLCanvasElement>, 'size' | 'events'>,
@@ -20,44 +21,6 @@ export interface Props
 
 type SetBlock = false | Promise<null> | null
 type UnblockProps = { set: React.Dispatch<React.SetStateAction<SetBlock>>; children: React.ReactNode }
-
-function extractDivAndCanvasProps(props: Omit<Props, 'children' | 'fallback' | 'resize' | 'style' | 'events'>) {
-  let {
-    gl,
-    shadows,
-    linear,
-    flat,
-    legacy,
-    orthographic,
-    frameloop,
-    dpr,
-    performance,
-    raycaster,
-    camera,
-    onPointerMissed,
-    onCreated,
-    ...divProps
-  } = props
-
-  return {
-    canvasProps: {
-      gl,
-      shadows,
-      linear,
-      flat,
-      legacy,
-      orthographic,
-      frameloop,
-      dpr,
-      performance,
-      raycaster,
-      camera,
-      onPointerMissed,
-      onCreated,
-    },
-    divProps,
-  }
-}
 
 function Block({ set }: Omit<UnblockProps, 'children'>) {
   React.useLayoutEffect(() => {
@@ -93,7 +56,7 @@ export const Canvas = /*#__PURE__*/ React.forwardRef<HTMLCanvasElement, Props>(f
   const canvasRef = React.useRef<HTMLCanvasElement>(null!)
   const [canvas, setCanvas] = React.useState<HTMLCanvasElement | null>(null)
 
-  const { canvasProps, divProps } = extractDivAndCanvasProps({ ...props, onPointerMissed })
+  const { canvasProps, wrapperProps: divProps } = extractCanvasProps('web', { ...props, onPointerMissed })
   const [block, setBlock] = React.useState<SetBlock>(false)
   const [error, setError] = React.useState<any>(false)
 


### PR DESCRIPTION
Because Canvas has more than 200 props, I personally don't think it would be wise to over copy the props and loop over an array of constants just to pick / omit selected props. This PR is meant to eliminate all of the above issues