### PR TITLE
fix(core): always prepare primitives

### DIFF
--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -85,7 +85,7 @@ function createRenderer<TCanvas>(roots: Map<TCanvas, Root>, getEventPriority?: (
     if (type === 'primitive') {
       if (props.object === undefined) throw `Primitives without 'object' are invalid!`
       const object = props.object as Instance
-      instance = prepare<Instance>(object, { type, root, attach, primitive: true })
+      instance = prepare<Instance>(object, { ...object.__r3f, type, root, attach, primitive: true })
     } else {
       const target = catalogue[name]
       if (!target) {

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -138,7 +138,7 @@ export function dispose<TObj extends { dispose?: () => void; type?: string; [key
 // Each object in the scene carries a small LocalState descriptor
 export function prepare<T = THREE.Object3D>(object: T, state?: Partial<LocalState>) {
   const instance = object as unknown as Instance
-  if (!instance.__r3f) {
+  if (state?.primitive || !instance.__r3f) {
     instance.__r3f = {
       type: '',
       root: null as unknown as UseBoundStore<RootState>,

--- a/packages/fiber/tests/core/renderer.test.tsx
+++ b/packages/fiber/tests/core/renderer.test.tsx
@@ -518,6 +518,38 @@ describe('renderer', () => {
     expect(state.internal.interaction.length).not.toBe(0)
   })
 
+  it('can swap primitives', async () => {
+    let state: RootState = null!
+
+    const o1 = new THREE.Group()
+    o1.add(new THREE.Group())
+    const o2 = new THREE.Group()
+
+    const Test = ({ n }: { n: number }) => (
+      <primitive object={n === 1 ? o1 : o2}>
+        <group attach="test" />
+      </primitive>
+    )
+
+    await act(async () => {
+      state = root.render(<Test n={1} />).getState()
+    })
+
+    // Initial object is added with children and attachments
+    expect(state.scene.children[0]).toBe(o1)
+    expect(state.scene.children[0].children.length).toBe(1)
+    expect((state.scene.children[0] as any).test).toBeInstanceOf(THREE.Group)
+
+    await act(async () => {
+      state = root.render(<Test n={2} />).getState()
+    })
+
+    // Swapped to object 2, does not copy old children, copies attachments
+    expect(state.scene.children[0]).toBe(o2)
+    expect(state.scene.children[0].children.length).toBe(0)
+    expect((state.scene.children[0] as any).test).toBeInstanceOf(THREE.Group)
+  })
+
   it('will make an Orthographic Camera & set the position', async () => {
     let camera: THREE.Camera = null!
 


### PR DESCRIPTION
Reverts the change in #2296 where instances were no longer unconditionally prepped when entering a new R3F root (see https://github.com/pmndrs/react-three-fiber/pull/2296#discussion_r885138009).

This PR accounts for my above nit by only overwriting essential, root-specific local state to allow for foreign instances to be re-used between roots.