### PR TITLE
fix(core): set THREE.ColorManagement.enabled if able

### DIFF
--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -28,7 +28,7 @@ import {
   useIsomorphicLayoutEffect,
   Camera,
   updateCamera,
-  setDeep,
+  ColorManagement,
 } from './utils'
 import { useStore } from './hooks'
 import { OffscreenCanvas } from 'three'
@@ -273,8 +273,9 @@ function createRoot<TCanvas extends Element>(canvas: TCanvas): ReconcilerRoot<TC
 
       // Safely set color management if available.
       // Avoid accessing THREE.ColorManagement to play nice with older versions
-      if ('ColorManagement' in THREE) {
-        setDeep(THREE, legacy, ['ColorManagement', 'legacyMode'])
+      if (ColorManagement) {
+        if ('enabled' in ColorManagement) ColorManagement.enabled = legacy
+        else if ('legacyMode' in ColorManagement) ColorManagement.legacyMode = legacy
       }
       const outputEncoding = linear ? THREE.LinearEncoding : THREE.sRGBEncoding
       const toneMapping = flat ? THREE.NoToneMapping : THREE.ACESFilmicToneMapping

--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -274,7 +274,7 @@ function createRoot<TCanvas extends Element>(canvas: TCanvas): ReconcilerRoot<TC
       // Safely set color management if available.
       // Avoid accessing THREE.ColorManagement to play nice with older versions
       if (ColorManagement) {
-        if ('enabled' in ColorManagement) ColorManagement.enabled = legacy
+        if ('enabled' in ColorManagement) ColorManagement.enabled = !legacy
         else if ('legacyMode' in ColorManagement) ColorManagement.legacyMode = legacy
       }
       const outputEncoding = linear ? THREE.LinearEncoding : THREE.sRGBEncoding

--- a/packages/fiber/tests/core/renderer.test.tsx
+++ b/packages/fiber/tests/core/renderer.test.tsx
@@ -686,6 +686,7 @@ describe('renderer', () => {
   })
 
   it('should respect legacy prop', async () => {
+    // r139 legacyMode
     await act(async () => {
       root.configure({ legacy: true }).render(<group />)
     })
@@ -695,6 +696,19 @@ describe('renderer', () => {
       root.configure({ legacy: false }).render(<group />)
     })
     expect((THREE as any).ColorManagement.legacyMode).toBe(false)
+
+    // r150 !enabled
+    ;(THREE as any).ColorManagement.enabled = true
+
+    await act(async () => {
+      root.configure({ legacy: true }).render(<group />)
+    })
+    expect((THREE as any).ColorManagement.enabled).toBe(false)
+
+    await act(async () => {
+      root.configure({ legacy: false }).render(<group />)
+    })
+    expect((THREE as any).ColorManagement.enabled).toBe(true)
   })
 
   it('can handle createPortal', async () => {


### PR DESCRIPTION
Prefers to set `THREE.ColorManagement.enabled` over `THREE.ColorManagement.legacyMode` if able (see https://github.com/mrdoob/three.js/pull/24940). This is a contentious part of THREE's API, so this will let us work around any further mutations without deprecation warnings.
