### PR TITLE
fix(types): don't overwrite types of infer fallback

### DIFF
--- a/packages/fiber/src/core/reconciler.ts
+++ b/packages/fiber/src/core/reconciler.ts
@@ -22,8 +22,8 @@ export interface Catalogue {
 
 export type Args<T> = T extends ConstructorRepresentation ? ConstructorParameters<T> : any[]
 
-export interface InstanceProps<T = any> {
-  args?: Args<T>
+export interface InstanceProps<T = any, P = any> {
+  args?: Args<P>
   object?: T
   visible?: boolean
   dispose?: null

--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -19,8 +19,8 @@ type MathProps<P> = {
       ? M extends VectorRepresentation
         ? M | Parameters<M['set']> | Parameters<M['setScalar']>[0]
         : M | Parameters<M['set']>
-      : {}
-    : {}
+      : M
+    : P[K]
 }
 
 interface RaycastableRepresentation {

--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -39,7 +39,7 @@ type ElementProps<T extends ConstructorRepresentation, P = InstanceType<T>> = Pa
 >
 
 export type ThreeElement<T extends ConstructorRepresentation> = Mutable<
-  Overwrite<ElementProps<T>, Omit<InstanceProps<InstanceType<T>>, 'object'>>
+  Overwrite<ElementProps<T>, Omit<InstanceProps<InstanceType<T>, T>, 'object'>>
 >
 
 type ThreeExports = typeof THREE

--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -11,7 +11,7 @@ interface MathRepresentation {
 interface VectorRepresentation extends MathRepresentation {
   setScalar(s: number): any
 }
-type MathProps<P> = {
+type WithMathProps<P> = {
   [K in keyof P]: P[K] extends infer M
     ? M extends THREE.Color
       ? ConstructorParameters<typeof THREE.Color> | THREE.ColorRepresentation
@@ -35,7 +35,7 @@ interface ReactProps<P> {
 }
 
 type ElementProps<T extends ConstructorRepresentation, P = InstanceType<T>> = Partial<
-  Overwrite<P, MathProps<EventProps<P>> & ReactProps<P>>
+  Overwrite<WithMathProps<P>, ReactProps<P> & EventProps<P>>
 >
 
 export type ThreeElement<T extends ConstructorRepresentation> = Mutable<

--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -35,7 +35,7 @@ interface ReactProps<P> {
 }
 
 type ElementProps<T extends ConstructorRepresentation, P = InstanceType<T>> = Partial<
-  Overwrite<P, ReactProps<P> & MathProps<P> & EventProps<P>>
+  Overwrite<P, MathProps<EventProps<P>> & ReactProps<P>>
 >
 
 export type ThreeElement<T extends ConstructorRepresentation> = Mutable<


### PR DESCRIPTION
Addresses some type regressions with `{}` and `children` investigated in #2668.