### PR TITLE
fix(native): create root on context restore

### DIFF
--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -80,12 +80,11 @@ export const Canvas = /*#__PURE__*/ React.forwardRef<View, Props>(
         getContext: (() => context) as any,
       } as HTMLCanvasElement
 
+      root.current = createRoot<Element>(canvasShim)
       setCanvas(canvasShim)
     }, [])
 
-    if (width > 0 && height > 0 && canvas) {
-      if (!root.current) root.current = createRoot<Element>(canvas)
-
+    if (root.current && width > 0 && height > 0) {
       root.current.configure({
         gl,
         events,


### PR DESCRIPTION
Fixes #2293 by creating a root alongside the canvas. This will let `expo-gl` create contexts without stalling R3F.