### PR TITLE
[v9] fix: prefer named functions, for loops in hot paths

### DIFF
--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -189,12 +189,12 @@ export function createEvents(store: UseBoundStore<RootState>) {
     // Allow callers to eliminate event objects
     const eventsObjects = filter ? filter(state.internal.interaction) : state.internal.interaction
     // Reset all raycaster cameras to undefined
-    eventsObjects.forEach((obj) => {
-      const state = getRootState(obj)
+    for (let i = 0; i < eventsObjects.length; i++) {
+      const state = getRootState(eventsObjects[i])
       if (state) {
         state.raycaster.camera = undefined!
       }
-    })
+    }
 
     if (!state.previousRoot) {
       // Make sure root-level pointer and ray are set up
@@ -363,7 +363,7 @@ export function createEvents(store: UseBoundStore<RootState>) {
 
   function cancelPointer(intersections: Intersection[]) {
     const { internal } = store.getState()
-    Array.from(internal.hovered.values()).forEach((hoveredObj) => {
+    for (const hoveredObj of internal.hovered.values()) {
       // When no objects were hit or the the hovered object wasn't found underneath the cursor
       // we call onPointerOut and delete the object from the hovered-elements map
       if (
@@ -386,7 +386,7 @@ export function createEvents(store: UseBoundStore<RootState>) {
           handlers.onPointerLeave?.(data as ThreeEvent<PointerEvent>)
         }
       }
-    })
+    }
   }
 
   const handlePointer = (name: string) => {
@@ -495,9 +495,9 @@ export function createEvents(store: UseBoundStore<RootState>) {
   }
 
   function pointerMissed(event: MouseEvent, objects: THREE.Object3D[]) {
-    objects.forEach((object: THREE.Object3D) =>
-      (object as Instance<THREE.Object3D>['object']).__r3f?.handlers.onPointerMissed?.(event),
-    )
+    for (let i = 0; i < objects.length; i++) {
+      (objects[i] as Instance<THREE.Object3D>['object']).__r3f?.handlers.onPointerMissed?.(event),
+    }
   }
 
   return { handlePointer }

--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -496,7 +496,8 @@ export function createEvents(store: UseBoundStore<RootState>) {
 
   function pointerMissed(event: MouseEvent, objects: THREE.Object3D[]) {
     for (let i = 0; i < objects.length; i++) {
-      (objects[i] as Instance<THREE.Object3D>['object']).__r3f?.handlers.onPointerMissed?.(event),
+      const instance = (objects[i] as Instance<THREE.Object3D>['object']).__r3f
+      instance?.handlers.onPointerMissed?.(event)
     }
   }
 

--- a/packages/fiber/src/core/loop.ts
+++ b/packages/fiber/src/core/loop.ts
@@ -36,7 +36,9 @@ export const addTail = (callback: GlobalRenderCallback) => createSubs(callback, 
 
 function run(effects: Set<SubItem>, timestamp: number) {
   if (!effects.size) return
-  effects.forEach(({ callback }) => callback(timestamp))
+  for (const { callback } of effects.values()) {
+    callback(timestamp)
+  }
 }
 
 export type GlobalEffectType = 'before' | 'after' | 'tail'
@@ -89,7 +91,7 @@ export function createLoop<TCanvas>(roots: Map<TCanvas, Root>) {
     flushGlobalEffects('before', timestamp)
 
     // Render all roots
-    roots.forEach((root) => {
+    for (const root of roots.values()) {
       state = root.store.getState()
 
       // If the frameloop is invalidated, do not run another frame
@@ -100,7 +102,7 @@ export function createLoop<TCanvas>(roots: Map<TCanvas, Root>) {
       ) {
         repeat += update(timestamp, state)
       }
-    })
+    }
 
     // Run after-effects
     flushGlobalEffects('after', timestamp)
@@ -130,7 +132,7 @@ export function createLoop<TCanvas>(roots: Map<TCanvas, Root>) {
 
   function advance(timestamp: number, runGlobalEffects: boolean = true, state?: RootState, frame?: XRFrame): void {
     if (runGlobalEffects) flushGlobalEffects('before', timestamp)
-    if (!state) roots.forEach((root) => update(timestamp, root.store.getState()))
+    if (!state) for (const root of roots.values()) {update(timestamp, root.store.getState())}
     else update(timestamp, state, frame)
     if (runGlobalEffects) flushGlobalEffects('after', timestamp)
   }

--- a/packages/fiber/src/core/loop.ts
+++ b/packages/fiber/src/core/loop.ts
@@ -132,7 +132,7 @@ export function createLoop<TCanvas>(roots: Map<TCanvas, Root>) {
 
   function advance(timestamp: number, runGlobalEffects: boolean = true, state?: RootState, frame?: XRFrame): void {
     if (runGlobalEffects) flushGlobalEffects('before', timestamp)
-    if (!state) for (const root of roots.values()) {update(timestamp, root.store.getState())}
+    if (!state) for (const root of roots.values()) update(timestamp, root.store.getState())
     else update(timestamp, state, frame)
     if (runGlobalEffects) flushGlobalEffects('after', timestamp)
   }


### PR DESCRIPTION
Following the discussion here https://discord.com/channels/740090768164651008/740093168770613279/1023859404111613962

I went to add a name function to remove this anonymous function from the performance tool report 
![ForEach](https://user-images.githubusercontent.com/7174039/192810846-8d1520ec-6e68-4135-9288-17436edb50f9.PNG)

I also thought that we could replace the forEach with for loops where applicable. 
With the for loop there isn't a need to use a named function at all in the end. 

So I went through the files and replaced the forEach loop that looked safe to replace. 

I'm expecting a gain of 1µs per frame with that 

The perf gain is probably neglectable but it removes some noise from the performance and also use less memory for one of them that was creating a new array on each call ( cancelPointer )