### PR TITLE
[v9] experiment(types): ThreeElements extends interface extends mapped type

### DIFF
--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -47,11 +47,12 @@ export type ThreeElement<T extends ConstructorRepresentation> = Mutable<
 >
 
 type ThreeExports = typeof THREE
-type ThreeElementsImpl = {
+type ThreeElementsType = {
   [K in keyof ThreeExports as Uncapitalize<K>]: ThreeExports[K] extends ConstructorRepresentation
     ? ThreeElement<ThreeExports[K]>
     : never
 }
+interface ThreeElementsImpl extends ThreeElementsType {}
 
 export interface ThreeElements extends ThreeElementsImpl {
   primitive: Omit<ThreeElement<any>, 'args'> & { object: object }


### PR DESCRIPTION
Tries to address an issue in https://github.com/pmndrs/react-three-fiber/issues/2668#issuecomment-1383008968 where writing into `ThreeElements` completely overwrites it.

```ts
declare module '@react-three/fiber' {
  interface ThreeElements {
    element: ThreeElement<typeof Element>
  }
}
```