### PR TITLE
fix: typo, changed "id" to "i"

### DIFF
--- a/docs/advanced/scaling-performance.mdx
+++ b/docs/advanced/scaling-performance.mdx
@@ -108,7 +108,7 @@ function Instances({ count = 100000, temp = new THREE.Object3D() }) {
     for (let i = 0; i < count; i++) {
       temp.position.set(Math.random(), Math.random(), Math.random())
       temp.updateMatrix()
-      ref.current.setMatrixAt(id, temp.matrix)
+      ref.current.setMatrixAt(i, temp.matrix)
     }
     // Update the instance
     ref.current.instanceMatrix.needsUpdate = true


### PR DESCRIPTION
looks like a typo to me, "id" is not defined.
I think "i" makes the most sense given what the docs say getMatrixAt does.
docs for getMatrixAt: https://threejs.org/docs/?q=instanced#api/en/objects/InstancedMesh