### PR TITLE
refactor: renderer update

### DIFF
--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -108,7 +108,7 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
 
     // It should NOT call onUpdate on object instanciation, because it hasn't been added to the
     // view yet. If the callback relies on references for instance, they won't be ready yet, this is
-    // why it passes “true” here
+    // why it passes "true" here
     // There is no reason to apply props to injects
     if (name !== 'inject') applyProps(instance, props)
     return instance


### PR DESCRIPTION
This PR contains refactor of the renderer, which means:
- Passes all types to type parameters to `Reconciler`. It simplified the API and will avoid potential typing problems.
- React-reconciler has some additional required properties, which we have missed (`supportsPersistence` and `supportsHydration`)
- Removes some `ts-ignore`, which makes the API a little bit more bulletproof.
- Fixes some linting issues and typos ;)

Btw. I'm currently learning Fiber and Reconciler and I'm so grateful because this is a superb playground and benchmark how it should work! Thanks so much! 🎉 