### PR TITLE
Fix link to `extend` documentation

### DIFF
--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -89,7 +89,7 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>, getEventPriority?: (
     } else {
       const target = catalogue[name]
       if (!target) {
-        throw `${name} is not part of the THREE namespace! Did you forget to extend? See: https://github.com/pmndrs/react-three-fiber/blob/master/markdown/api.md#using-3rd-party-objects-declaratively`
+        throw `${name} is not part of the THREE namespace! Did you forget to extend? See: https://docs.pmnd.rs/react-three-fiber/api/objects#using-3rd-party-objects-declaratively`
       }
 
       // Throw if an object or literal was passed for args


### PR DESCRIPTION
react-three-fiber raises an error when its renderer encounters an element type it does not know from the THREE namespace. The error message includes a link to the documentation of `extend`; this link was unfortunately 404ing.

This PR fixes the issue by updating the link.