### PR TITLE
:pencil2: fix small error in doc

### DIFF
--- a/docs/tutorials/v8-migration-guide.mdx
+++ b/docs/tutorials/v8-migration-guide.mdx
@@ -287,8 +287,8 @@ Arrays must be explcit now:
 
 ```diff
 <mesh>
--  {colors.map((color, index) => <meshBasicMaterial key={index} attachArray="material" color={color} />}
-+  {colors.map((color, index) => <meshBasicMaterial key={index} attach={`material-${index}`} color={color} />}
+-  {colors.map((color, index) => <meshBasicMaterial key={index} attachArray="material" color={color} />)}
++  {colors.map((color, index) => <meshBasicMaterial key={index} attach={`material-${index}`} color={color} />)}
 </mesh>
 ```
 


### PR DESCRIPTION
I fixed the small error of v8 Migration Guide.
See  #2172