### PR TITLE
feat: Add placeholder support for useLoader

### DIFF
--- a/packages/fiber/src/core/hooks.tsx
+++ b/packages/fiber/src/core/hooks.tsx
@@ -117,7 +117,9 @@ export function useLoader<T, U extends string | string[], L extends LoaderProto<
   input: U,
   extensions?: Extensions<L>,
   onProgress?: (event: ProgressEvent<EventTarget>) => void,
-  placeholder?: U extends any[] ? BranchingReturn<R, GLTF, GLTF & ObjectMap>[] : BranchingReturn<R, GLTF, GLTF & ObjectMap>
+  placeholder?: U extends any[]
+    ? BranchingReturn<R, GLTF, GLTF & ObjectMap>[]
+    : BranchingReturn<R, GLTF, GLTF & ObjectMap>,
 ): U extends any[] ? BranchingReturn<R, GLTF, GLTF & ObjectMap>[] : BranchingReturn<R, GLTF, GLTF & ObjectMap> {
   if (!input && placeholder) return placeholder
 

--- a/packages/fiber/src/core/hooks.tsx
+++ b/packages/fiber/src/core/hooks.tsx
@@ -117,7 +117,10 @@ export function useLoader<T, U extends string | string[], L extends LoaderProto<
   input: U,
   extensions?: Extensions<L>,
   onProgress?: (event: ProgressEvent<EventTarget>) => void,
+  placeholder?: U extends any[] ? BranchingReturn<R, GLTF, GLTF & ObjectMap>[] : BranchingReturn<R, GLTF, GLTF & ObjectMap>
 ): U extends any[] ? BranchingReturn<R, GLTF, GLTF & ObjectMap>[] : BranchingReturn<R, GLTF, GLTF & ObjectMap> {
+  if (!input && placeholder) return placeholder
+
   // Use suspense to load async assets
   const keys = (Array.isArray(input) ? input : [input]) as string[]
   const results = suspend(loadingFn<L>(extensions, onProgress), [Proto, ...keys], { equal: is.equ })


### PR DESCRIPTION
related issue #2696 

I believe doing it this way should be a non breaking change for everyone else while allowing others to use the placeholder property to display a mesh while waiting for the main mesh to load.
For that the path would need to be provided by the `useDeferredValue` hook.  
