### PR TITLE
[v9] refactor: remove onUpdate prop

### DIFF
--- a/docs/API/events.mdx
+++ b/docs/API/events.mdx
@@ -6,8 +6,6 @@ nav: 8
 
 `three.js` objects that implement their own `raycast` method (meshes, lines, etc) can be interacted with by declaring events on them. We support pointer events, clicks and wheel-scroll. Events contain the browser event as well as the `three.js` event data (object, point, distance, etc). You may want to [polyfill](https://github.com/jquery/PEP) them, if that's a concern.
 
-Additionally, there's a special `onUpdate` that is called every time the object gets fresh props, which is good for things like `self => (self.verticesNeedUpdate = true)`.
-
 Also notice the `onPointerMissed` on the canvas element, which fires on clicks that haven't hit _any_ meshes.
 
 ```jsx
@@ -24,7 +22,6 @@ Also notice the `onPointerMissed` on the canvas element, which fires on clicks t
   onPointerLeave={(e) => console.log('leave')} // see note 1
   onPointerMove={(e) => console.log('move')}
   onPointerMissed={() => console.log('missed')}
-  onUpdate={(self) => console.log('props have been updated')}
 />
 ```
 

--- a/docs/tutorials/events-and-interaction.mdx
+++ b/docs/tutorials/events-and-interaction.mdx
@@ -26,7 +26,6 @@ Any mesh in React Three Fiber has a large number of events, 13 to be more precis
   onPointerLeave={(e) => console.log('leave')}
   onPointerMove={(e) => console.log('move')}
   onPointerMissed={() => console.log('missed')}
-  onUpdate={(self) => console.log('props have been updated')}
 />
 ```
 

--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -3,17 +3,7 @@ import { UseBoundStore } from 'zustand'
 import Reconciler from 'react-reconciler'
 import { unstable_IdlePriority as idlePriority, unstable_scheduleCallback as scheduleCallback } from 'scheduler'
 import { DefaultEventPriority } from 'react-reconciler/constants'
-import {
-  is,
-  prepare,
-  diffProps,
-  DiffSet,
-  applyProps,
-  updateInstance,
-  invalidateInstance,
-  attach,
-  detach,
-} from './utils'
+import { is, prepare, diffProps, DiffSet, applyProps, invalidateInstance, attach, detach } from './utils'
 import { RootState } from './store'
 import { EventHandlers, removeInteractivity } from './events'
 
@@ -148,7 +138,6 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
       if (!added) parentInstance.__r3f?.objects.push(child)
       if (!child.__r3f) prepare(child, {})
       child.__r3f.parent = parentInstance
-      updateInstance(child)
       invalidateInstance(child)
     }
   }
@@ -174,7 +163,6 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
       if (!added) parentInstance.__r3f?.objects.push(child)
       if (!child.__r3f) prepare(child, {})
       child.__r3f.parent = parentInstance
-      updateInstance(child)
       invalidateInstance(child)
     }
   }

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -343,19 +343,12 @@ export function applyProps(instance: Instance, data: InstanceProps | DiffSet) {
     if (localState.eventCount) rootState.internal.interaction.push(instance as unknown as THREE.Object3D)
   }
 
-  // Call the update lifecycle when it is being updated, but only when it is part of the scene
-  if (changes.length && instance.parent) updateInstance(instance)
-
   return instance
 }
 
 export function invalidateInstance(instance: Instance) {
   const state = instance.__r3f?.root?.getState?.()
   if (state && state.internal.frames === 0) state.invalidate()
-}
-
-export function updateInstance(instance: Instance) {
-  instance.onUpdate?.(instance)
 }
 
 export function updateCamera(camera: Camera & { manual?: boolean }, size: Size) {

--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -39,7 +39,6 @@ export interface NodeProps<T, P> {
   children?: React.ReactNode
   ref?: React.Ref<T>
   key?: React.Key
-  onUpdate?: (self: T) => void
 }
 
 export type ExtendedColors<T> = { [K in keyof T]: T[K] extends THREE.Color | undefined ? Color : T[K] }


### PR DESCRIPTION
Follow-up to https://github.com/pmndrs/react-three-fiber/pull/2308#issuecomment-1153015467. Removes the `onUpdate` prop in favor of `useMemo` or `useEffect`.