### PR TITLE
Refactor ErrorBoundary to not use public class fields

### DIFF
--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -41,11 +41,12 @@ export function Block({ set }: Omit<UnblockProps, 'children'>) {
   return null
 }
 
-export class ErrorBoundary extends React.Component<
-  { set: React.Dispatch<Error | undefined>; children: React.ReactNode },
-  { error: boolean }
-> {
-  state = { error: false }
+type ErrorBoundaryProps = { set: React.Dispatch<Error | undefined>; children: React.ReactNode }
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, { error: boolean }> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = { error: false }
+  }
   static getDerivedStateFromError = () => ({ error: true })
   componentDidCatch(err: Error) {
     this.props.set(err)


### PR DESCRIPTION
According to caniuse.com, support of public class fields is around 92%.

https://caniuse.com/?search=class%20fields

Wondering if it make sense to refactor the usage in here (it's the only occurence I found, might not worth to adapt the build to transpile this)

Let me know.

PS:

I discovered this thx to [es-check](https://github.com/yowainwright/es-check) with es2017 target.   The CI was failing https://github.com/belgattitude/perso/actions/runs/4091656424/jobs/7055889714.



