### PR TITLE
[v9] refactor: frameloop and render props update

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "singleQuote": true,
   "tabWidth": 2,
   "printWidth": 120,
-  "jsxBracketSameLine": true
+  "jsxBracketSameLine": true,
+  "endOfLine": "auto"
 }

--- a/example/src/demos/Update.tsx
+++ b/example/src/demos/Update.tsx
@@ -114,7 +114,7 @@ function Update() {
 
 export default function App() {
   return (
-    <Canvas stages={lifecycle} frameloop={{ mode: 'auto', render: 'manual' }}>
+    <Canvas stages={lifecycle} render="manual">
       <Update />
     </Canvas>
   )

--- a/packages/fiber/src/core/renderer.tsx
+++ b/packages/fiber/src/core/renderer.tsx
@@ -18,6 +18,7 @@ import {
   Subscription,
   Frameloop,
   RootStore,
+  renderApi,
 } from './store'
 import { reconciler, Root } from './reconciler'
 import { invalidate, advance } from './loop'
@@ -150,12 +151,12 @@ const createStages = (stages: Stage[] | undefined, store: RootStore) => {
   Stages.Update.add(frameCallback, store)
 
   // Add render callback to render stage
-  const renderCallback = {
+  renderApi.callback = {
     current(state: RootState) {
-      if (state.internal.render === 'auto' && state.gl.render) state.gl.render(state.scene, state.camera)
+      if (state.gl.render) state.gl.render(state.scene, state.camera)
     },
   }
-  Stages.Render.add(renderCallback, store)
+  renderApi.add(store)
 }
 
 export interface ReconcilerRoot<TCanvas extends Element> {
@@ -222,6 +223,7 @@ export function createRoot<TCanvas extends Element>(canvas: TCanvas): Reconciler
         camera: cameraOptions,
         onPointerMissed,
         stages,
+        render,
       } = props
 
       let state = store.getState()
@@ -331,7 +333,9 @@ export function createRoot<TCanvas extends Element>(canvas: TCanvas): Reconciler
         state.setSize(size.width, size.height, size.top, size.left)
       }
       // Check frameloop
-      if (state.frameloop !== frameloop) state.setFrameloop(frameloop)
+      if (frameloop) state.setFrameloop(frameloop)
+      // Check render
+      if (render) state.setRender(render)
       // Check pointer missed
       if (!state.onPointerMissed) state.set({ onPointerMissed })
       // Check performance

--- a/packages/fiber/src/core/renderer.tsx
+++ b/packages/fiber/src/core/renderer.tsx
@@ -150,13 +150,8 @@ const createStages = (stages: Stage[] | undefined, store: RootStore) => {
   }
   Stages.Update.add(frameCallback, store)
 
-  // Add render callback to render stage
-  renderApi.callback = {
-    current(state: RootState) {
-      if (state.gl.render) state.gl.render(state.scene, state.camera)
-    },
-  }
-  renderApi.add(store)
+  // Add render callback to Render stage on setup
+  if (state.internal.render === 'auto') renderApi.add(store)
 }
 
 export interface ReconcilerRoot<TCanvas extends Element> {

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -29,6 +29,11 @@ type RenderApi = {
 }
 
 export const renderApi: RenderApi = {
+  callback: {
+    current(state: RootState) {
+      if (state.gl.render) state.gl.render(state.scene, state.camera)
+    },
+  },
   add: (store: RootStore) => {
     if (renderApi.callback) renderApi.remove = Stages.Render.add(renderApi.callback, store)
   },
@@ -304,7 +309,6 @@ export const createStore = (
       },
       setRender: (render: FrameloopRender) =>
         set((state) => {
-          console.log(state.internal.render, render)
           if (state.internal.render === render) return {}
           if (render === 'auto') renderApi.add(rootStore)
           if (render === 'manual') renderApi.remove && renderApi.remove()

--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -33,6 +33,7 @@ const CanvasImpl = /*#__PURE__*/ React.forwardRef<View, CanvasProps>(
       onPointerMissed,
       onCreated,
       stages,
+      render,
       ...props
     },
     forwardedRef,
@@ -100,6 +101,7 @@ const CanvasImpl = /*#__PURE__*/ React.forwardRef<View, CanvasProps>(
         raycaster,
         camera,
         stages,
+        render,
         // expo-gl can only render at native dpr/resolution
         // https://github.com/expo/expo-three/issues/39
         dpr: PixelRatio.get(),

--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -48,6 +48,7 @@ const CanvasImpl = /*#__PURE__*/ React.forwardRef<HTMLCanvasElement, CanvasProps
     onPointerMissed,
     onCreated,
     stages,
+    render,
     ...props
   },
   forwardedRef,
@@ -92,6 +93,7 @@ const CanvasImpl = /*#__PURE__*/ React.forwardRef<HTMLCanvasElement, CanvasProps
       raycaster,
       camera,
       stages,
+      render,
       size: containerRect,
       // Pass mutable reference to onPointerMissed so it's free to update
       onPointerMissed: (...args) => handlePointerMissed.current?.(...args),


### PR DESCRIPTION
This simplifies `frameloop` to only be a string and no longer take an object. It then adds `render` as a state that takes the string `auto` or `manual`, with the first adding a render callback to the Render stage while the second doe not. This PR further adds a small internal `renderApi` for adding and removing the render callback when the prop changes through its set method.

Note: This PR breaks backwards compatibility with useFrame priority, but we intend to remove that completely anyway.