### PR TITLE
refactor: useMemoizedFn => useMutableCallback

### DIFF
--- a/packages/fiber/src/core/hooks.tsx
+++ b/packages/fiber/src/core/hooks.tsx
@@ -4,7 +4,7 @@ import { StateSelector, EqualityChecker } from 'zustand'
 import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader'
 import { suspend, preload, clear } from 'suspend-react'
 import { context, RootState, RenderCallback } from './store'
-import { buildGraph, ObjectMap, is } from './utils'
+import { buildGraph, ObjectMap, is, useMutableCallback, useIsomorphicLayoutEffect } from './utils'
 
 export interface Loader<T> extends THREE.Loader {
   load(
@@ -45,11 +45,10 @@ export function useThree<T = RootState>(
 export function useFrame(callback: RenderCallback, renderPriority: number = 0): null {
   const store = useStore()
   const subscribe = store.getState().internal.subscribe
-  // Update ref
-  const ref = React.useRef<RenderCallback>(callback)
-  React.useLayoutEffect(() => void (ref.current = callback), [callback])
+  // Memoize ref
+  const ref = useMutableCallback(callback)
   // Subscribe on mount, unsubscribe on unmount
-  React.useLayoutEffect(() => subscribe(ref, renderPriority, store), [renderPriority, subscribe, store])
+  useIsomorphicLayoutEffect(() => subscribe(ref, renderPriority, store), [renderPriority, subscribe, store])
   return null
 }
 

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -12,6 +12,12 @@ const isSSR =
   typeof window === 'undefined' || !window.navigator || /ServerSideRendering|^Deno\//.test(window.navigator.userAgent)
 export const useIsomorphicLayoutEffect = isSSR ? React.useEffect : React.useLayoutEffect
 
+export function useMutableCallback<T>(fn: T) {
+  const ref = React.useRef<T>(fn)
+  useIsomorphicLayoutEffect(() => void (ref.current = fn), [fn])
+  return ref
+}
+
 export type SetBlock = false | Promise<null> | null
 export type UnblockProps = { set: React.Dispatch<React.SetStateAction<SetBlock>>; children: React.ReactNode }
 
@@ -32,15 +38,6 @@ export class ErrorBoundary extends React.Component<{ set: React.Dispatch<any> },
   render() {
     return this.state.error ? null : this.props.children
   }
-}
-
-type noop = (...args: any[]) => any
-type PickFunction<T extends noop> = (...args: Parameters<T>) => ReturnType<T>
-
-export function useMemoizedFn<T extends noop>(fn?: T): PickFunction<T> {
-  const fnRef = React.useRef<T | undefined>(fn)
-  useIsomorphicLayoutEffect(() => void (fnRef.current = fn), [fn])
-  return (...args: Parameters<T>) => fnRef.current?.(...args)
 }
 
 export const DEFAULT = '__default'

--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -3,7 +3,7 @@ import * as THREE from 'three'
 import mergeRefs from 'react-merge-refs'
 import { View, ViewProps, ViewStyle, LayoutChangeEvent, StyleSheet, PixelRatio } from 'react-native'
 import { ExpoWebGLRenderingContext, GLView } from 'expo-gl'
-import { SetBlock, Block, ErrorBoundary, useMemoizedFn, pick, omit } from '../core/utils'
+import { SetBlock, Block, ErrorBoundary, useMutableCallback, pick, omit } from '../core/utils'
 import { extend, createRoot, unmountComponentAtNode, RenderProps, ReconcilerRoot } from '../core'
 import { createTouchEvents } from './events'
 import { RootState } from '../core/store'
@@ -34,19 +34,19 @@ const CANVAS_PROPS: Array<keyof Props> = [
  * @see https://docs.pmnd.rs/react-three-fiber/api/canvas
  */
 export const Canvas = /*#__PURE__*/ React.forwardRef<View, Props>(
-  ({ children, style, events, ...props }, forwardedRef) => {
+  ({ children, style, events, onPointerMissed, ...props }, forwardedRef) => {
     // Create a known catalogue of Threejs-native elements
     // This will include the entire THREE namespace by default, users can extend
     // their own elements by using the createRoot API instead
     React.useMemo(() => extend(THREE), [])
-    const onPointerMissed = useMemoizedFn(props.onPointerMissed)
 
     const [{ width, height }, setSize] = React.useState({ width: 0, height: 0 })
     const [canvas, setCanvas] = React.useState<HTMLCanvasElement | null>(null)
     const [bind, setBind] = React.useState<any>()
 
-    const canvasProps = pick<Props>({ ...props, onPointerMissed }, CANVAS_PROPS)
-    const viewProps = omit<Props>({ ...props, onPointerMissed }, CANVAS_PROPS)
+    const handlePointerMissed = useMutableCallback(onPointerMissed)
+    const canvasProps = pick<Props>(props, CANVAS_PROPS)
+    const viewProps = omit<Props>(props, CANVAS_PROPS)
     const [block, setBlock] = React.useState<SetBlock>(false)
     const [error, setError] = React.useState<any>(false)
 
@@ -98,6 +98,7 @@ export const Canvas = /*#__PURE__*/ React.forwardRef<View, Props>(
 
       root.current.configure({
         ...canvasProps,
+        onPointerMissed: handlePointerMissed.current,
         // expo-gl can only render at native dpr/resolution
         // https://github.com/expo/expo-three/issues/39
         dpr: PixelRatio.get(),

--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -98,7 +98,7 @@ export const Canvas = /*#__PURE__*/ React.forwardRef<View, Props>(
 
       root.current.configure({
         ...canvasProps,
-        onPointerMissed: handlePointerMissed.current,
+        onPointerMissed: (...args) => handlePointerMissed.current?.(...args),
         // expo-gl can only render at native dpr/resolution
         // https://github.com/expo/expo-three/issues/39
         dpr: PixelRatio.get(),

--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -98,6 +98,7 @@ export const Canvas = /*#__PURE__*/ React.forwardRef<View, Props>(
 
       root.current.configure({
         ...canvasProps,
+        // Pass mutable reference to onPointerMissed so it's free to update
         onPointerMissed: (...args) => handlePointerMissed.current?.(...args),
         // expo-gl can only render at native dpr/resolution
         // https://github.com/expo/expo-three/issues/39

--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -3,7 +3,15 @@ import * as THREE from 'three'
 import mergeRefs from 'react-merge-refs'
 import useMeasure from 'react-use-measure'
 import type { Options as ResizeOptions } from 'react-use-measure'
-import { SetBlock, Block, ErrorBoundary, useMemoizedFn, useIsomorphicLayoutEffect, pick, omit } from '../core/utils'
+import {
+  SetBlock,
+  Block,
+  ErrorBoundary,
+  useMutableCallback,
+  useIsomorphicLayoutEffect,
+  pick,
+  omit,
+} from '../core/utils'
 import { ReconcilerRoot, extend, createRoot, unmountComponentAtNode, RenderProps } from '../core'
 import { createPointerEvents } from './events'
 
@@ -40,22 +48,22 @@ const CANVAS_PROPS: Array<keyof Props> = [
  * @see https://docs.pmnd.rs/react-three-fiber/api/canvas
  */
 export const Canvas = /*#__PURE__*/ React.forwardRef<HTMLCanvasElement, Props>(function Canvas(
-  { children, fallback, resize, style, events = createPointerEvents, ...props },
+  { children, fallback, resize, style, onPointerMissed, events = createPointerEvents, ...props },
   forwardedRef,
 ) {
   // Create a known catalogue of Threejs-native elements
   // This will include the entire THREE namespace by default, users can extend
   // their own elements by using the createRoot API instead
   React.useMemo(() => extend(THREE), [])
-  const onPointerMissed = useMemoizedFn(props.onPointerMissed)
 
   const [containerRef, { width, height }] = useMeasure({ scroll: true, debounce: { scroll: 50, resize: 0 }, ...resize })
   const meshRef = React.useRef<HTMLDivElement>(null!)
   const canvasRef = React.useRef<HTMLCanvasElement>(null!)
   const [canvas, setCanvas] = React.useState<HTMLCanvasElement | null>(null)
 
-  const canvasProps = pick<Props>({ ...props, onPointerMissed }, CANVAS_PROPS)
-  const divProps = omit<Props>({ ...props, onPointerMissed }, CANVAS_PROPS)
+  const handlePointerMissed = useMutableCallback(onPointerMissed)
+  const canvasProps = pick<Props>(props, CANVAS_PROPS)
+  const divProps = omit<Props>(props, CANVAS_PROPS)
   const [block, setBlock] = React.useState<SetBlock>(false)
   const [error, setError] = React.useState<any>(false)
 
@@ -70,6 +78,7 @@ export const Canvas = /*#__PURE__*/ React.forwardRef<HTMLCanvasElement, Props>(f
     if (!root.current) root.current = createRoot<HTMLElement>(canvas)
     root.current.configure({
       ...canvasProps,
+      onPointerMissed: handlePointerMissed.current,
       onCreated: (state) => {
         state.events.connect?.(meshRef.current)
         canvasProps.onCreated?.(state)

--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -78,7 +78,7 @@ export const Canvas = /*#__PURE__*/ React.forwardRef<HTMLCanvasElement, Props>(f
     if (!root.current) root.current = createRoot<HTMLElement>(canvas)
     root.current.configure({
       ...canvasProps,
-      onPointerMissed: handlePointerMissed.current,
+      onPointerMissed: (...args) => handlePointerMissed.current?.(...args),
       onCreated: (state) => {
         state.events.connect?.(meshRef.current)
         canvasProps.onCreated?.(state)

--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -78,6 +78,7 @@ export const Canvas = /*#__PURE__*/ React.forwardRef<HTMLCanvasElement, Props>(f
     if (!root.current) root.current = createRoot<HTMLElement>(canvas)
     root.current.configure({
       ...canvasProps,
+      // Pass mutable reference to onPointerMissed so it's free to update
       onPointerMissed: (...args) => handlePointerMissed.current?.(...args),
       onCreated: (state) => {
         state.events.connect?.(meshRef.current)


### PR DESCRIPTION
Continues #2110. ([onPointerMissed codesandbox](https://codesandbox.io/s/quirky-montalcini-bk2jlm?file=/src/App.js))

Makes useMemoizedFn more generic to allow re-use in useFrame.