### PR TITLE
fix(core): don't append to unmounted containers

### DIFF
--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -342,7 +342,7 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
       const scene = container.getState().scene as unknown as Instance
       if (!scene.__r3f) return
 
-      insertBefore(container.getState().scene as unknown as Instance, child, beforeChild)
+      insertBefore(scene, child, beforeChild)
     },
     getRootHostContext: () => null,
     getChildHostContext: (parentHostContext) => parentHostContext,

--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -323,7 +323,10 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
     appendChildToContainer: (container, child) => {
       if (!child) return
 
+      // Don't append to unmounted container
       const scene = container.getState().scene as unknown as Instance
+      if (!scene.__r3f) return
+
       // Link current root to the default scene
       scene.__r3f.root = container
       appendChild(scene, child)
@@ -334,6 +337,11 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
     },
     insertInContainerBefore: (container, child, beforeChild) => {
       if (!child || !beforeChild) return
+
+      // Don't append to unmounted container
+      const scene = container.getState().scene as unknown as Instance
+      if (!scene.__r3f) return
+
       insertBefore(container.getState().scene as unknown as Instance, child, beforeChild)
     },
     getRootHostContext: () => null,

--- a/packages/fiber/tests/core/renderer.test.tsx
+++ b/packages/fiber/tests/core/renderer.test.tsx
@@ -738,4 +738,28 @@ describe('renderer', () => {
     const respectedKeys = privateKeys.filter((key) => overwrittenKeys.includes(key) || state[key] === portalState[key])
     expect(respectedKeys).toStrictEqual(privateKeys)
   })
+
+  it('can handle createPortal on unmounted container', async () => {
+    let groupHandle!: THREE.Group | null
+    function Test(props: any) {
+      const [group, setGroup] = React.useState(null)
+      groupHandle = group
+
+      return (
+        <group {...props} ref={setGroup}>
+          {group && createPortal(<mesh />, group)}
+        </group>
+      )
+    }
+
+    await act(async () => root.render(<Test key={0} />))
+
+    expect(groupHandle).toBeDefined()
+    const prevUUID = groupHandle!.uuid
+
+    await act(async () => root.render(<Test key={1} />))
+
+    expect(groupHandle).toBeDefined()
+    expect(prevUUID).not.toBe(groupHandle!.uuid)
+  })
 })


### PR DESCRIPTION
Fixes #2469 by ensuring that containers passed to `createPortal` are mounted and managed by R3F before appending. In this case, React removes the parent container and then tries to re-append its child container, which is undefined behavior.