### PR TITLE
fix(core): don't use three.js math identity for HMR

### DIFF
--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -282,18 +282,15 @@ export function applyProps(instance: Instance, data: InstanceProps | DiffSet) {
     // with their respective constructor/set arguments
     // For removed props, try to set default values, if possible
     if (value === DEFAULT + 'remove') {
-      if (targetProp && targetProp.constructor) {
-        // use the prop constructor to find the default it should be
-        value = new targetProp.constructor(...(memoized.args ?? []))
-      } else if (currentInstance.constructor) {
+      if (currentInstance.constructor) {
         // create a blank slate of the instance and copy the particular parameter.
         // @ts-ignore
         const defaultClassCall = new currentInstance.constructor(...(currentInstance.__r3f.memoizedProps.args ?? []))
         value = defaultClassCall[targetProp]
-        // destory the instance
+        // destroy the instance
         if (defaultClassCall.dispose) defaultClassCall.dispose()
-        // instance does not have constructor, just set it to 0
       } else {
+        // instance does not have constructor, just set it to 0
         value = 0
       }
     }

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -286,7 +286,7 @@ export function applyProps(instance: Instance, data: InstanceProps | DiffSet) {
         // create a blank slate of the instance and copy the particular parameter.
         // @ts-ignore
         const defaultClassCall = new currentInstance.constructor(...(currentInstance.__r3f.memoizedProps.args ?? []))
-        value = defaultClassCall[targetProp]
+        value = defaultClassCall[key]
         // destroy the instance
         if (defaultClassCall.dispose) defaultClassCall.dispose()
       } else {

--- a/packages/fiber/tests/core/renderer.test.tsx
+++ b/packages/fiber/tests/core/renderer.test.tsx
@@ -834,7 +834,7 @@ describe('renderer', () => {
   })
 
   // https://github.com/mrdoob/three.js/issues/21209
-  it("can handle HMR where three.js isn't reliable", async () => {
+  it("can handle HMR default where three.js isn't reliable", async () => {
     const ref = React.createRef<THREE.Mesh>()
 
     function Test() {

--- a/packages/fiber/tests/core/renderer.test.tsx
+++ b/packages/fiber/tests/core/renderer.test.tsx
@@ -832,4 +832,21 @@ describe('renderer', () => {
     expect(texture2.needsUpdate).toBe(true)
     expect(texture2.name).toBe('test')
   })
+
+  // https://github.com/mrdoob/three.js/issues/21209
+  it("can handle HMR where three.js isn't reliable", async () => {
+    const ref = React.createRef<THREE.Mesh>()
+
+    function Test() {
+      const [scale, setScale] = React.useState(true)
+      const props: any = {}
+      if (scale) props.scale = 0.5
+      React.useEffect(() => void setScale(false), [])
+      return <mesh ref={ref} {...props} />
+    }
+
+    await act(async () => root.render(<Test />))
+
+    expect(ref.current!.scale.toArray()).toStrictEqual(new THREE.Object3D().scale.toArray())
+  })
 })


### PR DESCRIPTION
Mirrors https://github.com/pmndrs/react-three-fiber/pull/2465#discussion_r967339200 from v9. Correctly sets atomic props' defaults where unset by three.js.