### PR TITLE
refactor: revert multi-attach

### DIFF
--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -147,7 +147,7 @@ export function prepare<T = THREE.Object3D>(object: T, state?: Partial<LocalStat
       eventCount: 0,
       handlers: {},
       objects: [],
-      parents: [],
+      parent: null,
       ...state,
     }
   }
@@ -333,7 +333,7 @@ export function applyProps(instance: Instance, data: InstanceProps | DiffSet) {
     invalidateInstance(instance)
   })
 
-  if (localState.parents?.length && rootState.internal && instance.raycast && prevHandlers !== localState.eventCount) {
+  if (localState.parent && rootState.internal && instance.raycast && prevHandlers !== localState.eventCount) {
     // Pre-emptively remove the instance from the interaction manager
     const index = rootState.internal.interaction.indexOf(instance as unknown as THREE.Object3D)
     if (index > -1) rootState.internal.interaction.splice(index, 1)

--- a/packages/fiber/tests/core/renderer.test.tsx
+++ b/packages/fiber/tests/core/renderer.test.tsx
@@ -276,36 +276,6 @@ describe('renderer', () => {
     expect(scene.children[0].children.length).toBe(0)
   })
 
-  it('attaches multiple primitives that use attach', async () => {
-    const mesh = new THREE.Mesh()
-
-    let scene: THREE.Scene = null!
-    await act(async () => {
-      scene = root
-        .render(
-          <>
-            <hasObject3dMember>
-              <primitive object={mesh} attach="attachment" />
-            </hasObject3dMember>
-            <hasObject3dMember>
-              <primitive object={mesh} attach="attachment" />
-            </hasObject3dMember>
-          </>,
-        )
-        .getState().scene
-    })
-
-    const [member1, member2] = scene.children as HasObject3dMember[]
-
-    expect(member1).not.toBe(member2)
-
-    expect(member1.attachment).toBe(mesh)
-    expect(member2.attachment).toBe(mesh)
-
-    expect(member1.children.length).toBe(0)
-    expect(member2.children.length).toBe(0)
-  })
-
   it('can attach a Scene', async () => {
     let scene: THREE.Scene = null!
     await act(async () => {

--- a/packages/test-renderer/src/createTestInstance.ts
+++ b/packages/test-renderer/src/createTestInstance.ts
@@ -24,11 +24,11 @@ export class ReactThreeTestInstance<TInstance extends Object3D = Object3D> {
   }
 
   public get parent(): ReactThreeTestInstance | null {
-    const parents = this._fiber.__r3f.parents
-    if (!parents.length) return null
-
-    const parent = parents[parents.length - 1]
-    return wrapFiber(parent)
+    const parent = this._fiber.__r3f.parent
+    if (parent !== null) {
+      return wrapFiber(parent)
+    }
+    return parent
   }
 
   public get children(): ReactThreeTestInstance[] {

--- a/packages/test-renderer/src/types/internal.ts
+++ b/packages/test-renderer/src/types/internal.ts
@@ -6,10 +6,10 @@ import type { BaseInstance, LocalState, RootState } from '@react-three/fiber'
 export type MockUseStoreState = UseBoundStore<RootState>
 
 export interface MockInstance extends Omit<BaseInstance, '__r3f'> {
-  __r3f: Omit<LocalState, 'root' | 'objects' | 'parents'> & {
+  __r3f: Omit<LocalState, 'root' | 'objects' | 'parent'> & {
     root: MockUseStoreState
     objects: MockSceneChild[]
-    parents: MockInstance[]
+    parent: MockInstance
   }
 }
 


### PR DESCRIPTION
Reverts #2296 and #2305 where attached elements were incorrectly allowed in different areas of the tree and between different roots (related: #2294).