### PR TITLE
fix: store multiple parent references for multi-attach

### DIFF
--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -24,7 +24,7 @@ export type LocalState = {
   root: UseBoundStore<RootState>
   // objects and parent are used when children are added with `attach` instead of being added to the Object3D scene graph
   objects: Instance[]
-  parent: Instance | null
+  parents: Instance[]
   primitive?: boolean
   eventCount: number
   handlers: Partial<EventHandlers>
@@ -128,7 +128,7 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>, getEventPriority?: (
       // that is, anything that's a child in React but not a child in the scenegraph.
       if (!added) parentInstance.__r3f?.objects.push(child)
       if (!child.__r3f) prepare(child, {})
-      child.__r3f.parent = parentInstance
+      child.__r3f.parents.push(parentInstance)
       updateInstance(child)
       invalidateInstance(child)
     }
@@ -150,7 +150,7 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>, getEventPriority?: (
 
       if (!added) parentInstance.__r3f?.objects.push(child)
       if (!child.__r3f) prepare(child, {})
-      child.__r3f.parent = parentInstance
+      child.__r3f.parents.push(parentInstance)
       updateInstance(child)
       invalidateInstance(child)
     }
@@ -163,7 +163,7 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>, getEventPriority?: (
   function removeChild(parentInstance: Instance, child: Instance, dispose?: boolean) {
     if (child) {
       // Clear the parent reference
-      if (child.__r3f) child.__r3f.parent = null
+      if (child.__r3f) child.__r3f.parents = child.__r3f.parents.filter((parent) => parent !== parentInstance)
       // Remove child from the parents objects
       if (parentInstance.__r3f?.objects)
         parentInstance.__r3f.objects = parentInstance.__r3f.objects.filter((x) => x !== child)
@@ -222,8 +222,8 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>, getEventPriority?: (
   }
 
   function switchInstance(instance: Instance, type: string, newProps: InstanceProps, fiber: Reconciler.Fiber) {
-    const parent = instance.__r3f?.parent
-    if (!parent) return
+    const parents = instance.__r3f?.parents
+    if (!parents?.length) return
 
     const newInstance = createInstance(type, newProps, instance.__r3f?.root)
 
@@ -239,8 +239,10 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>, getEventPriority?: (
     instance.__r3f.objects.forEach((child) => appendChild(newInstance, child))
     instance.__r3f.objects = []
 
-    removeChild(parent, instance)
-    appendChild(parent, newInstance)
+    for (const parent of parents) {
+      removeChild(parent, instance)
+      appendChild(parent, newInstance)
+    }
 
     // Re-bind event handlers
     if (newInstance.raycast && newInstance.__r3f.eventCount) {
@@ -250,7 +252,9 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>, getEventPriority?: (
 
     // The attach attribute implies that the object attaches itself on the parent
     if (newInstance.__r3f?.attach) {
-      attach(parent, newInstance, newInstance.__r3f.attach)
+      for (const parent of parents) {
+        attach(parent, newInstance, newInstance.__r3f.attach)
+      }
     }
 
     // This evil hack switches the react-internal fiber node
@@ -341,7 +345,9 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>, getEventPriority?: (
 
       // The attach attribute implies that the object attaches itself on the parent
       if (localState.attach) {
-        attach(localState.parent!, instance, localState.attach)
+        for (const parent of localState.parents) {
+          attach(parent, instance, localState.attach)
+        }
       }
     },
     getPublicInstance: (instance: Instance) => instance,

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -138,7 +138,7 @@ export function dispose<TObj extends { dispose?: () => void; type?: string; [key
 // Each object in the scene carries a small LocalState descriptor
 export function prepare<T = THREE.Object3D>(object: T, state?: Partial<LocalState>) {
   const instance = object as unknown as Instance
-  if (state?.primitive || !instance.__r3f) {
+  if (!instance.__r3f) {
     instance.__r3f = {
       type: '',
       root: null as unknown as UseBoundStore<RootState>,
@@ -147,7 +147,7 @@ export function prepare<T = THREE.Object3D>(object: T, state?: Partial<LocalStat
       eventCount: 0,
       handlers: {},
       objects: [],
-      parent: null,
+      parents: [],
       ...state,
     }
   }
@@ -333,7 +333,7 @@ export function applyProps(instance: Instance, data: InstanceProps | DiffSet) {
     invalidateInstance(instance)
   })
 
-  if (localState.parent && rootState.internal && instance.raycast && prevHandlers !== localState.eventCount) {
+  if (localState.parents?.length && rootState.internal && instance.raycast && prevHandlers !== localState.eventCount) {
     // Pre-emptively remove the instance from the interaction manager
     const index = rootState.internal.interaction.indexOf(instance as unknown as THREE.Object3D)
     if (index > -1) rootState.internal.interaction.splice(index, 1)

--- a/packages/test-renderer/src/createTestInstance.ts
+++ b/packages/test-renderer/src/createTestInstance.ts
@@ -24,11 +24,11 @@ export class ReactThreeTestInstance<TInstance extends Object3D = Object3D> {
   }
 
   public get parent(): ReactThreeTestInstance | null {
-    const parent = this._fiber.__r3f.parent
-    if (parent !== null) {
-      return wrapFiber(parent)
-    }
-    return parent
+    const parents = this._fiber.__r3f.parents
+    if (!parents.length) return null
+
+    const parent = parents[parents.length - 1]
+    return wrapFiber(parent)
   }
 
   public get children(): ReactThreeTestInstance[] {

--- a/packages/test-renderer/src/types/internal.ts
+++ b/packages/test-renderer/src/types/internal.ts
@@ -1,15 +1,15 @@
 import * as THREE from 'three'
-import { UseStore } from 'zustand'
+import { UseBoundStore } from 'zustand'
 
 import type { BaseInstance, LocalState, RootState } from '@react-three/fiber'
 
-export type MockUseStoreState = UseStore<RootState>
+export type MockUseStoreState = UseBoundStore<RootState>
 
 export interface MockInstance extends Omit<BaseInstance, '__r3f'> {
-  __r3f: Omit<LocalState, 'root' | 'objects' | 'parent'> & {
+  __r3f: Omit<LocalState, 'root' | 'objects' | 'parents'> & {
     root: MockUseStoreState
     objects: MockSceneChild[]
-    parent: MockInstance
+    parents: MockInstance[]
   }
 }
 


### PR DESCRIPTION
Fixes #2294 by storing attached parents on instances themselves so they can be handled at any time. I've also updated RTTR's internal interfaces to reflect.