### PR TITLE
Readme file missing type for typescript example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -110,7 +110,7 @@ function Box(props: JSX.IntrinsicElements['mesh']) {
   )
 }
 
-createRoot(document.getElementById('root')).render(
+createRoot(document.getElementById('root') as HTMLElement).render(
   <Canvas>
     <ambientLight />
     <pointLight position={[10, 10, 10]} />


### PR DESCRIPTION
minor issue, anybody knowledgeable would find out where the problem is before running an example, nonetheless should be fixed