### PR TITLE
Rename `Props` to `CanvasProps`

### DIFF
--- a/.changeset/lemon-glasses-kneel.md
+++ b/.changeset/lemon-glasses-kneel.md
@@ -1,0 +1,5 @@
+---
+'@react-three/fiber': major
+---
+
+fsdf

--- a/.changeset/lemon-glasses-kneel.md
+++ b/.changeset/lemon-glasses-kneel.md
@@ -2,4 +2,4 @@
 '@react-three/fiber': major
 ---
 
-fsdf
+**Breaking Change:** Renamed the props interfaces exported by `web/Canvas.tsx` and `mobile/Canvas.tsx` from the generic `Props` to the more specific `CanvasProps`.

--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -8,7 +8,7 @@ import { createTouchEvents } from './events'
 import { RootState, Size } from '../core/store'
 import { polyfills } from './polyfills'
 
-export interface Props extends Omit<RenderProps<HTMLCanvasElement>, 'size' | 'dpr'>, ViewProps {
+export interface CanvasProps extends Omit<RenderProps<HTMLCanvasElement>, 'size' | 'dpr'>, ViewProps {
   children: React.ReactNode
   style?: ViewStyle
 }
@@ -17,7 +17,7 @@ export interface Props extends Omit<RenderProps<HTMLCanvasElement>, 'size' | 'dp
  * A native canvas which accepts threejs elements as children.
  * @see https://docs.pmnd.rs/react-three-fiber/api/canvas
  */
-export const Canvas = /*#__PURE__*/ React.forwardRef<View, Props>(
+export const Canvas = /*#__PURE__*/ React.forwardRef<View, CanvasProps>(
   (
     {
       children,

--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -6,7 +6,9 @@ import { SetBlock, Block, ErrorBoundary, useMutableCallback, useIsomorphicLayout
 import { ReconcilerRoot, extend, createRoot, unmountComponentAtNode, RenderProps } from '../core'
 import { createPointerEvents } from './events'
 
-export interface Props extends Omit<RenderProps<HTMLCanvasElement>, 'size'>, React.HTMLAttributes<HTMLDivElement> {
+export interface CanvasProps
+  extends Omit<RenderProps<HTMLCanvasElement>, 'size'>,
+    React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode
   /** Canvas fallback content, similar to img's alt prop */
   fallback?: React.ReactNode
@@ -21,7 +23,7 @@ export interface Props extends Omit<RenderProps<HTMLCanvasElement>, 'size'>, Rea
  * A DOM canvas which accepts threejs elements as children.
  * @see https://docs.pmnd.rs/react-three-fiber/api/canvas
  */
-export const Canvas = /*#__PURE__*/ React.forwardRef<HTMLCanvasElement, Props>(function Canvas(
+export const Canvas = /*#__PURE__*/ React.forwardRef<HTMLCanvasElement, CanvasProps>(function Canvas(
   {
     children,
     fallback,


### PR DESCRIPTION
- Renames the somewhat generically named `Props` interfaces from both `Canvas.tsx` modules to a more specific `CanvasProps`.
- The (minor) unrelated formatting changes were, I think/hope, Prettier picking up the repository's `.prettierrc`.
- Changeset included.
