### PR TITLE
feat(core): check instanceof for auto-attach

### DIFF
--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -119,9 +119,9 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
     }
 
     // Auto-attach geometries and materials
-    if (instance.attach === undefined) {
-      if (instance instanceof THREE.BufferGeometry) instance.attach = 'geometry'
-      else if (instance instanceof THREE.Material) instance.attach = 'material'
+    if (instance.__r3f.attach === undefined) {
+      if (instance instanceof THREE.BufferGeometry) instance.__r3f.attach = 'geometry'
+      else if (instance instanceof THREE.Material) instance.__r3f.attach = 'material'
     }
 
     // It should NOT call onUpdate on object instanciation, because it hasn't been added to the

--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -92,12 +92,6 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
     let name = `${type[0].toUpperCase()}${type.slice(1)}`
     let instance: Instance
 
-    // Auto-attach geometries and materials
-    if (attach === undefined) {
-      if (name.endsWith('Geometry')) attach = 'geometry'
-      else if (name.endsWith('Material')) attach = 'material'
-    }
-
     if (type === 'primitive') {
       if (props.object === undefined) throw new Error("R3F: Primitives without 'object' are invalid!")
       const object = props.object as Instance
@@ -122,6 +116,12 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
         // Save args in case we need to reconstruct later for HMR
         memoizedProps: { args },
       })
+    }
+
+    // Auto-attach geometries and materials
+    if (instance.attach === undefined) {
+      if (instance instanceof THREE.BufferGeometry) instance.attach = 'geometry'
+      else if (instance instanceof THREE.Material) instance.attach = 'material'
     }
 
     // It should NOT call onUpdate on object instanciation, because it hasn't been added to the


### PR DESCRIPTION
Prefers to check against instances' prototypes for whether they are valid Geometry/Material attach targets. This includes primitives and no longer relies on elements' semantics.