### PR TITLE
[v9] fix: handle container effects on completed trees, track instance visibility

### DIFF
--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -174,6 +174,7 @@ export function prepare<T = any>(
       object,
       eventCount: 0,
       handlers: {},
+      isHidden: false,
     }
     object.__r3f = instance
   }


### PR DESCRIPTION
Depends on #2465, fixes #2250.

Moves `attach` and interactivity to `handleContainerEffects` which will fire when trees are linked and finalized. This ensures that effects are not duplicated due to suspense and complete outside of commit, so we're never late and present an incomplete tree.

I've updated the CSB to highlight the intricacies throughout the reconciler lifecycle: https://codesandbox.io/s/scrgbc. Should fire `attach` (uuid must match ref and thus be current), `useLayoutEffect` (ensures the view is completed before presenting), then the parent is reconstructed from scratch so children will `detach` and `attach`.

I've also added an `isHidden` property to instances to make sure we don't handle `attach` or `detach` for instances that weren't hidden by React. This could similarly cause duplication.