### PR TITLE
fix(core): resume render loop on session end

### DIFF
--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -215,12 +215,11 @@ function createRoot<TCanvas extends Element>(canvas: TCanvas): ReconcilerRoot<TC
 
         // Toggle render switching on session
         const handleSessionChange = () => {
-          const gl = store.getState().gl
-          gl.xr.enabled = gl.xr.isPresenting
-          // @ts-ignore
-          // WebXRManager's signature is incorrect.
-          // See: https://github.com/pmndrs/react-three-fiber/pull/2017#discussion_r790134505
-          gl.xr.setAnimationLoop(gl.xr.isPresenting ? handleXRFrame : null)
+          const state = store.getState()
+          state.gl.xr.enabled = state.gl.xr.isPresenting
+
+          state.gl.xr.setAnimationLoop(state.gl.xr.isPresenting ? handleXRFrame : null)
+          if (!state.gl.xr.isPresenting) invalidate(state)
         }
 
         // WebXR session manager


### PR DESCRIPTION
Restarts R3F's internal render loop on session end to resume rendering outside of sessions.