### PR TITLE
Tighten allowed type for object prop on primitives

### DIFF
--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -188,7 +188,7 @@ export type MeshMatcapMaterialProps = MaterialNode<THREE.MeshMatcapMaterial, [TH
 export type LineDashedMaterialProps = MaterialNode<THREE.LineDashedMaterial, [THREE.LineDashedMaterialParameters]>
 export type LineBasicMaterialProps = MaterialNode<THREE.LineBasicMaterial, [THREE.LineBasicMaterialParameters]>
 
-export type PrimitiveProps = { object: any } & { [properties: string]: any }
+export type PrimitiveProps = { object: object } & { [properties: string]: any }
 
 export type LightProps = LightNode<THREE.Light, typeof THREE.Light>
 export type SpotLightShadowProps = Node<THREE.SpotLightShadow, typeof THREE.SpotLightShadow>


### PR DESCRIPTION
Primitives can only be rendered from objects, this helps catch mistakenly passing in `null` or `undefined` into the `object` prop.