### PR TITLE
[v9] fix!: type unstable_act

### DIFF
--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -561,7 +561,14 @@ reconciler.injectIntoDevTools({
   version: React.version,
 })
 
-const act = (React as any).unstable_act
+declare module 'react' {
+  const unstable_act: <T = any>(cb: () => Promise<T>) => Promise<T>
+}
+
+/**
+ * Safely flush async effects when testing, simulating a legacy root.
+ */
+const act = React.unstable_act
 
 export * from './hooks'
 export {

--- a/packages/test-renderer/src/index.tsx
+++ b/packages/test-renderer/src/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import * as THREE from 'three'
 
-import { extend, _roots as mockRoots, createRoot, reconciler, act as _act } from '@react-three/fiber'
+import { extend, _roots as mockRoots, createRoot, reconciler, act } from '@react-three/fiber'
 
 import { toTree } from './helpers/tree'
 import { toGraph } from './helpers/graph'
@@ -12,13 +12,11 @@ import { createWebGLContext } from './createWebGLContext'
 import { createEventFirer } from './fireEvent'
 
 import type { MockScene } from './types/internal'
-import type { CreateOptions, Renderer, Act } from './types/public'
+import type { CreateOptions, Renderer } from './types/public'
 import { wrapFiber } from './createTestInstance'
 
 // Extend catalogue for render API in tests.
 extend(THREE)
-
-const act = _act as unknown as Act
 
 type X =
   | ((contextId: 'webgl', options?: WebGLContextAttributes) => WebGLRenderingContext | null)

--- a/packages/test-renderer/src/types/public.ts
+++ b/packages/test-renderer/src/types/public.ts
@@ -17,8 +17,6 @@ export type MockSyntheticEvent = {
 
 export type CreateOptions = CreateCanvasParameters & RenderProps<HTMLCanvasElement>
 
-export type Act = (cb: () => Promise<any>) => Promise<any>
-
 export type Renderer = {
   scene: ReactThreeTestInstance
   unmount: () => Promise<void>


### PR DESCRIPTION
R3F exports `React.unstable_act` as `act` which is not defined in `@types/react`. This PR can possibly be picked into DefinitelyTyped, but it's notable that `act` will inherit the return value of the promise passed to it:

```tsx
const store: UseBoundStore<RootState> = await act(() => root.render(<Scene />))
console.log(store.getState()) // RootState
```