### PR TITLE
chore: upgrade bridge to harden suspense behavior

### DIFF
--- a/packages/fiber/package.json
+++ b/packages/fiber/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@babel/runtime": "^7.17.8",
     "@types/react-reconciler": "^0.26.7",
-    "its-fine": "^1.0.1",
+    "its-fine": "^1.0.2",
     "react-reconciler": "^0.27.0",
     "react-use-measure": "^2.1.1",
     "scheduler": "^0.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5366,10 +5366,10 @@ istanbul-reports@^3.1.3:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-its-fine@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/its-fine/-/its-fine-1.0.1.tgz#5b336ae72d221b01d8ed5d41fbacaac4c301eff5"
-  integrity sha512-E7ihBaOViboN99S9x1UkYVSrHyCguSls9ndOmLsq74wFZ6mUr+7PUSjykywVC5Ip065USSGdrjnys23nZb7xcQ==
+its-fine@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/its-fine/-/its-fine-1.0.2.tgz#0b4a861dea1d561251ac81565585aeba5893776f"
+  integrity sha512-EztmS3Wi9qH4FnhK3NkEyldMbDRKDaSJ3/4M7pH1BXG+IxF4xRV8Q5Ste5q0uJAPAGmXFqBpcsrXOTBi6DYcCQ==
   dependencies:
     "@types/react-reconciler" "^0.28.0"
 


### PR DESCRIPTION
Follow-up to https://github.com/pmndrs/its-fine/pull/13. Hardens context against cross-renderer suspense bubbling.