### PR TITLE
Expose ThreeElements interface

### DIFF
--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -243,168 +243,170 @@ export type FogProps = Node<THREE.Fog, typeof THREE.Fog>
 export type FogExp2Props = Node<THREE.FogExp2, typeof THREE.FogExp2>
 export type ShapeProps = Node<THREE.Shape, typeof THREE.Shape>
 
+export interface ThreeElements {
+  object3D: Object3DProps
+
+  // `audio` works but conflicts with @types/react. Try using Audio from react-three-fiber/components instead
+  // audio: AudioProps
+  audioListener: AudioListenerProps
+  positionalAudio: PositionalAudioProps
+
+  mesh: MeshProps
+  instancedMesh: InstancedMeshProps
+  scene: SceneProps
+  sprite: SpriteProps
+  lOD: LODProps
+  skinnedMesh: SkinnedMeshProps
+  skeleton: SkeletonProps
+  bone: BoneProps
+  lineSegments: LineSegmentsProps
+  lineLoop: LineLoopProps
+  // see `audio`
+  // line: LineProps
+  points: PointsProps
+  group: GroupProps
+
+  // cameras
+  camera: CameraProps
+  perspectiveCamera: PerspectiveCameraProps
+  orthographicCamera: OrthographicCameraProps
+  cubeCamera: CubeCameraProps
+  arrayCamera: ArrayCameraProps
+
+  // geometry
+  instancedBufferGeometry: InstancedBufferGeometryProps
+  bufferGeometry: BufferGeometryProps
+  boxBufferGeometry: BoxBufferGeometryProps
+  circleBufferGeometry: CircleBufferGeometryProps
+  coneBufferGeometry: ConeBufferGeometryProps
+  cylinderBufferGeometry: CylinderBufferGeometryProps
+  dodecahedronBufferGeometry: DodecahedronBufferGeometryProps
+  extrudeBufferGeometry: ExtrudeBufferGeometryProps
+  icosahedronBufferGeometry: IcosahedronBufferGeometryProps
+  latheBufferGeometry: LatheBufferGeometryProps
+  octahedronBufferGeometry: OctahedronBufferGeometryProps
+  planeBufferGeometry: PlaneBufferGeometryProps
+  polyhedronBufferGeometry: PolyhedronBufferGeometryProps
+  ringBufferGeometry: RingBufferGeometryProps
+  shapeBufferGeometry: ShapeBufferGeometryProps
+  sphereBufferGeometry: SphereBufferGeometryProps
+  tetrahedronBufferGeometry: TetrahedronBufferGeometryProps
+  torusBufferGeometry: TorusBufferGeometryProps
+  torusKnotBufferGeometry: TorusKnotBufferGeometryProps
+  tubeBufferGeometry: TubeBufferGeometryProps
+  wireframeGeometry: WireframeGeometryProps
+  tetrahedronGeometry: TetrahedronGeometryProps
+  octahedronGeometry: OctahedronGeometryProps
+  icosahedronGeometry: IcosahedronGeometryProps
+  dodecahedronGeometry: DodecahedronGeometryProps
+  polyhedronGeometry: PolyhedronGeometryProps
+  tubeGeometry: TubeGeometryProps
+  torusKnotGeometry: TorusKnotGeometryProps
+  torusGeometry: TorusGeometryProps
+  sphereGeometry: SphereGeometryProps
+  ringGeometry: RingGeometryProps
+  planeGeometry: PlaneGeometryProps
+  latheGeometry: LatheGeometryProps
+  shapeGeometry: ShapeGeometryProps
+  extrudeGeometry: ExtrudeGeometryProps
+  edgesGeometry: EdgesGeometryProps
+  coneGeometry: ConeGeometryProps
+  cylinderGeometry: CylinderGeometryProps
+  circleGeometry: CircleGeometryProps
+  boxGeometry: BoxGeometryProps
+  capsuleGeometry: CapsuleGeometryProps
+
+  // materials
+  material: MaterialProps
+  shadowMaterial: ShadowMaterialProps
+  spriteMaterial: SpriteMaterialProps
+  rawShaderMaterial: RawShaderMaterialProps
+  shaderMaterial: ShaderMaterialProps
+  pointsMaterial: PointsMaterialProps
+  meshPhysicalMaterial: MeshPhysicalMaterialProps
+  meshStandardMaterial: MeshStandardMaterialProps
+  meshPhongMaterial: MeshPhongMaterialProps
+  meshToonMaterial: MeshToonMaterialProps
+  meshNormalMaterial: MeshNormalMaterialProps
+  meshLambertMaterial: MeshLambertMaterialProps
+  meshDepthMaterial: MeshDepthMaterialProps
+  meshDistanceMaterial: MeshDistanceMaterialProps
+  meshBasicMaterial: MeshBasicMaterialProps
+  meshMatcapMaterial: MeshMatcapMaterialProps
+  lineDashedMaterial: LineDashedMaterialProps
+  lineBasicMaterial: LineBasicMaterialProps
+
+  // primitive
+  primitive: PrimitiveProps
+
+  // lights and other
+  light: LightProps
+  spotLightShadow: SpotLightShadowProps
+  spotLight: SpotLightProps
+  pointLight: PointLightProps
+  rectAreaLight: RectAreaLightProps
+  hemisphereLight: HemisphereLightProps
+  directionalLightShadow: DirectionalLightShadowProps
+  directionalLight: DirectionalLightProps
+  ambientLight: AmbientLightProps
+  lightShadow: LightShadowProps
+  ambientLightProbe: AmbientLightProbeProps
+  hemisphereLightProbe: HemisphereLightProbeProps
+  lightProbe: LightProbeProps
+
+  // helpers
+  spotLightHelper: SpotLightHelperProps
+  skeletonHelper: SkeletonHelperProps
+  pointLightHelper: PointLightHelperProps
+  hemisphereLightHelper: HemisphereLightHelperProps
+  gridHelper: GridHelperProps
+  polarGridHelper: PolarGridHelperProps
+  directionalLightHelper: DirectionalLightHelperProps
+  cameraHelper: CameraHelperProps
+  boxHelper: BoxHelperProps
+  box3Helper: Box3HelperProps
+  planeHelper: PlaneHelperProps
+  arrowHelper: ArrowHelperProps
+  axesHelper: AxesHelperProps
+
+  // textures
+  texture: TextureProps
+  videoTexture: VideoTextureProps
+  dataTexture: DataTextureProps
+  dataTexture3D: DataTexture3DProps
+  compressedTexture: CompressedTextureProps
+  cubeTexture: CubeTextureProps
+  canvasTexture: CanvasTextureProps
+  depthTexture: DepthTextureProps
+
+  // misc
+  raycaster: RaycasterProps
+  vector2: Vector2Props
+  vector3: Vector3Props
+  vector4: Vector4Props
+  euler: EulerProps
+  matrix3: Matrix3Props
+  matrix4: Matrix4Props
+  quaternion: QuaternionProps
+  bufferAttribute: BufferAttributeProps
+  float16BufferAttribute: Float16BufferAttributeProps
+  float32BufferAttribute: Float32BufferAttributeProps
+  float64BufferAttribute: Float64BufferAttributeProps
+  int8BufferAttribute: Int8BufferAttributeProps
+  int16BufferAttribute: Int16BufferAttributeProps
+  int32BufferAttribute: Int32BufferAttributeProps
+  uint8BufferAttribute: Uint8BufferAttributeProps
+  uint16BufferAttribute: Uint16BufferAttributeProps
+  uint32BufferAttribute: Uint32BufferAttributeProps
+  instancedBufferAttribute: InstancedBufferAttributeProps
+  color: ColorProps
+  fog: FogProps
+  fogExp2: FogExp2Props
+  shape: ShapeProps
+}
+
 declare global {
   namespace JSX {
-    interface IntrinsicElements {
-      object3D: Object3DProps
-
-      // `audio` works but conflicts with @types/react. Try using Audio from react-three-fiber/components instead
-      // audio: AudioProps
-      audioListener: AudioListenerProps
-      positionalAudio: PositionalAudioProps
-
-      mesh: MeshProps
-      instancedMesh: InstancedMeshProps
-      scene: SceneProps
-      sprite: SpriteProps
-      lOD: LODProps
-      skinnedMesh: SkinnedMeshProps
-      skeleton: SkeletonProps
-      bone: BoneProps
-      lineSegments: LineSegmentsProps
-      lineLoop: LineLoopProps
-      // see `audio`
-      // line: LineProps
-      points: PointsProps
-      group: GroupProps
-
-      // cameras
-      camera: CameraProps
-      perspectiveCamera: PerspectiveCameraProps
-      orthographicCamera: OrthographicCameraProps
-      cubeCamera: CubeCameraProps
-      arrayCamera: ArrayCameraProps
-
-      // geometry
-      instancedBufferGeometry: InstancedBufferGeometryProps
-      bufferGeometry: BufferGeometryProps
-      boxBufferGeometry: BoxBufferGeometryProps
-      circleBufferGeometry: CircleBufferGeometryProps
-      coneBufferGeometry: ConeBufferGeometryProps
-      cylinderBufferGeometry: CylinderBufferGeometryProps
-      dodecahedronBufferGeometry: DodecahedronBufferGeometryProps
-      extrudeBufferGeometry: ExtrudeBufferGeometryProps
-      icosahedronBufferGeometry: IcosahedronBufferGeometryProps
-      latheBufferGeometry: LatheBufferGeometryProps
-      octahedronBufferGeometry: OctahedronBufferGeometryProps
-      planeBufferGeometry: PlaneBufferGeometryProps
-      polyhedronBufferGeometry: PolyhedronBufferGeometryProps
-      ringBufferGeometry: RingBufferGeometryProps
-      shapeBufferGeometry: ShapeBufferGeometryProps
-      sphereBufferGeometry: SphereBufferGeometryProps
-      tetrahedronBufferGeometry: TetrahedronBufferGeometryProps
-      torusBufferGeometry: TorusBufferGeometryProps
-      torusKnotBufferGeometry: TorusKnotBufferGeometryProps
-      tubeBufferGeometry: TubeBufferGeometryProps
-      wireframeGeometry: WireframeGeometryProps
-      tetrahedronGeometry: TetrahedronGeometryProps
-      octahedronGeometry: OctahedronGeometryProps
-      icosahedronGeometry: IcosahedronGeometryProps
-      dodecahedronGeometry: DodecahedronGeometryProps
-      polyhedronGeometry: PolyhedronGeometryProps
-      tubeGeometry: TubeGeometryProps
-      torusKnotGeometry: TorusKnotGeometryProps
-      torusGeometry: TorusGeometryProps
-      sphereGeometry: SphereGeometryProps
-      ringGeometry: RingGeometryProps
-      planeGeometry: PlaneGeometryProps
-      latheGeometry: LatheGeometryProps
-      shapeGeometry: ShapeGeometryProps
-      extrudeGeometry: ExtrudeGeometryProps
-      edgesGeometry: EdgesGeometryProps
-      coneGeometry: ConeGeometryProps
-      cylinderGeometry: CylinderGeometryProps
-      circleGeometry: CircleGeometryProps
-      boxGeometry: BoxGeometryProps
-      capsuleGeometry: CapsuleGeometryProps
-
-      // materials
-      material: MaterialProps
-      shadowMaterial: ShadowMaterialProps
-      spriteMaterial: SpriteMaterialProps
-      rawShaderMaterial: RawShaderMaterialProps
-      shaderMaterial: ShaderMaterialProps
-      pointsMaterial: PointsMaterialProps
-      meshPhysicalMaterial: MeshPhysicalMaterialProps
-      meshStandardMaterial: MeshStandardMaterialProps
-      meshPhongMaterial: MeshPhongMaterialProps
-      meshToonMaterial: MeshToonMaterialProps
-      meshNormalMaterial: MeshNormalMaterialProps
-      meshLambertMaterial: MeshLambertMaterialProps
-      meshDepthMaterial: MeshDepthMaterialProps
-      meshDistanceMaterial: MeshDistanceMaterialProps
-      meshBasicMaterial: MeshBasicMaterialProps
-      meshMatcapMaterial: MeshMatcapMaterialProps
-      lineDashedMaterial: LineDashedMaterialProps
-      lineBasicMaterial: LineBasicMaterialProps
-
-      // primitive
-      primitive: PrimitiveProps
-
-      // lights and other
-      light: LightProps
-      spotLightShadow: SpotLightShadowProps
-      spotLight: SpotLightProps
-      pointLight: PointLightProps
-      rectAreaLight: RectAreaLightProps
-      hemisphereLight: HemisphereLightProps
-      directionalLightShadow: DirectionalLightShadowProps
-      directionalLight: DirectionalLightProps
-      ambientLight: AmbientLightProps
-      lightShadow: LightShadowProps
-      ambientLightProbe: AmbientLightProbeProps
-      hemisphereLightProbe: HemisphereLightProbeProps
-      lightProbe: LightProbeProps
-
-      // helpers
-      spotLightHelper: SpotLightHelperProps
-      skeletonHelper: SkeletonHelperProps
-      pointLightHelper: PointLightHelperProps
-      hemisphereLightHelper: HemisphereLightHelperProps
-      gridHelper: GridHelperProps
-      polarGridHelper: PolarGridHelperProps
-      directionalLightHelper: DirectionalLightHelperProps
-      cameraHelper: CameraHelperProps
-      boxHelper: BoxHelperProps
-      box3Helper: Box3HelperProps
-      planeHelper: PlaneHelperProps
-      arrowHelper: ArrowHelperProps
-      axesHelper: AxesHelperProps
-
-      // textures
-      texture: TextureProps
-      videoTexture: VideoTextureProps
-      dataTexture: DataTextureProps
-      dataTexture3D: DataTexture3DProps
-      compressedTexture: CompressedTextureProps
-      cubeTexture: CubeTextureProps
-      canvasTexture: CanvasTextureProps
-      depthTexture: DepthTextureProps
-
-      // misc
-      raycaster: RaycasterProps
-      vector2: Vector2Props
-      vector3: Vector3Props
-      vector4: Vector4Props
-      euler: EulerProps
-      matrix3: Matrix3Props
-      matrix4: Matrix4Props
-      quaternion: QuaternionProps
-      bufferAttribute: BufferAttributeProps
-      float16BufferAttribute: Float16BufferAttributeProps
-      float32BufferAttribute: Float32BufferAttributeProps
-      float64BufferAttribute: Float64BufferAttributeProps
-      int8BufferAttribute: Int8BufferAttributeProps
-      int16BufferAttribute: Int16BufferAttributeProps
-      int32BufferAttribute: Int32BufferAttributeProps
-      uint8BufferAttribute: Uint8BufferAttributeProps
-      uint16BufferAttribute: Uint16BufferAttributeProps
-      uint32BufferAttribute: Uint32BufferAttributeProps
-      instancedBufferAttribute: InstancedBufferAttributeProps
-      color: ColorProps
-      fog: FogProps
-      fogExp2: FogExp2Props
-      shape: ShapeProps
-    }
+    interface IntrinsicElements extends ThreeElements {}
   }
 }


### PR DESCRIPTION
This PR directly exposes all the r3f-specific React element types, instead of directly augmenting `JSX.IntrinsicElements`. `JSX.IntrinsicElements` still gets augmented, so it is fully backwards-compatible:

```ts
export interface ThreeElements {
  // ...
}

declare global {
  namespace JSX {
    interface IntrinsicElements extends ThreeElements {}
  }
}
```

This would be very useful for libraries that need to map over, or validate against r3f elements, like `@theatre/r3f` or `@react-spring/three`. Currently the only option is to use `JSX.IntrinsicElements`, which results in incorrect types that are way too broad and include other elements too, like those from `react-dom`. Furthermore since `JSX.IntrinsicElements` is huge, it can easily result in types that are either too complex for the type checker to handle, or too large for the compiler to serialize.

An interesting thing about the way this is solved in this PR, is that augmenting `ThreeElements` in turn will also augment `JSX.IntrinsicElements`:

```ts
declare module '@react-three/fiber' {
  interface ThreeElements {
    myMesh: Object3DNode<MyMesh, typeof MyMesh>
  }
}
```

The effect is that users would only have to augment a single interface, and it would automatically also work with all other libraries that depend on `ThreeElements`, while also exposing these elements in React.