### PR TITLE
fix: Primitives are incorrectly swapped on key change in maps #2679

### DIFF
--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -31,6 +31,7 @@ export type LocalState = {
   attach?: AttachType
   previousAttach: any
   memoizedProps: { [key: string]: any }
+  autoRemovedBeforeAppend?: boolean
 }
 
 export type AttachFnType = (parent: Instance, self: Instance) => () => void
@@ -268,7 +269,12 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
     instance.__r3f.objects.forEach((child) => appendChild(newInstance, child))
     instance.__r3f.objects = []
 
-    removeChild(parent, instance)
+    if (!instance.__r3f.autoRemovedBeforeAppend) {
+      removeChild(parent, instance)
+    }
+    if (newInstance.parent) {
+      newInstance.__r3f.autoRemovedBeforeAppend = true
+    }
     appendChild(parent, newInstance)
 
     // Re-bind event handlers

--- a/packages/fiber/tests/core/renderer.test.tsx
+++ b/packages/fiber/tests/core/renderer.test.tsx
@@ -520,6 +520,54 @@ describe('renderer', () => {
     expect((state.scene.children[0] as any).test).toBeInstanceOf(THREE.Group)
   })
 
+  it('can swap 4 array primitives', async () => {
+    let state: RootState = null!
+    const a = new THREE.Group()
+    const b = new THREE.Group()
+    const c = new THREE.Group()
+    const d = new THREE.Group()
+    const array = [a, b, c, d]
+
+    const Test = ({ array }: { array: THREE.Group[] }) => (
+      <>
+        {array.map((group, i) => (
+          <primitive key={i} object={group} />
+        ))}
+      </>
+    )
+
+    await act(async () => {
+      state = root.render(<Test array={array} />).getState()
+    })
+
+    expect(state.scene.children[0]).toBe(a)
+    expect(state.scene.children[1]).toBe(b)
+    expect(state.scene.children[2]).toBe(c)
+    expect(state.scene.children[3]).toBe(d)
+
+    const reversedArray = [...array.reverse()]
+
+    await act(async () => {
+      state = root.render(<Test array={reversedArray} />).getState()
+    })
+
+    expect(state.scene.children[0]).toBe(d)
+    expect(state.scene.children[1]).toBe(c)
+    expect(state.scene.children[2]).toBe(b)
+    expect(state.scene.children[3]).toBe(a)
+
+    const mixedArray = [b, a, d, c]
+
+    await act(async () => {
+      state = root.render(<Test array={mixedArray} />).getState()
+    })
+
+    expect(state.scene.children[0]).toBe(b)
+    expect(state.scene.children[1]).toBe(a)
+    expect(state.scene.children[2]).toBe(d)
+    expect(state.scene.children[3]).toBe(c)
+  })
+
   it('will make an Orthographic Camera & set the position', async () => {
     let camera: THREE.Camera = null!
 


### PR DESCRIPTION
Would this be a viable solution to #2679 ?


I'm least confident about the naming of `autoRemovedBeforeAppend` :D