### PR TITLE
[v9] fix(types): don't declare unstable_act

### DIFF
--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -561,14 +561,12 @@ reconciler.injectIntoDevTools({
   version: React.version,
 })
 
-declare module 'react' {
-  const unstable_act: <T = any>(cb: () => Promise<T>) => Promise<T>
-}
+type Act = <T = any>(cb: () => Promise<T>) => Promise<T>
 
 /**
  * Safely flush async effects when testing, simulating a legacy root.
  */
-const act = React.unstable_act
+const act: Act = (React as any).unstable_act
 
 export * from './hooks'
 export {
@@ -587,6 +585,7 @@ export {
   addAfterEffect,
   addTail,
   getRootState,
+  Act,
   act,
   roots as _roots,
 }


### PR DESCRIPTION
Follow-up to #2490. Prefers to keep React types local to avoid clashing with user-defined global React types.