### PR TITLE
chore: cleanup examples and leftovers

### DIFF
--- a/example/src/demos/Gltf.tsx
+++ b/example/src/demos/Gltf.tsx
@@ -1,5 +1,4 @@
-import * as THREE from 'three'
-import React, { Suspense, useState, useEffect, useReducer } from 'react'
+import React, { Suspense, useEffect, useReducer } from 'react'
 import { Canvas, useLoader } from '@react-three/fiber'
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
 

--- a/example/src/demos/Lines.tsx
+++ b/example/src/demos/Lines.tsx
@@ -118,8 +118,10 @@ function Controls({ children }: any) {
   const ref = useRef<OrbitControls>(null!)
   useEffect(() => {
     const current = ref.current
-    current.addEventListener('change', invalidate)
-    return () => current.removeEventListener('change', invalidate)
+    const onChange = () => invalidate()
+
+    current.addEventListener('change', onChange)
+    return () => current.removeEventListener('change', onChange)
   }, [invalidate])
 
   return (

--- a/example/src/demos/MultiMaterial.tsx
+++ b/example/src/demos/MultiMaterial.tsx
@@ -1,5 +1,5 @@
 import * as THREE from 'three'
-import React, { useState, useEffect, useRef, useMemo, useCallback, useLayoutEffect } from 'react'
+import React, { useState, useEffect, useRef, useMemo } from 'react'
 import { Canvas } from '@react-three/fiber'
 
 const redMaterial = new THREE.MeshBasicMaterial({ color: 'aquamarine', toneMapped: false })
@@ -15,7 +15,10 @@ function ReuseMaterial(props: any) {
 
 function TestReuse() {
   const [i, set] = useState(true)
-  useEffect(() => void setInterval(() => set((s) => !s), 1000), [])
+  useEffect(() => {
+    const interval = setInterval(() => set((s) => !s), 1000)
+    return () => clearInterval(interval)
+  }, [])
   return (
     <>
       {i && <ReuseMaterial position={[-1.5, 0, 0]} />}

--- a/example/src/demos/MultiView.tsx
+++ b/example/src/demos/MultiView.tsx
@@ -1,6 +1,6 @@
 import * as THREE from 'three'
 import * as React from 'react'
-import { useCallback, useEffect, useState, useRef } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Canvas, useFrame, useThree, createPortal } from '@react-three/fiber'
 import {
   useGLTF,

--- a/example/src/demos/ResetProps.tsx
+++ b/example/src/demos/ResetProps.tsx
@@ -1,6 +1,6 @@
 import * as THREE from 'three'
-import React, { memo, useEffect, useState, useRef } from 'react'
-import { Canvas, useThree, useFrame, extend } from '@react-three/fiber'
+import React, { useEffect, useState, useRef } from 'react'
+import { Canvas, useThree, useFrame } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 
 function AdaptivePixelRatio() {
@@ -36,7 +36,7 @@ function AdaptiveEvents() {
 }
 
 function Scene() {
-  const group = useRef<THREE.Group>()
+  const group = useRef<THREE.Group>(null!)
   const [showCube, setShowCube] = useState(false)
   const [hovered, setHovered] = useState(false)
   const [color, setColor] = useState('pink')

--- a/example/src/demos/Test.tsx
+++ b/example/src/demos/Test.tsx
@@ -1,5 +1,5 @@
 import * as THREE from 'three'
-import React, { useState, useEffect, useRef, useReducer } from 'react'
+import React, { useState, useEffect, useReducer } from 'react'
 import { Canvas, useFrame } from '@react-three/fiber'
 
 function Test() {

--- a/example/src/demos/ViewTracking.tsx
+++ b/example/src/demos/ViewTracking.tsx
@@ -1,20 +1,12 @@
 import * as React from 'react'
 import * as THREE from 'three'
-import {
-  useGLTF,
-  Preload,
-  OrbitControls,
-  PerspectiveCamera,
-  CameraShake,
-  TransformControls,
-  Environment,
-} from '@react-three/drei'
-import { Canvas, createPortal, useFrame, useThree } from '@react-three/fiber'
-import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
+import { useGLTF, Preload, OrbitControls, PerspectiveCamera, TransformControls, Environment } from '@react-three/drei'
+import { Canvas, createPortal, ThreeEvent, useFrame, useThree } from '@react-three/fiber'
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
 import useRefs from 'react-use-refs'
 
 function Soda(props: any) {
-  const ref = useRef()
+  const ref = useRef<THREE.Group>(null!)
   const [hovered, spread] = useHover()
   const { nodes, materials } = useGLTF(
     'https://market-assets.fra1.cdn.digitaloceanspaces.com/market-assets/models/soda-bottle/model.gltf',
@@ -32,7 +24,13 @@ function Soda(props: any) {
 
 function useHover() {
   const [hovered, hover] = useState(false)
-  return [hovered, { onPointerOver: (e) => (e.stopPropagation(), hover(true)), onPointerOut: () => hover(false) }]
+  return [
+    hovered,
+    {
+      onPointerOver: (e: ThreeEvent<PointerEvent>) => (e.stopPropagation(), hover(true)),
+      onPointerOut: () => hover(false),
+    },
+  ]
 }
 
 function Duck(props: any) {
@@ -96,9 +94,6 @@ function Container({ scene, index, children, frames, rect, track }: any) {
     }
 
     camera.updateProjectionMatrix()
-    if (left === undefined) {
-      debugger
-    }
     state.gl.setViewport(left, positiveYUpBottom, width, height)
     state.gl.setScissor(left, positiveYUpBottom, width, height)
     state.gl.setScissorTest(true)

--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -143,7 +143,7 @@ function releaseInternalPointerCapture(
 }
 
 export function removeInteractivity(store: UseBoundStore<RootState>, object: THREE.Object3D) {
-  const { events, internal } = store.getState()
+  const { internal } = store.getState()
   // Removes every trace of an object from the data store
   internal.interaction = internal.interaction.filter((o) => o !== object)
   internal.initialHits = internal.initialHits.filter((o) => o !== object)
@@ -354,14 +354,14 @@ export function createEvents(store: UseBoundStore<RootState>) {
     return intersections
   }
 
-  function cancelPointer(hits: Intersection[]) {
+  function cancelPointer(intersections: Intersection[]) {
     const { internal } = store.getState()
     Array.from(internal.hovered.values()).forEach((hoveredObj) => {
       // When no objects were hit or the the hovered object wasn't found underneath the cursor
       // we call onPointerOut and delete the object from the hovered-elements map
       if (
-        !hits.length ||
-        !hits.find(
+        !intersections.length ||
+        !intersections.find(
           (hit) =>
             hit.object === hoveredObj.object &&
             hit.index === hoveredObj.index &&
@@ -374,7 +374,7 @@ export function createEvents(store: UseBoundStore<RootState>) {
         internal.hovered.delete(makeId(hoveredObj))
         if (instance?.eventCount) {
           // Clear out intersects, they are outdated by now
-          const data = { ...hoveredObj, intersections: hits || [] }
+          const data = { ...hoveredObj, intersections }
           handlers.onPointerOut?.(data as ThreeEvent<PointerEvent>)
           handlers.onPointerLeave?.(data as ThreeEvent<PointerEvent>)
         }

--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -225,7 +225,7 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>, getEventPriority?: (
     const parent = instance.__r3f?.parent
     if (!parent) return
 
-    const newInstance = createInstance(type, newProps, instance.__r3f?.root)
+    const newInstance = createInstance(type, newProps, instance.__r3f.root)
 
     // https://github.com/pmndrs/react-three-fiber/issues/1348
     // When args change the instance has to be re-constructed, which then
@@ -334,7 +334,7 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>, getEventPriority?: (
     commitMount(instance: Instance, type, props, int) {
       // https://github.com/facebook/react/issues/20271
       // This will make sure events are only added once to the central container
-      const localState = (instance?.__r3f ?? {}) as LocalState
+      const localState = (instance.__r3f ?? {}) as LocalState
       if (instance.raycast && localState.handlers && localState.eventCount) {
         instance.__r3f.root.getState().internal.interaction.push(instance as unknown as THREE.Object3D)
       }

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -236,7 +236,7 @@ export function diffProps(
 // This function applies a set of changes to the instance
 export function applyProps(instance: Instance, data: InstanceProps | DiffSet) {
   // Filter equals, events and reserved props
-  const localState = (instance?.__r3f ?? {}) as LocalState
+  const localState = (instance.__r3f ?? {}) as LocalState
   const root = localState.root
   const rootState = root?.getState?.() ?? {}
   const { memoized, changes } = isDiffSet(data) ? data : diffProps(instance, data)

--- a/packages/fiber/src/native/events.ts
+++ b/packages/fiber/src/native/events.ts
@@ -65,7 +65,7 @@ export function createTouchEvents(store: UseBoundStore<RootState>): EventManager
       const { set, events } = store.getState()
       events.disconnect?.()
 
-      const connected = new Pressability(events?.handlers)
+      const connected = new Pressability(events.handlers)
       set((state) => ({ events: { ...state.events, connected } }))
 
       const handlers = connected.getEventHandlers()

--- a/packages/fiber/src/web/events.ts
+++ b/packages/fiber/src/web/events.ts
@@ -38,7 +38,7 @@ export function createPointerEvents(store: UseBoundStore<RootState>): EventManag
       const { set, events } = store.getState()
       events.disconnect?.()
       set((state) => ({ events: { ...state.events, connected: target } }))
-      Object.entries(events?.handlers ?? []).forEach(([name, event]) => {
+      Object.entries(events.handlers ?? []).forEach(([name, event]) => {
         const [eventName, passive] = DOM_EVENTS[name as keyof typeof DOM_EVENTS]
         target.addEventListener(eventName, event, { passive })
       })


### PR DESCRIPTION
Tidies examples for StrictMode and removes leftovers from rounds of refactors in the core.