### PR TITLE
fix(web): use isomorphic effects in canvas for react ssr

### DIFF
--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -9,7 +9,7 @@ import { Renderer, createStore, isRenderer, context, RootState, Size, Camera, Dp
 import { createRenderer, extend, Root } from './renderer'
 import { createLoop, addEffect, addAfterEffect, addTail } from './loop'
 import { getEventPriority, EventManager, ComputeFunction } from './events'
-import { is, dispose, calculateDpr, EquConfig, getRootState } from './utils'
+import { is, dispose, calculateDpr, EquConfig, getRootState, useIsomorphicLayoutEffect } from './utils'
 import { useStore } from './hooks'
 
 const roots = new Map<Element, Root>()
@@ -302,7 +302,7 @@ function Provider<TElement extends Element>({
   rootElement: TElement
   parent?: React.MutableRefObject<TElement | undefined>
 }) {
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const state = store.getState()
     // Flag the canvas active, rendering will now begin
     state.set((state) => ({ internal: { ...state.internal, active: true } }))

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -10,7 +10,7 @@ import { Dpr, RootState } from './store'
 // useLayoutEffect on the client.
 const isSSR =
   typeof window === 'undefined' || !window.navigator || /ServerSideRendering|^Deno\//.test(window.navigator.userAgent)
-export const useIsomorphicLayoutEffect = isSSR ? React.useLayoutEffect : React.useEffect
+export const useIsomorphicLayoutEffect = isSSR ? React.useEffect : React.useLayoutEffect
 
 export type SetBlock = false | Promise<null> | null
 export type UnblockProps = { set: React.Dispatch<React.SetStateAction<SetBlock>>; children: React.ReactNode }

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -12,6 +12,28 @@ const isSSR =
   typeof window === 'undefined' || !window.navigator || /ServerSideRendering|^Deno\//.test(window.navigator.userAgent)
 export const useIsomorphicLayoutEffect = isSSR ? React.useLayoutEffect : React.useEffect
 
+export type SetBlock = false | Promise<null> | null
+export type UnblockProps = { set: React.Dispatch<React.SetStateAction<SetBlock>>; children: React.ReactNode }
+
+export function Block({ set }: Omit<UnblockProps, 'children'>) {
+  useIsomorphicLayoutEffect(() => {
+    set(new Promise(() => null))
+    return () => set(false)
+  }, [set])
+  return null
+}
+
+export class ErrorBoundary extends React.Component<{ set: React.Dispatch<any> }, { error: boolean }> {
+  state = { error: false }
+  static getDerivedStateFromError = () => ({ error: true })
+  componentDidCatch(error: any) {
+    this.props.set(error)
+  }
+  render() {
+    return this.state.error ? null : this.props.children
+  }
+}
+
 type noop = (...args: any[]) => any
 type PickFunction<T extends noop> = (...args: Parameters<T>) => ReturnType<T>
 

--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -3,7 +3,7 @@ import * as THREE from 'three'
 import mergeRefs from 'react-merge-refs'
 import { View, ViewProps, ViewStyle, LayoutChangeEvent, StyleSheet, PixelRatio } from 'react-native'
 import { ExpoWebGLRenderingContext, GLView } from 'expo-gl'
-import { useMemoizedFn, pick, omit } from '../core/utils'
+import { SetBlock, Block, ErrorBoundary, useMemoizedFn, pick, omit } from '../core/utils'
 import { extend, createRoot, unmountComponentAtNode, RenderProps, ReconcilerRoot } from '../core'
 import { createTouchEvents } from './events'
 import { RootState } from '../core/store'
@@ -11,12 +11,6 @@ import { RootState } from '../core/store'
 export interface Props extends Omit<RenderProps<HTMLCanvasElement>, 'size'>, ViewProps {
   children: React.ReactNode
   style?: ViewStyle
-}
-
-type SetBlock = false | Promise<null> | null
-type UnblockProps = {
-  set: React.Dispatch<React.SetStateAction<SetBlock>>
-  children: React.ReactNode
 }
 
 const CANVAS_PROPS: Array<keyof Props> = [
@@ -34,25 +28,6 @@ const CANVAS_PROPS: Array<keyof Props> = [
   'onPointerMissed',
   'onCreated',
 ]
-
-function Block({ set }: Omit<UnblockProps, 'children'>) {
-  React.useLayoutEffect(() => {
-    set(new Promise(() => null))
-    return () => set(false)
-  }, [set])
-  return null
-}
-
-class ErrorBoundary extends React.Component<{ set: React.Dispatch<any> }, { error: boolean }> {
-  state = { error: false }
-  static getDerivedStateFromError = () => ({ error: true })
-  componentDidCatch(error: any) {
-    this.props.set(error)
-  }
-  render() {
-    return this.state.error ? null : this.props.children
-  }
-}
 
 /**
  * A native canvas which accepts threejs elements as children.

--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -12,8 +12,10 @@ import { EventManager } from '../core/events'
 
 // React currently throws a warning when using useLayoutEffect on the server.
 // To get around it, we can conditionally useEffect on the server (no-op) and
-// useLayoutEffect in the browser.
-const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect
+// useLayoutEffect on the client.
+const isSSR =
+  typeof window === 'undefined' || !window.navigator || /ServerSideRendering|^Deno\//.test(window.navigator.userAgent)
+const useIsomorphicLayoutEffect = isSSR ? React.useLayoutEffect : React.useEffect
 
 export interface Props
   extends Omit<RenderProps<HTMLCanvasElement>, 'size' | 'events'>,

--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -3,16 +3,9 @@ import * as THREE from 'three'
 import mergeRefs from 'react-merge-refs'
 import useMeasure from 'react-use-measure'
 import type { Options as ResizeOptions } from 'react-use-measure'
-import { useMemoizedFn, pick, omit } from '../core/utils'
+import { useMemoizedFn, useIsomorphicLayoutEffect, pick, omit } from '../core/utils'
 import { ReconcilerRoot, extend, createRoot, unmountComponentAtNode, RenderProps } from '../core'
 import { createPointerEvents } from './events'
-
-// React currently throws a warning when using useLayoutEffect on the server.
-// To get around it, we can conditionally useEffect on the server (no-op) and
-// useLayoutEffect on the client.
-const isSSR =
-  typeof window === 'undefined' || !window.navigator || /ServerSideRendering|^Deno\//.test(window.navigator.userAgent)
-const useIsomorphicLayoutEffect = isSSR ? React.useLayoutEffect : React.useEffect
 
 export interface Props extends Omit<RenderProps<HTMLCanvasElement>, 'size'>, React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode

--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -3,7 +3,7 @@ import * as THREE from 'three'
 import mergeRefs from 'react-merge-refs'
 import useMeasure from 'react-use-measure'
 import type { Options as ResizeOptions } from 'react-use-measure'
-import { useMemoizedFn, useIsomorphicLayoutEffect, pick, omit } from '../core/utils'
+import { SetBlock, Block, ErrorBoundary, useMemoizedFn, useIsomorphicLayoutEffect, pick, omit } from '../core/utils'
 import { ReconcilerRoot, extend, createRoot, unmountComponentAtNode, RenderProps } from '../core'
 import { createPointerEvents } from './events'
 
@@ -17,9 +17,6 @@ export interface Props extends Omit<RenderProps<HTMLCanvasElement>, 'size'>, Rea
    */
   resize?: ResizeOptions
 }
-
-type SetBlock = false | Promise<null> | null
-type UnblockProps = { set: React.Dispatch<React.SetStateAction<SetBlock>>; children: React.ReactNode }
 
 const CANVAS_PROPS: Array<keyof Props> = [
   'gl',
@@ -37,25 +34,6 @@ const CANVAS_PROPS: Array<keyof Props> = [
   'onPointerMissed',
   'onCreated',
 ]
-
-function Block({ set }: Omit<UnblockProps, 'children'>) {
-  React.useLayoutEffect(() => {
-    set(new Promise(() => null))
-    return () => set(false)
-  }, [set])
-  return null
-}
-
-class ErrorBoundary extends React.Component<{ set: React.Dispatch<any> }, { error: boolean }> {
-  state = { error: false }
-  static getDerivedStateFromError = () => ({ error: true })
-  componentDidCatch(error: any) {
-    this.props.set(error)
-  }
-  render() {
-    return this.state.error ? null : this.props.children
-  }
-}
 
 /**
  * A DOM canvas which accepts threejs elements as children.

--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -10,6 +10,11 @@ import { createPointerEvents } from './events'
 import { RootState } from '../core/store'
 import { EventManager } from '../core/events'
 
+// React currently throws a warning when using useLayoutEffect on the server.
+// To get around it, we can conditionally useEffect on the server (no-op) and
+// useLayoutEffect in the browser.
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect
+
 export interface Props
   extends Omit<RenderProps<HTMLCanvasElement>, 'size' | 'events'>,
     React.HTMLAttributes<HTMLDivElement> {
@@ -103,13 +108,11 @@ export const Canvas = /*#__PURE__*/ React.forwardRef<HTMLCanvasElement, Props>(f
     )
   }
 
-  React.useLayoutEffect(() => {
-    setCanvas(canvasRef.current)
+  useIsomorphicLayoutEffect(() => {
+    const canvas = canvasRef.current
+    setCanvas(canvas)
+    return () => unmountComponentAtNode(canvas)
   }, [])
-
-  React.useEffect(() => {
-    return () => unmountComponentAtNode(canvas!)
-  }, [canvas])
 
   return (
     <div

--- a/packages/fiber/tests/web/canvas.test.tsx
+++ b/packages/fiber/tests/web/canvas.test.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react'
+// use default export for jest.spyOn
+import React from 'react'
 import { render, RenderResult } from '@testing-library/react'
 
 import { Canvas, act } from '../../src'
@@ -43,5 +44,19 @@ describe('web Canvas', () => {
     })
 
     expect(() => renderer.unmount()).not.toThrow()
+  })
+
+  it('plays nice with react SSR', async () => {
+    const useLayoutEffect = jest.spyOn(React, 'useLayoutEffect')
+
+    await act(async () => {
+      render(
+        <Canvas>
+          <group />
+        </Canvas>,
+      )
+    })
+
+    expect(useLayoutEffect).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Fixes #1163 where we regressed from using an isomorphic effect in canvas to play nice with react ssr.