### PR TITLE
[v9] refactor(types): export public types

### DIFF
--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three'
 import { ContinuousEventPriority, DiscreteEventPriority, DefaultEventPriority } from 'react-reconciler/constants'
-import { getRootState } from './utils'
+import { Camera, getRootState } from './utils'
 import type { UseBoundStore } from 'zustand'
 import type { Instance } from './renderer'
 import type { RootState } from './store'
@@ -10,7 +10,7 @@ export interface Intersection extends THREE.Intersection {
   eventObject: THREE.Object3D
 }
 
-export interface IntersectionEvent<TSourceEvent> extends Intersection {
+export interface ThreeEvent<TEvent> extends Intersection {
   /** The event source (the object which registered the handler) */
   eventObject: THREE.Object3D
   /** An array of intersections */
@@ -28,16 +28,14 @@ export interface IntersectionEvent<TSourceEvent> extends Intersection {
   /** stopPropagation will stop underlying handlers from firing */
   stopPropagation: () => void
   /** The original host event */
-  nativeEvent: TSourceEvent
+  nativeEvent: TEvent
   /** If the event was stopped by calling stopPropagation */
   stopped: boolean
 }
 
-export type Camera = THREE.OrthographicCamera | THREE.PerspectiveCamera
-export type ThreeEvent<TEvent> = IntersectionEvent<TEvent>
 export type DomEvent = PointerEvent | MouseEvent | WheelEvent
 
-export type Events = {
+export interface Events {
   onClick: EventListener
   onContextMenu: EventListener
   onDoubleClick: EventListener
@@ -50,7 +48,7 @@ export type Events = {
   onLostPointerCapture: EventListener
 }
 
-export type EventHandlers = {
+export interface EventHandlers {
   onClick?: (event: ThreeEvent<MouseEvent>) => void
   onContextMenu?: (event: ThreeEvent<MouseEvent>) => void
   onDoubleClick?: (event: ThreeEvent<MouseEvent>) => void

--- a/packages/fiber/src/core/hooks.tsx
+++ b/packages/fiber/src/core/hooks.tsx
@@ -5,7 +5,7 @@ import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader'
 import { suspend, preload, clear } from 'suspend-react'
 import { context, RootState, RenderCallback, StageTypes } from './store'
 import { buildGraph, ObjectMap, is, useMutableCallback, useIsomorphicLayoutEffect } from './utils'
-import { Stage, Stages, UpdateCallback } from './stages'
+import { Stages } from './stages'
 import { LoadingManager } from 'three'
 import { Instance } from './renderer'
 
@@ -74,7 +74,7 @@ export function useFrame(callback: RenderCallback, renderPriority: number = 0): 
  * Executes a callback in a given update stage.
  * Uses the stage instance to indetify which stage to target in the lifecycle.
  */
-export function useUpdate(callback: UpdateCallback, stage: StageTypes = Stages.Update) {
+export function useUpdate(callback: RenderCallback, stage: StageTypes = Stages.Update) {
   const store = useStore()
   const stages = store.getState().internal.stages
   // Memoize ref

--- a/packages/fiber/src/core/hooks.tsx
+++ b/packages/fiber/src/core/hooks.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { StateSelector, EqualityChecker } from 'zustand'
 import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader'
 import { suspend, preload, clear } from 'suspend-react'
-import { context, RootState, RenderCallback, StageTypes } from './store'
+import { context, RootState, RenderCallback, UpdateCallback, StageTypes } from './store'
 import { buildGraph, ObjectMap, is, useMutableCallback, useIsomorphicLayoutEffect } from './utils'
 import { Stages } from './stages'
 import { LoadingManager } from 'three'
@@ -74,7 +74,7 @@ export function useFrame(callback: RenderCallback, renderPriority: number = 0): 
  * Executes a callback in a given update stage.
  * Uses the stage instance to indetify which stage to target in the lifecycle.
  */
-export function useUpdate(callback: RenderCallback, stage: StageTypes = Stages.Update) {
+export function useUpdate(callback: UpdateCallback, stage: StageTypes = Stages.Update) {
   const store = useStore()
   const stages = store.getState().internal.stages
   // Memoize ref

--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -605,6 +605,7 @@ export type {
   Size,
   Viewport,
   RenderCallback,
+  UpdateCallback,
   LegacyAlways,
   FrameloopMode,
   FrameloopRender,

--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -616,6 +616,7 @@ export type {
   Renderer,
   XRManager,
   RootState,
+  RootStore,
 } from './store'
 export type {
   Intersection,

--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -589,3 +589,43 @@ export {
   act,
   roots as _roots,
 }
+
+export type {
+  AttachFnType,
+  AttachType,
+  ConstructorRepresentation,
+  Catalogue,
+  Args,
+  InstanceProps,
+  Instance,
+} from './renderer'
+export type {
+  Subscription,
+  Dpr,
+  Size,
+  Viewport,
+  RenderCallback,
+  LegacyAlways,
+  FrameloopMode,
+  FrameloopRender,
+  FrameloopLegacy,
+  Frameloop,
+  Performance,
+  Renderer,
+  XRManager,
+  RootState,
+} from './store'
+export type {
+  Intersection,
+  ThreeEvent,
+  DomEvent,
+  Events,
+  EventHandlers,
+  FilterFunction,
+  ComputeFunction,
+  EventManager,
+  createEvents,
+} from './events'
+export type { ObjectMap, Camera } from './utils'
+export type { GlobalRenderCallback, GlobalEffectType, flushGlobalEffects } from './loop'
+export { Stage, FixedStage, Stages } from './stages'

--- a/packages/fiber/src/core/loop.ts
+++ b/packages/fiber/src/core/loop.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three'
 import { Root } from './renderer'
 import { RootState, Subscription } from './store'
 
-type GlobalRenderCallback = (timeStamp: number) => void
+export type GlobalRenderCallback = (timestamp: number) => void
 type SubItem = { callback: GlobalRenderCallback }
 
 function createSubs(callback: GlobalRenderCallback, subs: Set<SubItem>): () => void {

--- a/packages/fiber/src/core/stages.ts
+++ b/packages/fiber/src/core/stages.ts
@@ -1,17 +1,8 @@
-import { MutableRefObject } from 'react'
 import { StoreApi, UseBoundStore } from 'zustand'
-import { RootState } from './store'
+import { RootState, Subscription } from './store'
 
-export interface UpdateCallback {
-  (state: RootState, delta: number, frame?: XRFrame): void
-}
-
-export type UpdateCallbackRef = MutableRefObject<UpdateCallback>
-type Store = UseBoundStore<RootState, StoreApi<RootState>>
-export type UpdateSubscription = { ref: UpdateCallbackRef; store: Store }
-
-export type FixedStageOptions = { fixedStep?: number; maxSubsteps?: number }
-export type FixedStageProps = { fixedStep: number; maxSubsteps: number; accumulator: number; alpha: number }
+// TODO: Remove deprecated fields in `Subscription`
+export type UpdateSubscription = Omit<Subscription, 'priority'>
 
 /**
  * Class representing a stage that updates every frame.
@@ -48,7 +39,7 @@ export class Stage {
    * @param store - The store to be used with the callback execution.
    * @returns A function to remove the subscription.
    */
-  add(ref: UpdateCallbackRef, store: Store) {
+  add(ref: UpdateSubscription['ref'], store: UseBoundStore<RootState, StoreApi<RootState>>) {
     this.subscribers.push({ ref, store })
 
     return () => {

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -21,19 +21,20 @@ export const privateKeys = [
 
 export type PrivateKeys = typeof privateKeys[number]
 
-export interface Intersection extends THREE.Intersection {
-  eventObject: THREE.Object3D
-}
-
-export type Subscription = {
+export interface Subscription {
   ref: React.MutableRefObject<RenderCallback>
   priority: number
   store: UseBoundStore<RootState, StoreApi<RootState>>
 }
 
 export type Dpr = number | [min: number, max: number]
-export type Size = { width: number; height: number; top: number; left: number }
-export type Viewport = Size & {
+export interface Size {
+  width: number
+  height: number
+  top: number
+  left: number
+}
+export interface Viewport extends Size {
   /** The initial pixel ratio */
   initialDpr: number
   /** Current pixel ratio */
@@ -46,15 +47,16 @@ export type Viewport = Size & {
   aspect: number
 }
 
+// TODO: rename to UpdateCallback
 export type RenderCallback = (state: RootState, delta: number, frame?: XRFrame) => void
 
-type LegacyAlways = 'always'
+export type LegacyAlways = 'always'
 export type FrameloopMode = LegacyAlways | 'auto' | 'demand' | 'never'
-type FrameloopRender = 'auto' | 'manual'
+export type FrameloopRender = 'auto' | 'manual'
 export type FrameloopLegacy = 'always' | 'demand' | 'never'
 export type Frameloop = FrameloopLegacy | { mode?: FrameloopMode; render?: FrameloopRender; maxDelta?: number }
 
-export type Performance = {
+export interface Performance {
   /** Current performance normal, between min and max */
   current: number
   /** How low the performance can go, between 0 and max */
@@ -67,12 +69,14 @@ export type Performance = {
   regress: () => void
 }
 
-export type Renderer = { render: (scene: THREE.Scene, camera: THREE.Camera) => any }
+export interface Renderer {
+  render: (scene: THREE.Scene, camera: THREE.Camera) => any
+}
 export const isRenderer = (def: any) => !!def?.render
 
 export type StageTypes = Stage | FixedStage
 
-export type InternalState = {
+export interface InternalState {
   interaction: THREE.Object3D[]
   hovered: Map<string, ThreeEvent<DomEvent>>
   subscribers: Subscription[]
@@ -96,7 +100,12 @@ export type InternalState = {
   ) => () => void
 }
 
-export type RootState = {
+export interface XRManager {
+  connect: () => void
+  disconnect: () => void
+}
+
+export interface RootState {
   /** Set current state */
   set: SetState<RootState>
   /** Get current state */
@@ -114,7 +123,7 @@ export type RootState = {
   /** Event layer interface, contains the event handler and the node they're connected to */
   events: EventManager<any>
   /** XR interface */
-  xr: { connect: () => void; disconnect: () => void }
+  xr: XRManager
   /** Currently used controls */
   controls: THREE.EventDispatcher | null
   /** Normalized event coordinates */
@@ -206,7 +215,7 @@ const createStore = (
       camera: null as unknown as Camera,
       raycaster: null as unknown as THREE.Raycaster,
       events: { priority: 1, enabled: true, connected: false },
-      xr: null as unknown as { connect: () => void; disconnect: () => void },
+      xr: null as unknown as XRManager,
 
       invalidate: (frames = 1) => invalidate(get(), frames),
       advance: (timestamp: number, runGlobalEffects?: boolean) => advance(timestamp, runGlobalEffects, get()),

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -47,8 +47,8 @@ export interface Viewport extends Size {
   aspect: number
 }
 
-// TODO: rename to UpdateCallback
 export type RenderCallback = (state: RootState, delta: number, frame?: XRFrame) => void
+export type UpdateCallback = RenderCallback
 
 export type LegacyAlways = 'always'
 export type FrameloopMode = LegacyAlways | 'auto' | 'demand' | 'never'

--- a/packages/fiber/src/index.tsx
+++ b/packages/fiber/src/index.tsx
@@ -1,27 +1,4 @@
-export * from './three-types'
-export type {
-  AttachFnType,
-  AttachType,
-  ConstructorRepresentation,
-  Catalogue,
-  Args,
-  InstanceProps,
-  Instance,
-} from './core/renderer'
-export type {
-  Intersection,
-  Subscription,
-  Dpr,
-  Size,
-  Viewport,
-  RenderCallback,
-  Performance,
-  RootState,
-} from './core/store'
-export type { ThreeEvent, Events, EventManager, ComputeFunction } from './core/events'
-export type { ObjectMap, Camera } from './core/utils'
-export * from './web/Canvas'
-export { createEvents } from './core/events'
-export { createPointerEvents as events } from './web/events'
 export * from './core'
-export { Stage, FixedStage, Stages } from './core/stages'
+export * from './three-types'
+export * from './web/Canvas'
+export { createPointerEvents as events } from './web/events'

--- a/packages/fiber/src/native.tsx
+++ b/packages/fiber/src/native.tsx
@@ -1,25 +1,4 @@
 export * from './three-types'
-export type {
-  AttachFnType,
-  AttachType,
-  ConstructorRepresentation,
-  Catalogue,
-  Args,
-  InstanceProps,
-  Instance,
-} from './core/renderer'
-export type {
-  Intersection,
-  Subscription,
-  Dpr,
-  Size,
-  Viewport,
-  RenderCallback,
-  Performance,
-  RootState,
-} from './core/store'
-export type { ThreeEvent, Events, EventManager, ComputeFunction } from './core/events'
-export type { ObjectMap, Camera } from './core/utils'
+export * from './core'
 export * from './native/Canvas'
 export { createTouchEvents as events } from './native/events'
-export * from './core'


### PR DESCRIPTION
Exports public-facing types from the core, namely events and state keys.