### PR TITLE
docs(tutorials/typescript): fix typo

### DIFF
--- a/docs/tutorials/typescript.mdx
+++ b/docs/tutorials/typescript.mdx
@@ -24,7 +24,7 @@ function Box(props) {
   }, [])
 
   return (
-    <mesh {...props} ref={props}>
+    <mesh {...props} ref={ref}>
       <boxGeometry />
       <meshBasicMaterial />
     </mesh>


### PR DESCRIPTION
should pass `ref` to props `ref`