### PR TITLE
fix (#1684): add div container for canvas size handling

### DIFF
--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -107,12 +107,16 @@ export const Canvas = /*#__PURE__*/ React.forwardRef<HTMLCanvasElement, Props>(f
 
   return (
     <div
-      ref={mergeRefs([meshRef, containerRef])}
+      ref={meshRef}
       style={{ position: 'relative', width: '100%', height: '100%', overflow: 'hidden', ...style }}
       {...props}>
-      <canvas ref={mergeRefs([canvasRef, forwardedRef])} style={{ display: 'block' }}>
-        {fallback}
-      </canvas>
+      <div
+        ref={containerRef}
+        style={{ width: '100%', height: '100%' }}>
+        <canvas ref={mergeRefs([canvasRef, forwardedRef])} style={{ display: 'block' }}>
+          {fallback}
+        </canvas>
+      </div>
     </div>
   )
 })

--- a/packages/fiber/tests/core/events.test.tsx
+++ b/packages/fiber/tests/core/events.test.tsx
@@ -3,6 +3,8 @@ import { render, fireEvent, RenderResult } from '@testing-library/react'
 
 import { Canvas, act } from '../../src'
 
+const getContainer = () => document.querySelector('canvas')?.parentNode?.parentNode as HTMLDivElement
+
 describe('events', () => {
   it('can handle onPointerDown', async () => {
     const handlePointerDown = jest.fn()
@@ -24,7 +26,7 @@ describe('events', () => {
     // @ts-ignore
     evt.offsetY = 480
 
-    fireEvent(document.querySelector('canvas')?.parentNode as HTMLDivElement, evt)
+    fireEvent(getContainer(), evt)
 
     expect(handlePointerDown).toHaveBeenCalled()
   })
@@ -50,7 +52,7 @@ describe('events', () => {
     //@ts-ignore
     evt.offsetY = 0
 
-    fireEvent(document.querySelector('canvas')?.parentNode as HTMLDivElement, evt)
+    fireEvent(getContainer(), evt)
 
     expect(handleClick).not.toHaveBeenCalled()
     expect(handleMissed).toHaveBeenCalledWith(evt)
@@ -77,7 +79,7 @@ describe('events', () => {
     //@ts-ignore
     down.offsetY = 480
 
-    fireEvent(document.querySelector('canvas')?.parentNode as HTMLDivElement, down)
+    fireEvent(getContainer(), down)
 
     const up = new PointerEvent('pointerup')
     //@ts-ignore
@@ -91,7 +93,7 @@ describe('events', () => {
     //@ts-ignore
     evt.offsetY = 480
 
-    fireEvent(document.querySelector('canvas')?.parentNode as HTMLDivElement, evt)
+    fireEvent(getContainer(), evt)
 
     expect(handleClick).toHaveBeenCalled()
     expect(handleMissed).not.toHaveBeenCalled()
@@ -120,7 +122,7 @@ describe('events', () => {
     //@ts-ignore
     down.offsetY = 480
 
-    fireEvent(document.querySelector('canvas')?.parentNode as HTMLDivElement, down)
+    fireEvent(getContainer(), down)
 
     const up = new PointerEvent('pointerup')
     //@ts-ignore
@@ -134,7 +136,7 @@ describe('events', () => {
     //@ts-ignore
     evt.offsetY = 480
 
-    fireEvent(document.querySelector('canvas')?.parentNode as HTMLDivElement, evt)
+    fireEvent(getContainer(), evt)
 
     expect(handleClick).toHaveBeenCalled()
     expect(handleMissed).not.toHaveBeenCalled()
@@ -160,7 +162,7 @@ describe('events', () => {
     //@ts-ignore
     evt.offsetY = 0
 
-    fireEvent(document.querySelector('canvas')?.parentNode as HTMLDivElement, evt)
+    fireEvent(getContainer(), evt)
     expect(handleMissed).toHaveBeenCalledWith(evt)
   })
 
@@ -191,7 +193,7 @@ describe('events', () => {
     //@ts-ignore
     evt1.offsetY = 480
 
-    fireEvent(document.querySelector('canvas')?.parentNode as HTMLDivElement, evt1)
+    fireEvent(getContainer(), evt1)
 
     expect(handlePointerMove).toHaveBeenCalled()
     expect(handlePointerOver).toHaveBeenCalled()
@@ -203,7 +205,7 @@ describe('events', () => {
     //@ts-ignore
     evt2.offsetY = 0
 
-    fireEvent(document.querySelector('canvas')?.parentNode as HTMLDivElement, evt2)
+    fireEvent(getContainer(), evt2)
 
     expect(handlePointerOut).toHaveBeenCalled()
   })
@@ -235,7 +237,7 @@ describe('events', () => {
     //@ts-ignore
     evt1.offsetY = 480
 
-    fireEvent(document.querySelector('canvas')?.parentNode as HTMLDivElement, evt1)
+    fireEvent(getContainer(), evt1)
 
     expect(handlePointerEnter).toHaveBeenCalled()
 
@@ -245,7 +247,7 @@ describe('events', () => {
     //@ts-ignore
     evt2.offsetY = 0
 
-    fireEvent(document.querySelector('canvas')?.parentNode as HTMLDivElement, evt2)
+    fireEvent(getContainer(), evt2)
 
     expect(handlePointerLeave).toHaveBeenCalled()
   })
@@ -275,7 +277,7 @@ describe('events', () => {
     //@ts-ignore
     down.offsetY = 480
 
-    fireEvent(document.querySelector('canvas')?.parentNode as HTMLDivElement, down)
+    fireEvent(getContainer(), down)
 
     const up = new PointerEvent('pointerup')
     //@ts-ignore
@@ -283,7 +285,7 @@ describe('events', () => {
     //@ts-ignore
     up.offsetY = 480
 
-    fireEvent(document.querySelector('canvas')?.parentNode as HTMLDivElement, up)
+    fireEvent(getContainer(), up)
 
     const event = new MouseEvent('click')
     //@ts-ignore
@@ -291,7 +293,7 @@ describe('events', () => {
     //@ts-ignore
     event.offsetY = 480
 
-    fireEvent(document.querySelector('canvas')?.parentNode as HTMLDivElement, event)
+    fireEvent(getContainer(), event)
 
     expect(handleClickFront).toHaveBeenCalled()
     expect(handleClickRear).not.toHaveBeenCalled()
@@ -324,7 +326,7 @@ describe('events', () => {
         return renderResult
       })
 
-      const canvas = document.querySelector('canvas')?.parentNode as HTMLDivElement
+      const canvas = getContainer()
 
       canvas.setPointerCapture = jest.fn()
       canvas.releasePointerCapture = jest.fn()

--- a/packages/fiber/tests/web/__snapshots__/canvas.test.tsx.snap
+++ b/packages/fiber/tests/web/__snapshots__/canvas.test.tsx.snap
@@ -5,12 +5,16 @@ exports[`web Canvas should correctly mount 1`] = `
   <div
     style="position: relative; width: 100%; height: 100%; overflow: hidden;"
   >
-    <canvas
-      data-engine="three.js r139"
-      height="800"
-      style="display: block; width: 1280px; height: 800px;"
-      width="1280"
-    />
+    <div
+      style="width: 100%; height: 100%;"
+    >
+      <canvas
+        data-engine="three.js r139"
+        height="800"
+        style="display: block; width: 1280px; height: 800px;"
+        width="1280"
+      />
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
This PR is fixing this [issue](https://github.com/pmndrs/react-three-fiber/issues/1684)

I added a separate div to control size of canvas. In this case the size of new inner div doesn't depend on other styles that customize outer div "positions".