### PR TITLE
fix(core): report react's internal version to devtools

### DIFF
--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -507,7 +507,7 @@ function Portal({
 reconciler.injectIntoDevTools({
   bundleType: process.env.NODE_ENV === 'production' ? 0 : 1,
   rendererPackageName: '@react-three/fiber',
-  version: '18.0.0',
+  version: React.version,
 })
 
 const act = (React as any).unstable_act


### PR DESCRIPTION
Uses the shared internal react version when initializing dev tools as does [`react-dom`](https://github.com/facebook/react/blob/3133dfa6ee8d1a8355c0249007176955d4b7d6b0/packages/react-dom/src/client/ReactDOM.js#L227).