### PR TITLE
Point to correct minimum React version in docs

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -8,7 +8,7 @@ nav: 1
 npm install three @react-three/fiber
 ```
 
-> Fiber is compatible with React v16.8+ and works with ReactDOM and React Native.
+> Fiber is compatible with React v18.0.0+ and works with ReactDOM and React Native.
 
 Getting started with React Three Fiber is not nearly has hard as you might have thought, but various frameworks may require particular attention.
 


### PR DESCRIPTION
R3F has a peer dep on React 18.0.0 but the docs starts saying it needs React v16.8+