### PR TITLE
docs: remove usage of *BufferGeometry

### DIFF
--- a/docs/API/canvas.mdx
+++ b/docs/API/canvas.mdx
@@ -14,7 +14,7 @@ const App = () => (
   <Canvas>
     <pointLight position={[10, 10, 10]} />
     <mesh>
-      <sphereBufferGeometry />
+      <sphereGeometry />
       <meshStandardMaterial color="hotpink" />
     </mesh>
   </Canvas>

--- a/docs/advanced/pitfalls.mdx
+++ b/docs/advanced/pitfalls.mdx
@@ -11,7 +11,7 @@ This is a good overview: https://discoverthreejs.com/tips-and-tricks
 The most important gotcha in three.js is that creating objects can be expensive, think twice before you mount/unmount things! Every material or light that you put into the scene has to compile, every geometry you create will be processed. Share materials and geometries if you can, either in global scope or locally:
 
 ```jsx
-const geom = useMemo(() => new BoxBufferGeometry(), [])
+const geom = useMemo(() => new BoxGeometry(), [])
 const mat = useMemo(() => new MeshBasicMaterial(), [])
 return items.map(i => <mesh geometry={geom} material={mat} ...
 ```

--- a/docs/tutorials/how-it-works.mdx
+++ b/docs/tutorials/how-it-works.mdx
@@ -21,7 +21,7 @@ function MyApp() {
       <group>
         <mesh>
           <meshNormalMaterial />
-          <boxBufferGeometry args={[2, 2, 2]} />
+          <boxGeometry args={[2, 2, 2]} />
         </mesh>
       </group>
     </Canvas>
@@ -40,7 +40,7 @@ const group = new THREE.Group() // <group>
 
 const mesh = new THREE.Mesh() // <mesh />
 const material = new THREE.MeshNormalMaterial() // <meshNormalMaterial />
-const geometry = new THREE.BoxBufferGeometry(2, 2, 2) // <boxBufferGeometry />
+const geometry = new THREE.BoxGeometry(2, 2, 2) // <boxGeometry />
 
 mesh.material = material
 mesh.geometry = geometry
@@ -66,13 +66,13 @@ Additionally, Fiber will:
 In three.js, we can create new object using the classic JS API:
 
 ```js
-const myBox = new THREE.BoxBufferGeometry(1, 2, 3)
+const myBox = new THREE.BoxGeometry(1, 2, 3)
 ```
 
-Object creation is handled transparently by the Fiber renderer, the name of the constructor `BoxBufferGeometry` is equivalent to the camel case component `<boxBufferGeometry />`, while the constructor arguments - in our example `[1, 2, 3]` - are passed via the `args` prop:
+Object creation is handled transparently by the Fiber renderer, the name of the constructor `BoxGeometry` is equivalent to the camel case component `<boxGeometry />`, while the constructor arguments - in our example `[1, 2, 3]` - are passed via the `args` prop:
 
 ```jsx
-<boxBufferGeometry args={[1, 2, 3]} />
+<boxGeometry args={[1, 2, 3]} />
 ```
 
 <Hint>Note that the object will be created only when first adding the component the React three!</Hint>
@@ -100,7 +100,7 @@ With the `attach` prop, we can precisely tell the renderer what property to atta
 ```jsx
 <mesh>
   <meshNormalMaterial attach="material" />
-  <boxBufferGeometry attach="geometry" />
+  <boxGeometry attach="geometry" />
 </mesh>
 ```
 
@@ -108,7 +108,7 @@ This will _explicitly_ tell Fiber to render like this:
 
 ```js
 mesh.material = new THREE.MeshNormalMaterial()
-mesh.geometry = new THREE.BoxBufferGeometry()
+mesh.geometry = new THREE.BoxGeometry()
 ```
 
 As you can see, the `attach` prop is telling Fiber to set the parent's `material` property to a reference to our `<meshNormalMaterial />` object.

--- a/example/src/demos/Animation.tsx
+++ b/example/src/demos/Animation.tsx
@@ -17,7 +17,7 @@ export default function Box() {
   return (
     <Canvas>
       <a.mesh rotation-y={rotation} scale-x={scale} scale-z={scale} onClick={() => setActive(Number(!active))}>
-        <boxBufferGeometry />
+        <boxGeometry />
         <a.meshBasicMaterial color={color} />
       </a.mesh>
       <OrbitControls />

--- a/example/src/demos/AutoDispose.tsx
+++ b/example/src/demos/AutoDispose.tsx
@@ -13,7 +13,7 @@ function Box1(props: any) {
       onClick={(e) => props.setActive(!props.active)}
       onPointerOver={(e) => setHover(true)}
       onPointerOut={(e) => setHover(false)}>
-      <boxBufferGeometry />
+      <boxGeometry />
       <meshStandardMaterial color={hovered ? 'hotpink' : 'orange'} />
     </mesh>
   )
@@ -31,7 +31,7 @@ function Box2(props: any) {
         onClick={(e) => props.setActive(!props.active)}
         onPointerOver={(e) => setHover(true)}
         onPointerOut={(e) => setHover(false)}>
-        <boxBufferGeometry />
+        <boxGeometry />
         <meshStandardMaterial color={hovered ? 'green' : 'blue'} />
       </mesh>
     </group>

--- a/example/src/demos/ClickAndHover.tsx
+++ b/example/src/demos/ClickAndHover.tsx
@@ -21,7 +21,7 @@ function Box(props: any) {
       onClick={() => setClicked(!clicked)}
       scale={clicked ? [1.5, 1.5, 1.5] : [1, 1, 1]}
       {...props}>
-      <boxBufferGeometry />
+      <boxGeometry />
       <meshBasicMaterial color={hovered ? 'hotpink' : 'aquamarine'} />
     </mesh>
   )

--- a/example/src/demos/MultiRender.tsx
+++ b/example/src/demos/MultiRender.tsx
@@ -15,7 +15,7 @@ const Obj = () => {
   })
   return (
     <mesh ref={meshRef}>
-      <boxBufferGeometry args={[1, 1, 1]} />
+      <boxGeometry args={[1, 1, 1]} />
       <meshNormalMaterial />
     </mesh>
   )

--- a/example/src/demos/Selection.tsx
+++ b/example/src/demos/Selection.tsx
@@ -6,7 +6,7 @@ function Sphere() {
   console.log('sphere', hovered)
   return (
     <mesh onPointerOver={(e) => (e.stopPropagation(), set(true))} onPointerOut={(e) => set(false)}>
-      <sphereBufferGeometry args={[0.5, 64, 64]} />
+      <sphereGeometry args={[0.5, 64, 64]} />
       <meshBasicMaterial color={hovered ? 'hotpink' : 'indianred'} />
     </mesh>
   )

--- a/example/src/demos/SuspenseMaterial.tsx
+++ b/example/src/demos/SuspenseMaterial.tsx
@@ -10,7 +10,7 @@ export default function App() {
       <ambientLight />
       <directionalLight />
       <mesh onClick={inc}>
-        <sphereBufferGeometry args={[1, 64, 32]} />
+        <sphereGeometry args={[1, 64, 32]} />
         <Suspense fallback={<FallbackMaterial />}>
           <SlowMaterial arg={arg} />
         </Suspense>

--- a/packages/fiber/tests/core/hooks.test.tsx
+++ b/packages/fiber/tests/core/hooks.test.tsx
@@ -147,11 +147,11 @@ describe('hooks', () => {
     const MockGroup = new THREE.Group()
     const mat1 = new THREE.MeshBasicMaterial()
     mat1.name = 'Mat 1'
-    const mesh1 = new THREE.Mesh(new THREE.BoxBufferGeometry(2, 2), mat1)
+    const mesh1 = new THREE.Mesh(new THREE.BoxGeometry(2, 2), mat1)
     mesh1.name = 'Mesh 1'
     const mat2 = new THREE.MeshBasicMaterial()
     mat2.name = 'Mat 2'
-    const mesh2 = new THREE.Mesh(new THREE.BoxBufferGeometry(2, 2), mat2)
+    const mesh2 = new THREE.Mesh(new THREE.BoxGeometry(2, 2), mat2)
     mesh2.name = 'Mesh 2'
     MockGroup.add(mesh1, mesh2)
 
@@ -203,20 +203,20 @@ describe('hooks', () => {
     const group = new THREE.Group()
     const mat1 = new THREE.MeshBasicMaterial()
     mat1.name = 'Mat 1'
-    const mesh1 = new THREE.Mesh(new THREE.BoxBufferGeometry(2, 2), mat1)
+    const mesh1 = new THREE.Mesh(new THREE.BoxGeometry(2, 2), mat1)
     mesh1.name = 'Mesh 1'
     const mat2 = new THREE.MeshBasicMaterial()
     mat2.name = 'Mat 2'
-    const mesh2 = new THREE.Mesh(new THREE.BoxBufferGeometry(2, 2), mat2)
+    const mesh2 = new THREE.Mesh(new THREE.BoxGeometry(2, 2), mat2)
     mesh2.name = 'Mesh 2'
     const subGroup = new THREE.Group()
     const mat3 = new THREE.MeshBasicMaterial()
     mat3.name = 'Mat 3'
-    const mesh3 = new THREE.Mesh(new THREE.BoxBufferGeometry(2, 2), mat3)
+    const mesh3 = new THREE.Mesh(new THREE.BoxGeometry(2, 2), mat3)
     mesh3.name = 'Mesh 3'
     const mat4 = new THREE.MeshBasicMaterial()
     mat4.name = 'Mat 4'
-    const mesh4 = new THREE.Mesh(new THREE.BoxBufferGeometry(2, 2), mat4)
+    const mesh4 = new THREE.Mesh(new THREE.BoxGeometry(2, 2), mat4)
     mesh4.name = 'Mesh 4'
 
     subGroup.add(mesh3, mesh4)

--- a/packages/fiber/tests/core/renderer.test.tsx
+++ b/packages/fiber/tests/core/renderer.test.tsx
@@ -106,7 +106,7 @@ describe('renderer', () => {
     const Mesh = () => {
       return (
         <mesh>
-          <boxBufferGeometry args={[2, 2]} />
+          <boxGeometry args={[2, 2]} />
           <meshBasicMaterial />
         </mesh>
       )
@@ -150,7 +150,7 @@ describe('renderer', () => {
     const Child = () => {
       return (
         <mesh>
-          <boxBufferGeometry args={[2, 2]} />
+          <boxGeometry args={[2, 2]} />
           <meshBasicMaterial />
         </mesh>
       )

--- a/packages/test-renderer/README.md
+++ b/packages/test-renderer/README.md
@@ -38,7 +38,7 @@ import ReactThreeTestRenderer from '@react-three/test-renderer'
 
 const renderer = await ReactThreeTestRenderer.create(
   <mesh>
-    <boxBufferGeometry args={[2, 2]} />
+    <boxGeometry args={[2, 2]} />
     <meshStandardMaterial
       args={[
         {

--- a/packages/test-renderer/src/__tests__/RTTR.core.test.tsx
+++ b/packages/test-renderer/src/__tests__/RTTR.core.test.tsx
@@ -278,7 +278,7 @@ describe('ReactThreeTestRenderer Core', () => {
         log.push('render ' + this.props.name)
         return (
           <mesh>
-            <boxBufferGeometry args={[2, 2]} />
+            <boxGeometry args={[2, 2]} />
             <meshStandardMaterial />
           </mesh>
         )

--- a/packages/test-renderer/src/__tests__/RTTR.methods.test.tsx
+++ b/packages/test-renderer/src/__tests__/RTTR.methods.test.tsx
@@ -61,10 +61,10 @@ describe('ReactThreeTestRenderer instance methods', () => {
     expect(foundAllByMesh[0].instance.name).toEqual('mesh_01')
     expect(foundAllByMesh[1].instance.name).toEqual('mesh_02')
 
-    const foundAllByBoxGeometry = scene.findAllByType('BoxGeometry')
+    const foundAllByBoxBufferGeometry = scene.findAllByType('BoxBufferGeometry')
 
-    expect(foundAllByBoxGeometry).toHaveLength(0)
-    expect(foundAllByBoxGeometry).toEqual([])
+    expect(foundAllByBoxBufferGeometry).toHaveLength(0)
+    expect(foundAllByBoxBufferGeometry).toEqual([])
 
     expect(() => scene.findByType('BufferGeometry')).toThrow()
   })

--- a/packages/test-renderer/src/__tests__/RTTR.methods.test.tsx
+++ b/packages/test-renderer/src/__tests__/RTTR.methods.test.tsx
@@ -7,11 +7,11 @@ describe('ReactThreeTestRenderer instance methods', () => {
     return (
       <group>
         <mesh name="mesh_01">
-          <boxBufferGeometry args={[2, 2]} />
+          <boxGeometry args={[2, 2]} />
           <meshStandardMaterial color={0x0000ff} />
         </mesh>
         <mesh name="mesh_02">
-          <boxBufferGeometry args={[2, 2]} />
+          <boxGeometry args={[2, 2]} />
           <meshBasicMaterial color={0x0000ff} />
         </mesh>
       </group>
@@ -61,10 +61,10 @@ describe('ReactThreeTestRenderer instance methods', () => {
     expect(foundAllByMesh[0].instance.name).toEqual('mesh_01')
     expect(foundAllByMesh[1].instance.name).toEqual('mesh_02')
 
-    const foundAllByBoxBufferGeometry = scene.findAllByType('BoxBufferGeometry')
+    const foundAllByBoxGeometry = scene.findAllByType('BoxGeometry')
 
-    expect(foundAllByBoxBufferGeometry).toHaveLength(0)
-    expect(foundAllByBoxBufferGeometry).toEqual([])
+    expect(foundAllByBoxGeometry).toHaveLength(0)
+    expect(foundAllByBoxGeometry).toEqual([])
 
     expect(() => scene.findByType('BufferGeometry')).toThrow()
   })


### PR DESCRIPTION
Removes usage of aliases in docs and examples such as `BoxBufferGeometry` in favor of `BoxGeometry`.