### PR TITLE
fix: state copy respect private keys

### DIFF
--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -15,8 +15,6 @@ export const privateKeys = [
   'events',
   'invalidate',
   'advance',
-  'performance',
-  'internal',
   'size',
   'viewport',
 ] as const

--- a/packages/fiber/tests/core/renderer.test.tsx
+++ b/packages/fiber/tests/core/renderer.test.tsx
@@ -694,7 +694,7 @@ describe('renderer', () => {
     expect(portalState.scene).toBe(scene)
 
     // Preserves internal keys
-    const overwrittenKeys = ['events', 'size', 'viewport']
+    const overwrittenKeys = ['get', 'set', 'events', 'size', 'viewport']
     const respectedKeys = privateKeys.filter((key) => overwrittenKeys.includes(key) || state[key] === portalState[key])
     expect(respectedKeys).toStrictEqual(privateKeys)
   })


### PR DESCRIPTION
Closes #2211 

The private key list was doing the opposite of what was intended (i think), and was only copying the things from the root state that was in the list. Meaning the get & set was being copied from the parent store.

Made some assumptions about what keys should be private, based on the previous behaviour before b0a16c95da6a97b5af82a0db8a9d397f1593177c