### PR TITLE
[v9] fix(core): correctly swap map elements on invalidate

### DIFF
--- a/packages/fiber/src/core/reconciler.ts
+++ b/packages/fiber/src/core/reconciler.ts
@@ -42,6 +42,7 @@ export interface Instance<O = any> {
   attach?: AttachType<O>
   previousAttach?: any
   isHidden: boolean
+  autoRemovedBeforeAppend?: boolean
 }
 
 interface HostConfig {
@@ -243,7 +244,12 @@ function switchInstance(
   // Link up new instance
   const parent = oldInstance.parent
   if (parent) {
-    insertBefore(parent, newInstance, oldInstance, true)
+    // Manually handle replace https://github.com/pmndrs/react-three-fiber/pull/2680
+    // insertBefore(parent, newInstance, oldInstance, true)
+
+    if (!oldInstance.autoRemovedBeforeAppend) removeChild(parent, oldInstance)
+    if (newInstance.parent) newInstance.autoRemovedBeforeAppend = true
+    appendChild(parent, newInstance)
   }
 
   // This evil hack switches the react-internal fiber node

--- a/packages/fiber/src/core/reconciler.ts
+++ b/packages/fiber/src/core/reconciler.ts
@@ -156,7 +156,7 @@ function insertBefore(
     beforeChild.object instanceof THREE.Object3D
   ) {
     child.object.parent = parent.object
-    parent.object.children.splice(parent.object.children.indexOf(beforeChild.object), 0, child.object)
+    parent.object.children.splice(parent.object.children.indexOf(beforeChild.object), replace ? 1 : 0, child.object)
     child.object.dispatchEvent({ type: 'added' })
   }
 

--- a/packages/fiber/tests/renderer.test.tsx
+++ b/packages/fiber/tests/renderer.test.tsx
@@ -393,6 +393,35 @@ describe('renderer', () => {
     expect(disposeDeclarativePrimitive).toBeCalled()
   })
 
+  it('can swap 4 array primitives', async () => {
+    const a = new THREE.Group()
+    const b = new THREE.Group()
+    const c = new THREE.Group()
+    const d = new THREE.Group()
+
+    const Test = ({ array }: { array: THREE.Group[] }) => (
+      <>
+        {array.map((group, i) => (
+          <primitive key={i} object={group} />
+        ))}
+      </>
+    )
+
+    const array = [a, b, c, d]
+    const store = await act(async () => root.render(<Test array={array} />))
+    const { scene } = store.getState()
+
+    expect(scene.children).toStrictEqual(array)
+
+    const reversedArray = [d, c, b, a]
+    await act(async () => root.render(<Test array={reversedArray} />))
+    expect(scene.children).toStrictEqual(reversedArray)
+
+    const mixedArray = [b, a, d, c]
+    await act(async () => root.render(<Test array={mixedArray} />))
+    expect(scene.children).toStrictEqual(mixedArray)
+  })
+
   it('should gracefully handle text', async () => {
     const warn = console.warn
     console.warn = jest.fn()

--- a/packages/test-renderer/src/__tests__/__snapshots__/RTTR.core.test.tsx.snap
+++ b/packages/test-renderer/src/__tests__/__snapshots__/RTTR.core.test.tsx.snap
@@ -389,6 +389,13 @@ Array [
           Object {
             "children": Array [],
             "props": Object {
+              "attach": "material",
+            },
+            "type": "meshBasicMaterial",
+          },
+          Object {
+            "children": Array [],
+            "props": Object {
               "args": Array [
                 2,
                 2,
@@ -396,13 +403,6 @@ Array [
               "attach": "geometry",
             },
             "type": "boxGeometry",
-          },
-          Object {
-            "children": Array [],
-            "props": Object {
-              "attach": "material",
-            },
-            "type": "meshBasicMaterial",
           },
         ],
         "props": Object {


### PR DESCRIPTION
Mirrors https://github.com/pmndrs/react-three-fiber/pull/2680 in the new architecture.