### PR TITLE
Indent function in hooks doc

### DIFF
--- a/docs/API/hooks.mdx
+++ b/docs/API/hooks.mdx
@@ -25,11 +25,13 @@ function App() {
 ```jsx
 function Foo() {
   const { size } = useThree()
+  ...
+}
 
-  function App() {
-    return (
-      <Canvas>
-        <Foo />
+function App() {
+  return (
+    <Canvas>
+      <Foo />
 ```
 
 ## useThree

--- a/docs/API/hooks.mdx
+++ b/docs/API/hooks.mdx
@@ -26,10 +26,10 @@ function App() {
 function Foo() {
   const { size } = useThree()
 
-function App() {
-  return (
-    <Canvas>
-      <Foo />
+  function App() {
+    return (
+      <Canvas>
+        <Foo />
 ```
 
 ## useThree


### PR DESCRIPTION
Small docs change that indents the `function App()` in the hooks doc so that it's more obvious that the function is supposed to be nested inside of `<Foo>`