### PR TITLE
fix(types): add loadAsync to Loader interface

### DIFF
--- a/packages/fiber/src/core/hooks.tsx
+++ b/packages/fiber/src/core/hooks.tsx
@@ -14,6 +14,7 @@ export interface Loader<T> extends THREE.Loader {
     onProgress?: (event: ProgressEvent) => void,
     onError?: (event: ErrorEvent) => void,
   ): unknown
+  loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<T>
 }
 
 export type LoaderProto<T> = new (...args: any) => Loader<T extends unknown ? any : T>


### PR DESCRIPTION
When trying to use `@types/three@0.149.0` with R3F, I get these type errors:
```

node_modules/@react-three/fiber/dist/declarations/src/core/hooks.d.ts:12:108 - error TS2344: Type 'InstanceType<L>["loadAsync"]' does not satisfy the constraint '(...args: any) => any'.

12 export declare type LoaderReturnType<T, L extends LoaderProto<T>> = T extends unknown ? Awaited<ReturnType<InstanceType<L>['loadAsync']>> : T;
                                                                                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@react-three/fiber/dist/declarations/src/core/hooks.d.ts:12:108 - error TS2536: Type '"loadAsync"' cannot be used to index type 'InstanceType<L>'.

12 export declare type LoaderReturnType<T, L extends LoaderProto<T>> = T extends unknown ? Awaited<ReturnType<InstanceType<L>['loadAsync']>> : T;
                                                                                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

This is caused by the `loadAsync` method being removed from `THREE.Loader` in https://github.com/three-types/three-ts-types/pull/311, since there's not a good consistent type definition for it.

This fixes the situation by adding the `loadAsync` method here.

This change change should be backwards-compatible, I tested it with both `@types/three@0.149.0` and `@types/three@0.139.0`.