### PR TITLE
fix: replace IntrinsicElements with ThreeElements

### DIFF
--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -89,9 +89,9 @@ npm install @types/three
 import * as THREE from 'three'
 import { createRoot } from 'react-dom/client'
 import React, { useRef, useState } from 'react'
-import { Canvas, useFrame } from '@react-three/fiber'
+import { Canvas, useFrame, ThreeElements } from '@react-three/fiber'
 
-function Box(props: JSX.IntrinsicElements['mesh']) {
+function Box(props: ThreeElements['mesh']) {
   const mesh = useRef<THREE.Mesh>(null!)
   const [hovered, setHover] = useState(false)
   const [active, setActive] = useState(false)

--- a/docs/tutorials/typescript.mdx
+++ b/docs/tutorials/typescript.mdx
@@ -101,7 +101,7 @@ MaterialNode
 LightNode
 ```
 
-### Extending JSX.IntrinsicElements
+### Extending ThreeElements
 
 Since our custom element is an object, we'll use `Object3DNode` to define it.
 
@@ -116,12 +116,10 @@ class CustomElement extends GridHelper {}
 // Extend so the reconciler will learn about it
 extend({ CustomElement })
 
-// Add types to JSX.Intrinsic elements so primitives pick up on it
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      customElement: Object3DNode<CustomElement, typeof CustomElement>
-    }
+// Add types to ThreeElements elements so primitives pick up on it
+declare module '@react-three/fiber' {
+  interface ThreeElements {
+    customElement: Object3DNode<CustomElement, typeof CustomElement>
   }
 }
 

--- a/example/src/demos/Lines.tsx
+++ b/example/src/demos/Lines.tsx
@@ -1,16 +1,7 @@
 import React, { useRef, useEffect, useState, useCallback, useContext, useMemo } from 'react'
 import { extend, Canvas, useThree, ReactThreeFiber } from '@react-three/fiber'
-// @ts-ignore
 import { OrbitControls } from 'three-stdlib'
 extend({ OrbitControls })
-
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      orbitControls: ReactThreeFiber.Node<OrbitControls, typeof OrbitControls>
-    }
-  }
-}
 
 function useHover(stopPropagation = true) {
   const [hovered, setHover] = useState(false)

--- a/example/src/demos/Pointcloud.tsx
+++ b/example/src/demos/Pointcloud.tsx
@@ -1,8 +1,10 @@
+import React, { useRef, useEffect, useState, useCallback, useContext, useMemo } from 'react'
+import { extend, Canvas, useThree, ReactThreeFiber } from '@react-three/fiber'
 import * as THREE from 'three'
-import React, { useMemo, useRef, useCallback } from 'react'
-import { Canvas, extend, Object3DNode } from '@react-three/fiber'
+import { OrbitControls } from 'three-stdlib'
+extend({ OrbitControls })
 
-class DotMaterial extends THREE.ShaderMaterial {
+export class DotMaterial extends THREE.ShaderMaterial {
   constructor() {
     super({
       transparent: true,
@@ -18,14 +20,6 @@ class DotMaterial extends THREE.ShaderMaterial {
 }
 
 extend({ DotMaterial })
-
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      dotMaterial: Object3DNode<DotMaterial, typeof DotMaterial>
-    }
-  }
-}
 
 const white = new THREE.Color('white')
 const hotpink = new THREE.Color('hotpink')

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "ESNext",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "types": ["vite/client"],
     "allowJs": false,
     "skipLibCheck": false,
     "esModuleInterop": false,
@@ -16,5 +15,5 @@
     "noEmit": true,
     "jsx": "react"
   },
-  "include": ["./src", "../packages/*"]
+  "include": ["./src", "./typings/*.d.ts", "../packages/*"]
 }

--- a/example/typings/global.d.ts
+++ b/example/typings/global.d.ts
@@ -1,0 +1,11 @@
+import { ReactThreeFiber } from '@react-three/fiber'
+import { OrbitControls } from 'three-stdlib'
+
+import { DotMaterial } from '../src/demos/Pointcloud'
+
+declare module '@react-three/fiber' {
+  interface ThreeElements {
+    orbitControls: ReactThreeFiber.Node<OrbitControls, typeof OrbitControls>
+    dotMaterial: ReactThreeFiber.MaterialNode<DotMaterial, typeof DotMaterial>
+  }
+}

--- a/packages/fiber/tests/core/renderer.test.tsx
+++ b/packages/fiber/tests/core/renderer.test.tsx
@@ -53,14 +53,12 @@ class MyGroup extends THREE.Group {}
 
 extend({ HasObject3dMember, HasObject3dMethods, MyGroup })
 
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      hasObject3dMember: ReactThreeFiber.Node<HasObject3dMember, typeof HasObject3dMember>
-      hasObject3dMethods: ReactThreeFiber.Node<HasObject3dMethods, typeof HasObject3dMethods>
-      myColor: ReactThreeFiber.Node<MyColor, typeof MyColor>
-      myGroup: Overwrite<ReactThreeFiber.Object3DNode<THREE.Group, typeof THREE.Group>, { args?: any }>
-    }
+declare module '@react-three/fiber' {
+  interface ThreeElements {
+    hasObject3dMember: ReactThreeFiber.Node<HasObject3dMember, typeof HasObject3dMember>
+    hasObject3dMethods: ReactThreeFiber.Node<HasObject3dMethods, typeof HasObject3dMethods>
+    myColor: ReactThreeFiber.Node<MyColor, typeof MyColor>
+    myGroup: Overwrite<ReactThreeFiber.Object3DNode<THREE.Group, typeof THREE.Group>, { args?: any }>
   }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -89,9 +89,9 @@ npm install @types/three
 import * as THREE from 'three'
 import { createRoot } from 'react-dom/client'
 import React, { useRef, useState } from 'react'
-import { Canvas, useFrame } from '@react-three/fiber'
+import { Canvas, useFrame, ThreeElements } from '@react-three/fiber'
 
-function Box(props: JSX.IntrinsicElements['mesh']) {
+function Box(props: ThreeElements['mesh']) {
   const ref = useRef<THREE.Mesh>(null!)
   const [hovered, hover] = useState(false)
   const [clicked, click] = useState(false)
@@ -116,7 +116,7 @@ createRoot(document.getElementById('root') as HTMLElement).render(
     <pointLight position={[10, 10, 10]} />
     <Box position={[-1.2, 0, 0]} />
     <Box position={[1.2, 0, 0]} />
-  </Canvas>
+  </Canvas>,
 )
 ```
 


### PR DESCRIPTION
This PR replaces all cases where we had the old approach of typing:
```
declare global {
  namespace JSX {
    interface IntrinsicElements extends ThreeElements {}
  }
}
```

with the new one:
```
declare module '@react-three/fiber' {
  interface ThreeElements {
    myMesh: Object3DNode<MyMesh, typeof MyMesh>
  }
}
```