### PR TITLE
fix(core): safely set ColorManagement

### DIFF
--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -28,6 +28,7 @@ import {
   useIsomorphicLayoutEffect,
   Camera,
   updateCamera,
+  setDeep,
 } from './utils'
 import { useStore } from './hooks'
 
@@ -253,9 +254,9 @@ function createRoot<TCanvas extends Element>(canvas: TCanvas): ReconcilerRoot<TC
         }
       }
 
-      // Set color management
-      if ((THREE as any).ColorManagement) {
-        ;(THREE as any).ColorManagement.legacyMode = legacy
+      // Safely set color management if available
+      if ('ColorManagement' in THREE) {
+        setDeep(THREE, legacy, ['ColorManagement', 'legacyMode'])
       }
       const outputEncoding = linear ? THREE.LinearEncoding : THREE.sRGBEncoding
       const toneMapping = flat ? THREE.NoToneMapping : THREE.ACESFilmicToneMapping

--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -254,7 +254,8 @@ function createRoot<TCanvas extends Element>(canvas: TCanvas): ReconcilerRoot<TC
         }
       }
 
-      // Safely set color management if available
+      // Safely set color management if available.
+      // Avoid accessing THREE.ColorManagement to play nice with bundlers
       if ('ColorManagement' in THREE) {
         setDeep(THREE, legacy, ['ColorManagement', 'legacyMode'])
       }

--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -255,7 +255,7 @@ function createRoot<TCanvas extends Element>(canvas: TCanvas): ReconcilerRoot<TC
       }
 
       // Safely set color management if available.
-      // Avoid accessing THREE.ColorManagement to play nice with bundlers
+      // Avoid accessing THREE.ColorManagement to play nice with older versions
       if ('ColorManagement' in THREE) {
         setDeep(THREE, legacy, ['ColorManagement', 'legacyMode'])
       }

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -317,7 +317,7 @@ export function applyProps(instance: Instance, data: InstanceProps | DiffSet) {
         // For versions of three which don't support THREE.ColorManagement,
         // Auto-convert sRGB colors
         // https://github.com/pmndrs/react-three-fiber/issues/344
-        const supportsColorManagement = (THREE as any).ColorManagement
+        const supportsColorManagement = 'ColorManagement' in THREE
         if (!supportsColorManagement && !rootState.linear && isColor) targetProp.convertSRGBToLinear()
       }
       // Else, just overwrite the value
@@ -373,4 +373,14 @@ export function updateCamera(camera: Camera & { manual?: boolean }, size: Size) 
     // Update matrix world since the renderer is a frame late
     camera.updateMatrixWorld()
   }
+}
+
+/**
+ * Safely sets a deeply-nested value on an object.
+ */
+export function setDeep(obj: any, value: any, keys: string[]) {
+  const key = keys.pop()!
+  const target = keys.reduce((acc, key) => acc[key], obj)
+
+  return (target[key] = value)
 }

--- a/packages/fiber/tests/core/renderer.test.tsx
+++ b/packages/fiber/tests/core/renderer.test.tsx
@@ -638,10 +638,10 @@ describe('renderer', () => {
   })
 
   it('should respect legacy prop', async () => {
-    // await act(async () => {
-    //   root.configure({ legacy: true }).render(<group />)
-    // })
-    // expect((THREE as any).ColorManagement.legacyMode).toBe(true)
+    await act(async () => {
+      root.configure({ legacy: true }).render(<group />)
+    })
+    expect((THREE as any).ColorManagement.legacyMode).toBe(true)
 
     await act(async () => {
       root.configure({ legacy: false }).render(<group />)

--- a/packages/fiber/tests/core/renderer.test.tsx
+++ b/packages/fiber/tests/core/renderer.test.tsx
@@ -638,21 +638,13 @@ describe('renderer', () => {
   })
 
   it('should respect legacy prop', async () => {
-    let gl: THREE.WebGLRenderer = null!
-    await act(async () => {
-      gl = root
-        .configure({ legacy: true })
-        .render(<group />)
-        .getState().gl
-    })
-
-    expect((THREE as any).ColorManagement.legacyMode).toBe(true)
+    // await act(async () => {
+    //   root.configure({ legacy: true }).render(<group />)
+    // })
+    // expect((THREE as any).ColorManagement.legacyMode).toBe(true)
 
     await act(async () => {
-      gl = root
-        .configure({ legacy: false })
-        .render(<group />)
-        .getState().gl
+      root.configure({ legacy: false }).render(<group />)
     })
     expect((THREE as any).ColorManagement.legacyMode).toBe(false)
   })


### PR DESCRIPTION
Fixes #2272 by using a more lenient guard for `THREE.ColorManagement` checks. Will also side-step runtime checks by safely traversing `THREE => THREE.ColorManagement => THREE.ColorManagement.legacyMode` before mutating in the guard.