### PR TITLE
Add automated prerelease builds for V9

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,4 +1,4 @@
-name: V9 Canary Builds
+name: V9 Prerelease Builds
 
 on:
   push:
@@ -9,7 +9,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   canary_release:
-    name: Release V9 Canary
+    name: Release V9 Prelelase
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -36,5 +36,5 @@ jobs:
 
       - name: Publish Snapshot Release
         run: |
-          yarn changeset version --snapshot canary
-          yarn release --no-git-tag --snapshot canary --tag canary
+          yarn changeset version --snapshot next
+          yarn release --no-git-tag --snapshot next --tag next

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,40 @@
+name: V9 Canary Builds
+
+on:
+  push:
+    branches:
+      - v9
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  canary_release:
+    name: Release V9 Canary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+        with:
+          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
+          fetch-depth: 0
+
+      - name: Setup Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Create .npmrc
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish Snapshot Release
+        run: |
+          yarn changeset version --snapshot canary
+          yarn release --no-git-tag --snapshot canary --tag canary

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -9,7 +9,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   canary_release:
-    name: Release V9 Prelelase
+    name: V9 Prerelase
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
As discussed on Discord, this sets up automated preleases for the V9 branch. Every push to `v9` will cause this action to publish a new version to NPM, using the `next` tag.

- Obviously, there's no way for me to test this; but it is based on the [configuration](https://github.com/hmans/three-vfx/blob/bac2ff8a07a61d03d1e58fcd045a7a8a7e5db9f8/.github/workflows/release.yml#L43-L72) I've been using successfully in my vfx repo. I recommend running the last two comments in the script manually once to see if and how they work.
- This action requires an `NPM_TOKEN` secret to be configured.
- It's possible this will only activate when `changesets` detects unpublished changesets.
- I **heavily** recommend integrating the `yarn test` task into `yarn release`, so new builds are only published when tests succeed.