### PR TITLE
Use self to get global context before window in getEventPriority.

### DIFF
--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -100,7 +100,8 @@ function makeId(event: Intersection) {
 // https://github.com/facebook/react/tree/main/packages/react-reconciler#getcurrenteventpriority
 // Gives React a clue as to how import the current interaction is
 export function getEventPriority() {
-  let name = window?.event?.type
+  const globalScope = self || window
+  let name = globalScope?.event?.type
   switch (name) {
     case 'click':
     case 'contextmenu':

--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -100,8 +100,12 @@ function makeId(event: Intersection) {
 // https://github.com/facebook/react/tree/main/packages/react-reconciler#getcurrenteventpriority
 // Gives React a clue as to how import the current interaction is
 export function getEventPriority() {
-  const globalScope = self || window
-  let name = globalScope?.event?.type
+  // Get a handle to the current global scope in window and worker contexts if able
+  // https://github.com/pmndrs/react-three-fiber/pull/2493
+  const globalScope = (typeof self !== 'undefined' && self) || (typeof window !== 'undefined' && window)
+  if (!globalScope) return DefaultEventPriority
+
+  const name = globalScope.event?.type
   switch (name) {
     case 'click':
     case 'contextmenu':

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -71,7 +71,8 @@ export type ObjectMap = {
 }
 
 export function calculateDpr(dpr: Dpr) {
-  return Array.isArray(dpr) ? Math.min(Math.max(dpr[0], window.devicePixelRatio), dpr[1]) : dpr
+  const target = typeof window !== 'undefined' ? window.devicePixelRatio : 1
+  return Array.isArray(dpr) ? Math.min(Math.max(dpr[0], target), dpr[1]) : dpr
 }
 
 /**


### PR DESCRIPTION
Prior to this change, this code would throw an error when run inside of a WebWorker, since window is not defined inside of webworkers.
This prevented us from using R3F inside of an offscreen canvas in a webworker.

See https://stackoverflow.com/questions/71587025/cant-use-offscreencanvas-with-react-three-fiber for an example.