### PR TITLE
Fix: initial canvas size computation in createRoot

### DIFF
--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -109,7 +109,7 @@ const createRendererInstance = <TElement extends HTMLCanvasElement>(
   else
     return new THREE.WebGLRenderer({
       powerPreference: 'high-performance',
-      canvas: canvas as unknown as HTMLCanvasElement,
+      canvas: canvas,
       antialias: true,
       alpha: true,
       ...gl,

--- a/packages/fiber/src/core/loop.ts
+++ b/packages/fiber/src/core/loop.ts
@@ -3,12 +3,12 @@ import { Root } from './renderer'
 import { RootState, Subscription } from './store'
 
 type GlobalRenderCallback = (timeStamp: number) => void
-type SubItem = {callback: GlobalRenderCallback}
+type SubItem = { callback: GlobalRenderCallback }
 
 function createSubs(callback: GlobalRenderCallback, subs: Set<SubItem>): () => void {
-  const sub = {callback}
-  subs.add(sub);
-  return () => void subs.delete(sub);
+  const sub = { callback }
+  subs.add(sub)
+  return () => void subs.delete(sub)
 }
 
 let i
@@ -35,7 +35,7 @@ export const addAfterEffect = (callback: GlobalRenderCallback) => createSubs(cal
 export const addTail = (callback: GlobalRenderCallback) => createSubs(callback, globalTailEffects)
 
 function run(effects: Set<SubItem>, timestamp: number) {
-  effects.forEach(({callback}) => callback(timestamp))
+  effects.forEach(({ callback }) => callback(timestamp))
 }
 
 let subscribers: Subscription[]


### PR DESCRIPTION
As @madou noted [here](https://github.com/pmndrs/drei/issues/944#issuecomment-1193931385), the `clientTop` used in the previous MR around

Seems this would only effect users of direct `createRoot` and not `Canvas` but still worth correcting.

Did a small amount of boyscoutting to remove `let`s and improve types here. The notable change is using a typeguard to throw at the top of `createRoot` if the supplied element is not a canvas. This allows cleaner typings after the guard. Specifically, the same `canvas` variable is later passed to `createRendererInstance` where it is cast to `HTMLCanvasElement` and I assume would fail if the cast is inaccurate. Happy to revert this part of the change if it is not desired.