### PR TITLE
docs: update to docs to reference pointerEvents

### DIFF
--- a/docs/API/events.mdx
+++ b/docs/API/events.mdx
@@ -143,3 +143,14 @@ function App() {
   )
 }
 ```
+or the `pointerEvents` prop on the `Canvas` ( this will also set `pointer-events: none` instead of `auto`)
+```jsx
+function App() {
+  const target = useRef()
+  return (
+    <div ref={target}>
+      <Canvas pointerEvents={target}></Canvas>
+    </div>
+  )
+}
+```


### PR DESCRIPTION
I had to look up source to figure out why `pointer-events` were `auto` with a custom target.  
I don't know if the `pointerEvents` prop on the canvas is a new thing, but I think a reference here to it is a good idea.