### PR TITLE
feat(hooks): useInstanceHandle

### DIFF
--- a/docs/API/additional-exports.mdx
+++ b/docs/API/additional-exports.mdx
@@ -3,17 +3,18 @@ title: Additional Exports
 nav: 9
 ---
 
-| export         | usage                                                          |
-| -------------- | -------------------------------------------------------------- |
-| addEffect      | Adds a global render callback which is called each frame       |
-| addAfterEffect | Adds a global after-render callback which is called each frame |
-| addTail        | Adds a global callback which is called when rendering stops    |
-| invalidate     | Forces view global invalidation                                |
-| advance        | Advances the frameloop (given that it's set to 'never')        |
-| extend         | Extends the native-object catalogue                            |
-| createPortal   | Creates a portal (it's a React feature for re-parenting)       |
-| createRoot     | Creates a root that can render three JSX into a canvas         |
-| events         | Dom pointer-event system                                       |
-| applyProps     | `applyProps(element, props)` sets element properties,          |
-| act            | usage with react-testing                                       |
-|                |                                                                |
+| export            | usage                                                          |
+| ----------------- | -------------------------------------------------------------- |
+| addEffect         | Adds a global render callback which is called each frame       |
+| addAfterEffect    | Adds a global after-render callback which is called each frame |
+| addTail           | Adds a global callback which is called when rendering stops    |
+| invalidate        | Forces view global invalidation                                |
+| advance           | Advances the frameloop (given that it's set to 'never')        |
+| extend            | Extends the native-object catalogue                            |
+| createPortal      | Creates a portal (it's a React feature for re-parenting)       |
+| createRoot        | Creates a root that can render three JSX into a canvas         |
+| events            | Dom pointer-event system                                       |
+| applyProps        | `applyProps(element, props)` sets element properties,          |
+| act               | usage with react-testing                                       |
+| useInstanceHandle | Exposes react-internal local state from `instance.__r3f`       |
+|                   |                                                                |

--- a/packages/fiber/src/core/hooks.tsx
+++ b/packages/fiber/src/core/hooks.tsx
@@ -24,7 +24,7 @@ export type BranchingReturn<T, Parent, Coerced> = ConditionalType<T, Parent, Coe
 
 export function useInstanceHandle<O>(ref: React.MutableRefObject<O>): React.MutableRefObject<LocalState> {
   const instance = React.useRef<LocalState>(null!)
-  useIsomorphicLayoutEffect(() => void (instance.current = (ref.current as Instance).__r3f), [ref])
+  useIsomorphicLayoutEffect(() => void (instance.current = (ref.current as unknown as Instance).__r3f), [ref])
   return instance
 }
 

--- a/packages/fiber/src/core/hooks.tsx
+++ b/packages/fiber/src/core/hooks.tsx
@@ -6,6 +6,7 @@ import { suspend, preload, clear } from 'suspend-react'
 import { context, RootState, RenderCallback } from './store'
 import { buildGraph, ObjectMap, is, useMutableCallback, useIsomorphicLayoutEffect } from './utils'
 import { LoadingManager } from 'three'
+import { LocalState, Instance } from './renderer'
 
 export interface Loader<T> extends THREE.Loader {
   load(
@@ -20,6 +21,12 @@ export type Extensions = (loader: THREE.Loader) => void
 export type LoaderResult<T> = T extends any[] ? Loader<T[number]> : Loader<T>
 export type ConditionalType<Child, Parent, Truthy, Falsy> = Child extends Parent ? Truthy : Falsy
 export type BranchingReturn<T, Parent, Coerced> = ConditionalType<T, Parent, Coerced, T>
+
+export function useInstanceHandle<O>(ref: React.MutableRefObject<O>): React.MutableRefObject<LocalState> {
+  const instance = React.useRef<LocalState>(null!)
+  useIsomorphicLayoutEffect(() => void (instance.current = (ref.current as Instance).__r3f), [ref])
+  return instance
+}
 
 export function useStore() {
   const store = React.useContext(context)

--- a/packages/fiber/src/core/hooks.tsx
+++ b/packages/fiber/src/core/hooks.tsx
@@ -22,6 +22,12 @@ export type LoaderResult<T> = T extends any[] ? Loader<T[number]> : Loader<T>
 export type ConditionalType<Child, Parent, Truthy, Falsy> = Child extends Parent ? Truthy : Falsy
 export type BranchingReturn<T, Parent, Coerced> = ConditionalType<T, Parent, Coerced, T>
 
+/**
+ * Exposes an object's {@link LocalState}.
+ * @see https://docs.pmnd.rs/react-three-fiber/api/additional-exports#useInstanceHandle
+ *
+ * **Note**: this is an escape hatch to react-internal fields. Expect this to change significantly between versions.
+ */
 export function useInstanceHandle<O>(ref: React.MutableRefObject<O>): React.MutableRefObject<LocalState> {
   const instance = React.useRef<LocalState>(null!)
   useIsomorphicLayoutEffect(() => void (instance.current = (ref.current as unknown as Instance).__r3f), [ref])

--- a/packages/fiber/tests/core/hooks.test.tsx
+++ b/packages/fiber/tests/core/hooks.test.tsx
@@ -6,7 +6,19 @@ import { createWebGLContext } from '@react-three/test-renderer/src/createWebGLCo
 
 import { asyncUtils } from '../../../shared/asyncUtils'
 
-import { createRoot, advance, useLoader, act, useThree, useGraph, useFrame, ObjectMap } from '../../src'
+import {
+  createRoot,
+  advance,
+  useLoader,
+  act,
+  useThree,
+  useGraph,
+  useFrame,
+  ObjectMap,
+  useInstanceHandle,
+  LocalState,
+} from '../../src'
+import { Instance } from 'packages/fiber/src/core/renderer'
 
 const resolvers: (() => void)[] = []
 
@@ -248,5 +260,18 @@ describe('hooks', () => {
         [mat4.name]: mat4,
       },
     })
+  })
+
+  it('can handle useInstanceHandle hook', async () => {
+    const ref = React.createRef<THREE.Group>()
+    let instance!: React.MutableRefObject<LocalState>
+
+    const Component = () => {
+      instance = useInstanceHandle(ref)
+      return <group ref={ref} />
+    }
+    await act(async () => createRoot(canvas).render(<Component />))
+
+    expect(instance.current).toBe((ref.current as unknown as Instance).__r3f)
   })
 })


### PR DESCRIPTION
Implements #2467. Adds a `useInstanceHandle` hook that accepts a ref to an R3F element and returns its local state. This would be equivalent to `ref.current.__r3f`, which should be avoided in production code.

```jsx
const ref = React.useRef()
const instance = useInstanceHandle(ref)

React.useLayoutEffect(() => {
  instance.parent.foo()
}, [])

<group ref={ref} />
```

> **Note**: this is an escape hatch to react-internal fields. Expect this to change significantly between versions.