### PR TITLE
Fix typo in `installation.md`

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -10,7 +10,7 @@ npm install three @react-three/fiber
 
 > Fiber is compatible with React v18.0.0+ and works with ReactDOM and React Native.
 
-Getting started with React Three Fiber is not nearly has hard as you might have thought, but various frameworks may require particular attention.
+Getting started with React Three Fiber is not nearly as hard as you might have thought, but various frameworks may require particular attention.
 
 We've put together guides for getting started with each popular framework:
 


### PR DESCRIPTION
Correct `has` to `as` in:

> Getting started with React Three Fiber is not nearly **has** hard as you might have thought