### PR TITLE
Add ReactThreeFiber namespace and math prop types back

### DIFF
--- a/packages/fiber/src/index.tsx
+++ b/packages/fiber/src/index.tsx
@@ -1,4 +1,7 @@
-export * from './core'
 export * from './three-types'
+import * as ReactThreeFiber from './three-types'
+export { ReactThreeFiber }
+
+export * from './core'
 export * from './web/Canvas'
 export { createPointerEvents as events } from './web/events'

--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -1,6 +1,23 @@
 import type * as THREE from 'three'
 import type { EventHandlers, InstanceProps, ConstructorRepresentation } from './core'
 
+/**
+ * Turn an implementation of THREE.Vector in to the type that an r3f component would accept as a prop.
+ */
+type VectorLike<VectorClass extends THREE.Vector> =
+  | VectorClass
+  | Parameters<VectorClass['set']>
+  | Readonly<Parameters<VectorClass['set']>>
+  | Parameters<VectorClass['setScalar']>[0]
+
+export type Vector2 = VectorLike<THREE.Vector2>
+export type Vector3 = VectorLike<THREE.Vector3>
+export type Vector4 = VectorLike<THREE.Vector4>
+export type Color = ConstructorParameters<typeof THREE.Color> | THREE.Color | number | string // Parameters<T> will not work here because of multiple function signatures in three.js types
+export type ColorArray = typeof THREE.Color | Parameters<THREE.Color['set']>
+export type Layers = THREE.Layers | Parameters<THREE.Layers['set']>[0]
+export type Quaternion = THREE.Quaternion | Parameters<THREE.Quaternion['set']>
+
 type Mutable<P> = { [K in keyof P]: P[K] | Readonly<P[K]> }
 type NonFunctionKeys<P> = { [K in keyof P]-?: P[K] extends Function ? never : K }[keyof P]
 type Overwrite<P, O> = Omit<P, NonFunctionKeys<O>> & O


### PR DESCRIPTION
Exports types under the `ReactThreeFiber` namespace and adds the following math prop types back:

```ts
type VectorLike<VectorClass extends THREE.Vector> =
  | VectorClass
  | Parameters<VectorClass['set']>
  | Readonly<Parameters<VectorClass['set']>>
  | Parameters<VectorClass['setScalar']>[0]

export type Vector2 = VectorLike<THREE.Vector2>
export type Vector3 = VectorLike<THREE.Vector3>
export type Vector4 = VectorLike<THREE.Vector4>
export type Color = ConstructorParameters<typeof THREE.Color> | THREE.Color | number | string // Parameters<T> will not work here because of multiple function signatures in three.js types
export type ColorArray = typeof THREE.Color | Parameters<THREE.Color['set']>
export type Layers = THREE.Layers | Parameters<THREE.Layers['set']>[0]
export type Quaternion = THREE.Quaternion | Parameters<THREE.Quaternion['set']>
```