### PR TITLE
fix(core): don't handle attach on visibility change

### DIFF
--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -344,16 +344,10 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>, getEventPriority?: (
     clearContainer: () => false,
     detachDeletedInstance: () => {},
     hideInstance(instance: Instance) {
-      // Detach while the instance is hidden
-      const { attach: type, parent } = instance?.__r3f ?? {}
-      if (type && parent) detach(parent, instance, type)
       if (instance.isObject3D) instance.visible = false
       invalidateInstance(instance)
     },
     unhideInstance(instance: Instance, props: InstanceProps) {
-      // Re-attach when the instance is unhidden
-      const { attach: type, parent } = instance?.__r3f ?? {}
-      if (type && parent) attach(parent, instance, type)
       if ((instance.isObject3D && props.visible == null) || props.visible) instance.visible = true
       invalidateInstance(instance)
     },

--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -117,10 +117,9 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>, getEventPriority?: (
   function appendChild(parentInstance: Instance, child: Instance) {
     let added = false
     if (child) {
-      // The attach attribute implies that the object attaches itself on the parent
-      if (child.__r3f?.attach) {
-        attach(parentInstance, child, child.__r3f.attach)
-      } else if (child.isObject3D && parentInstance.isObject3D) {
+      // The attach attribute implies that the object attaches itself on the parent.
+      // That is handled at commit to avoid duplication during Suspense
+      if (!child.__r3f?.attach && child.isObject3D && parentInstance.isObject3D) {
         // add in the usual parent-child way
         parentInstance.add(child)
         added = true
@@ -290,7 +289,7 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>, getEventPriority?: (
       const localState = (instance?.__r3f ?? {}) as LocalState
       // https://github.com/facebook/react/issues/20271
       // Returning true will trigger commitMount
-      return !!localState.handlers
+      return !!localState.handlers || !!localState.attach
     },
     prepareUpdate(instance: Instance, type: string, oldProps: any, newProps: any) {
       // Create diff-sets
@@ -333,6 +332,11 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>, getEventPriority?: (
       const localState = (instance?.__r3f ?? {}) as LocalState
       if (instance.raycast && localState.handlers && localState.eventCount) {
         instance.__r3f.root.getState().internal.interaction.push(instance as unknown as THREE.Object3D)
+      }
+
+      // The attach attribute implies that the object attaches itself on the parent
+      if (localState.attach) {
+        attach(localState.parent!, instance, localState.attach)
       }
     },
     getPublicInstance: (instance: Instance) => instance,


### PR DESCRIPTION
Fixes #2250 by reverting a fix made prior to React 18 as reported in #1551 (see #1902 and https://github.com/pmndrs/react-three-fiber/commit/5eafc6a522d00afaa3858793e83ac06843a9d230).

This PR moves attach logic to `commitMount` when we know for sure instances are ready to mount.

[2250 sandbox](https://codesandbox.io/s/append-bug-forked-rhjx6m) | [1551 sandbox](https://codesandbox.io/s/material-suspense-bug-forked-nquc9g)