### PR TITLE
Guard against frameloop: never render calls

### DIFF
--- a/docs/getting-started/examples.mdx
+++ b/docs/getting-started/examples.mdx
@@ -8,7 +8,7 @@ nav: 3
 
 <Grid cols={1}>
   <li>
-    <Codesandbox id="024uom" />
+    <Codesandbox id="bst0cy" />
   </li>
 </Grid>
 <Grid cols={2}>
@@ -16,7 +16,7 @@ nav: 3
     <Codesandbox id="lxvqek" />
   </li>
   <li>
-    <Codesandbox id="j3ycvl" />
+    <Codesandbox id="fslt99" />
   </li>
   <li>
     <Codesandbox id="2qfxj4" />
@@ -27,7 +27,10 @@ nav: 3
 </Grid>
 <Grid cols={4}>
   <li>
-    <Codesandbox id="fslt99" />
+    <Codesandbox id="j3ycvl" />
+  </li>
+  <li>
+    <Codesandbox id="024uom" />
   </li>
   <li>
     <Codesandbox id="f79ucc" />

--- a/packages/fiber/src/core/loop.ts
+++ b/packages/fiber/src/core/loop.ts
@@ -99,8 +99,10 @@ export function createLoop<TCanvas>(roots: Map<TCanvas, Root>) {
       if (
         state.internal.active &&
         (state.frameloop === 'always' || state.internal.frames > 0) &&
-        !state.gl.xr?.isPresenting
+        !state.gl.xr?.isPresenting &&
+        state.frameloop !== 'never'
       ) {
+        console.log(state.frameloop, state.internal.frames)
         repeat += render(timestamp, state)
       }
     }

--- a/packages/fiber/src/core/loop.ts
+++ b/packages/fiber/src/core/loop.ts
@@ -102,7 +102,6 @@ export function createLoop<TCanvas>(roots: Map<TCanvas, Root>) {
         !state.gl.xr?.isPresenting &&
         state.frameloop !== 'never'
       ) {
-        console.log(state.frameloop, state.internal.frames)
         repeat += render(timestamp, state)
       }
     }


### PR DESCRIPTION
This adds a single guard to the `render()` call in `loop()`. This makes it so that if the frameloop changes from `always` to `never`, it does not fire off one last `render()` call without `advance()` which then has the rAF timestamp passed in, which is in milliseconds instead of seconds, and reports deltas at absurdly high values.