### PR TITLE
Allow `useFrame`'s first argument to be `undefined`

### DIFF
--- a/.changeset/good-squids-move.md
+++ b/.changeset/good-squids-move.md
@@ -2,4 +2,20 @@
 '@react-three/fiber': patch
 ---
 
-`usefjdsiofjsod`
+`useFrame` now allows its first argument to be `undefined`. This is useful in situations where you want to _conditionally_ register a frame callback, but can't wrap the actual `useFrame` invocation in a conditional statement, because React will not allow that.
+
+Example:
+
+```jsx
+const Component = ({ animate = false }) => {
+  useFrame(
+    animate
+      ? () => {
+          // do something
+        }
+      : undefined,
+  )
+
+  /* ... */
+}
+```

--- a/.changeset/good-squids-move.md
+++ b/.changeset/good-squids-move.md
@@ -1,0 +1,5 @@
+---
+'@react-three/fiber': patch
+---
+
+`usefjdsiofjsod`

--- a/packages/fiber/src/core/hooks.tsx
+++ b/packages/fiber/src/core/hooks.tsx
@@ -43,13 +43,16 @@ export function useThree<T = RootState>(
  * Can order effects with render priority or manually render with a positive priority.
  * @see https://docs.pmnd.rs/react-three-fiber/api/hooks#useframe
  */
-export function useFrame(callback: RenderCallback, renderPriority: number = 0): null {
+export function useFrame(callback: RenderCallback | undefined, renderPriority: number = 0): null {
   const store = useStore()
   const subscribe = store.getState().internal.subscribe
   // Memoize ref
-  const ref = useMutableCallback(callback)
+  const ref = useMutableCallback(callback || (() => null))
   // Subscribe on mount, unsubscribe on unmount
-  useIsomorphicLayoutEffect(() => subscribe(ref, renderPriority, store), [renderPriority, subscribe, store])
+  useIsomorphicLayoutEffect(() => {
+    if (!callback) return
+    subscribe(ref, renderPriority, store)
+  }, [renderPriority, subscribe, store])
   return null
 }
 

--- a/packages/fiber/src/core/hooks.tsx
+++ b/packages/fiber/src/core/hooks.tsx
@@ -51,7 +51,7 @@ export function useFrame(callback: RenderCallback | undefined, renderPriority: n
   // Subscribe on mount, unsubscribe on unmount
   useIsomorphicLayoutEffect(() => {
     if (!callback) return
-    subscribe(ref, renderPriority, store)
+    return subscribe(ref, renderPriority, store)
   }, [renderPriority, subscribe, store])
   return null
 }

--- a/packages/fiber/tests/core/hooks.test.tsx
+++ b/packages/fiber/tests/core/hooks.test.tsx
@@ -109,6 +109,42 @@ describe('hooks', () => {
     expect(frameCalls.length).toBeGreaterThan(0)
   })
 
+  it('can handle useFrame hook with an empty argument', async () => {
+    const frameCalls: number[] = []
+
+    const Component = ({ animate = false }) => {
+      const ref = React.useRef<THREE.Mesh>(null!)
+
+      useFrame(
+        animate
+          ? (_, delta) => {
+              frameCalls.push(delta)
+              ref.current.position.x = 1
+            }
+          : undefined,
+      )
+
+      return (
+        <mesh ref={ref}>
+          <boxGeometry args={[2, 2]} />
+          <meshBasicMaterial />
+        </mesh>
+      )
+    }
+
+    let scene: THREE.Scene = null!
+    await act(
+      async () =>
+        (scene = createRoot(canvas)
+          .configure({ frameloop: 'never' })
+          .render(<Component />)
+          .getState().scene),
+    )
+    advance(Date.now())
+    expect(scene.children[0].position.x).toEqual(0)
+    expect(frameCalls.length).toEqual(0)
+  })
+
   it('can handle useLoader hook', async () => {
     const MockMesh = new THREE.Mesh()
     jest.spyOn(Stdlib, 'GLTFLoader').mockImplementation(


### PR DESCRIPTION
Wait, what? Why would `useFrame` ever want to take an `undefined` callback? Go home, hmans, you're drunk!

No, seriously, this solves the following issue: sometimes you may want to only mount a per-frame callback _conditionally_, kinda like this:

```js
if (condition) useFrame(callback)
```

But this will make React throw errors at you, and rightfully so, because it really, _really_ doesn't like hook invocations (like the inner `useLayoutEffect` that `useFrame` runs) to appear and disappear between re-renders. React hooks require a stable invocation order across re-renders of the same components, and so on and so forth.

So you're all sad and lonely and drunk on German beer and end up doing this:

```js
useFrame(() => {
  if (!condition) return;
  /* otherwise, do something else */
})
```

This works, but now you're even more sad (and lonely) because you know that there's an almost-no-op function running every frame checking the same condition over and over again and doing nothing else.

Then the abyss starts to slowly consume you and you start doing stuff like this:

```js
useFrame(condition ? actualCallback : (() => null))
```

This works, but you're still sad, because there's still an empty callback function stored in a state somewhere, invoked every frame. You think of the countless engineers at Google who have very likely optimized the sh*t out of empty functions, but you know that it's still a _thing_ that exists in a _state_ and is being _looped over_ and also the German beer is starting to run out and you're finally starting to sober up, and you realize that what you _really_ want to do is this:

```js
useFrame(condition ? actualCallback : undefined)
```

This PR allows this. Prost.