### PR TITLE
Accept readonly arrays for vector props

### DIFF
--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -11,10 +11,20 @@ export type Overwrite<T, O> = Omit<T, NonFunctionKeys<O>> & O
 type Args<T> = T extends new (...args: any) => any ? ConstructorParameters<T> : T
 
 export type Euler = THREE.Euler | Parameters<THREE.Euler['set']>
-export type Matrix4 = THREE.Matrix4 | Parameters<THREE.Matrix4['set']>
-export type Vector2 = THREE.Vector2 | Parameters<THREE.Vector2['set']> | Parameters<THREE.Vector2['setScalar']>[0]
-export type Vector3 = THREE.Vector3 | Parameters<THREE.Vector3['set']> | Parameters<THREE.Vector3['setScalar']>[0]
-export type Vector4 = THREE.Vector4 | Parameters<THREE.Vector4['set']> | Parameters<THREE.Vector4['setScalar']>[0]
+export type Matrix4 = THREE.Matrix4 | Parameters<THREE.Matrix4['set']> | Readonly<THREE.Matrix4['set']>
+
+/**
+ * Turn an implementation of THREE.Vector in to the type that an r3f component would accept as a prop.
+ */
+type VectorLike<VectorClass extends THREE.Vector> =
+  | VectorClass
+  | Parameters<VectorClass['set']>
+  | Readonly<Parameters<VectorClass['set']>>
+  | Parameters<VectorClass['setScalar']>[0]
+
+export type Vector2 = VectorLike<THREE.Vector2>
+export type Vector3 = VectorLike<THREE.Vector3>
+export type Vector4 = VectorLike<THREE.Vector4>
 export type Color = ConstructorParameters<typeof THREE.Color> | THREE.Color | number | string // Parameters<T> will not work here because of multiple function signatures in three.js types
 export type ColorArray = typeof THREE.Color | Parameters<THREE.Color['set']>
 export type Layers = THREE.Layers | Parameters<THREE.Layers['set']>[0]


### PR DESCRIPTION
Closes #2374 

Also supports `readonly` variants of other vectors and `THREE.Matrix4`