### PR TITLE
fix(core): copy attached children on swap

### DIFF
--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -234,7 +234,11 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>, getEventPriority?: (
       instance.children = []
     }
 
-    instance.__r3f.objects.forEach((child) => appendChild(newInstance, child))
+    // Copy over child attachments
+    for (const child of instance.__r3f.objects) {
+      appendChild(newInstance, child)
+      if (child.__r3f.attach) attach(newInstance, child, child.__r3f.attach)
+    }
     instance.__r3f.objects = []
 
     for (const parent of parents) {
@@ -248,7 +252,7 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>, getEventPriority?: (
       rootState.internal.interaction.push(newInstance as unknown as THREE.Object3D)
     }
 
-    // The attach attribute implies that the object attaches itself on the parent
+    // Attach instance to parent
     if (newInstance.__r3f?.attach) {
       for (const parent of parents) {
         attach(parent, newInstance, newInstance.__r3f.attach)

--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -236,6 +236,7 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>, getEventPriority?: (
 
     // Copy over child attachments
     for (const child of instance.__r3f.objects) {
+      removeChild(instance, child)
       appendChild(newInstance, child)
       if (child.__r3f.attach) attach(newInstance, child, child.__r3f.attach)
     }

--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -237,10 +237,8 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>, getEventPriority?: (
     // Copy over child attachments
     for (const child of instance.__r3f.objects) {
       appendChild(newInstance, child)
-      if (child.__r3f.attach) {
-        detach(instance, child, child.__r3f.attach)
-        attach(newInstance, child, child.__r3f.attach)
-      }
+      detach(instance, child, child.__r3f.attach!)
+      attach(newInstance, child, child.__r3f.attach!)
     }
     instance.__r3f.objects = []
 

--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -236,9 +236,11 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>, getEventPriority?: (
 
     // Copy over child attachments
     for (const child of instance.__r3f.objects) {
-      removeChild(instance, child)
       appendChild(newInstance, child)
-      if (child.__r3f.attach) attach(newInstance, child, child.__r3f.attach)
+      if (child.__r3f.attach) {
+        detach(instance, child, child.__r3f.attach)
+        attach(newInstance, child, child.__r3f.attach)
+      }
     }
     instance.__r3f.objects = []
 

--- a/packages/fiber/tests/core/renderer.test.tsx
+++ b/packages/fiber/tests/core/renderer.test.tsx
@@ -455,11 +455,20 @@ describe('renderer', () => {
     let state: RootState = null!
     const instances: { uuid: string; parentUUID?: string; childUUID?: string }[] = []
 
+    let lastAttached: Instance = null!
+    let lastDetached: Instance = null!
+
     const Test = ({ n }: { n: number }) => (
       // @ts-ignore args isn't a valid prop but changing it will swap
       <group args={[n]} onPointerOver={() => null}>
         <group />
         <group attach="test" />
+        <group
+          attach={(parent) => {
+            lastAttached = parent
+            return () => void (lastDetached = parent)
+          }}
+        />
       </group>
     )
 
@@ -467,21 +476,21 @@ describe('renderer', () => {
       state = root.render(<Test n={1} />).getState()
     })
 
-    // Has initial attachment
-    expect((state.scene.children[0] as any).test).toBeInstanceOf(THREE.Group)
-
     instances.push({
       uuid: state.scene.children[0].uuid,
       parentUUID: state.scene.children[0].parent?.uuid,
       childUUID: state.scene.children[0].children[0]?.uuid,
     })
 
+    // Has initial attachments
+    expect((state.scene.children[0] as any).test).toBeInstanceOf(THREE.Group)
+    expect(lastAttached).not.toBe(null)
+    expect(lastAttached.uuid).toBe(state.scene.children[0].uuid)
+    expect(lastDetached).toBe(null)
+
     await act(async () => {
       state = root.render(<Test n={2} />).getState()
     })
-
-    // Preserves initial attachment
-    expect((state.scene.children[0] as any).test).toBeInstanceOf(THREE.Group)
 
     instances.push({
       uuid: state.scene.children[0].uuid,
@@ -497,6 +506,13 @@ describe('renderer', () => {
     // Preserves scene hierarchy
     expect(oldInstance.parentUUID).toBe(newInstance.parentUUID)
     expect(oldInstance.childUUID).toBe(newInstance.childUUID)
+
+    // Preserves initial attachments
+    expect((state.scene.children[0] as any).test).toBeInstanceOf(THREE.Group)
+    expect(lastAttached).not.toBe(null)
+    expect(lastAttached.uuid).toBe(newInstance.uuid)
+    expect(lastDetached).not.toBe(null)
+    expect(lastDetached.uuid).toBe(oldInstance.uuid)
 
     // Rebinds events
     expect(state.internal.interaction.length).not.toBe(0)

--- a/packages/fiber/tests/core/renderer.test.tsx
+++ b/packages/fiber/tests/core/renderer.test.tsx
@@ -459,12 +459,16 @@ describe('renderer', () => {
       // @ts-ignore args isn't a valid prop but changing it will swap
       <group args={[n]} onPointerOver={() => null}>
         <group />
+        <group attach="test" />
       </group>
     )
 
     await act(async () => {
       state = root.render(<Test n={1} />).getState()
     })
+
+    // Has initial attachment
+    expect((state.scene.children[0] as any).test).toBeInstanceOf(THREE.Group)
 
     instances.push({
       uuid: state.scene.children[0].uuid,
@@ -475,6 +479,9 @@ describe('renderer', () => {
     await act(async () => {
       state = root.render(<Test n={2} />).getState()
     })
+
+    // Preserves initial attachment
+    expect((state.scene.children[0] as any).test).toBeInstanceOf(THREE.Group)
 
     instances.push({
       uuid: state.scene.children[0].uuid,


### PR DESCRIPTION
Fixes an issue where objects won't have their child attachments copied over.

[Instances (before)](https://codesandbox.io/s/rj6uoo) | [Instances (now)](https://codesandbox.io/s/zo47oc)