### PR TITLE
Update three-types.ts

### DIFF
--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -27,7 +27,7 @@ export interface NodeProps<T, P> {
   /** Constructor arguments */
   args?: Args<P>
   children?: React.ReactNode
-  ref?: React.RefCallback<T> | React.RefObject<React.ReactNode> | null
+  ref?: React.Ref<T>
   key?: React.Key
   onUpdate?: (self: T) => void
 }


### PR DESCRIPTION
Potential Bug because of `React.RefObject<React.Node>`.

React.Ref is defined as
`React.Ref<T> = RefCallback<T> | RefObject<T> | null;`