### PR TITLE
fix(core) insertBefore supports attachArray

### DIFF
--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -366,8 +366,11 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>) {
     let added = false
     if (child) {
       if (child.attachArray) {
-        const array = parentInstance[child.attachArray]
-        if (!is.arr(array)) parentInstance[child.attachArray] = []
+        let array = parentInstance[child.attachArray]
+        if (!is.arr(array)) {
+          parentInstance[child.attachArray] = []
+          array = parentInstance[child.attachArray]
+        }
         array.splice(array.indexOf(beforeChild), 0, child)
       } else if (child.attachObject || (child.attach && !is.fun(child.attach))) {
         // attach and attachObject don't have an order anyway, so just append


### PR DESCRIPTION
Previously it did not work (would call .splice on null) if the array didn't already exist.

**NB** this PR is against the v7 branch. My project won't be able to update to v8 for at least the next year owing to the React dependency, so we'll be continuing to patch bugs and develop the event system in the v7 version.