### PR TITLE
Babel: transpile class properties for wider browser support

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,6 +5,7 @@ module.exports = {
       '@babel/preset-env',
       {
         include: [
+          '@babel/plugin-proposal-class-properties',
           '@babel/plugin-proposal-optional-chaining',
           '@babel/plugin-proposal-nullish-coalescing-operator',
           '@babel/plugin-proposal-numeric-separator',

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -41,12 +41,11 @@ export function Block({ set }: Omit<UnblockProps, 'children'>) {
   return null
 }
 
-type ErrorBoundaryProps = { set: React.Dispatch<Error | undefined>; children: React.ReactNode }
-export class ErrorBoundary extends React.Component<ErrorBoundaryProps, { error: boolean }> {
-  constructor(props: ErrorBoundaryProps) {
-    super(props)
-    this.state = { error: false }
-  }
+export class ErrorBoundary extends React.Component<
+  { set: React.Dispatch<Error | undefined>; children: React.ReactNode },
+  { error: boolean }
+> {
+  state = { error: false }
   static getDerivedStateFromError = () => ({ error: true })
   componentDidCatch(err: Error) {
     this.props.set(err)


### PR DESCRIPTION
> According to caniuse.com, support of public class fields is around 92%, see https://caniuse.com/?search=class%20fields. 

Enable transpilation of public class properties in babel.

See https://babel.dev/docs/en/babel-plugin-proposal-class-properties 

Linked to https://github.com/pmndrs/react-three-fiber/pull/2748


## Before

Class properties in the dist

![image](https://user-images.githubusercontent.com/259798/216771205-076964c1-a382-45ae-92d4-fc044f4595b6.png)


## After

Class properties are transpiled

![image](https://user-images.githubusercontent.com/259798/216771246-bf2c8b5d-ab2c-4fdf-a919-511a31b4d1d5.png)


## Sizes

Seems a very small size increase: `76505` vs `76444` bytes (in the esm build)

<details>
  <summary>ls -la ./dist</summary>
   
```
// with class properties in babel
-rw-rw-r-- 1 sebastien sebastien 78461 févr.  4 14:43 index-455b51ca.cjs.prod.js
-rw-rw-r-- 1 sebastien sebastien 78504 févr.  4 14:43 index-6442a2a3.cjs.dev.js
-rw-rw-r-- 1 sebastien sebastien 76505 févr.  4 14:43 index-7dbf758c.esm.js
-rw-rw-r-- 1 sebastien sebastien  9186 févr.  4 14:43 react-three-fiber.cjs.dev.js
-rw-rw-r-- 1 sebastien sebastien    42 févr.  4 14:43 react-three-fiber.cjs.d.ts
-rw-rw-r-- 1 sebastien sebastien   196 févr.  4 14:43 react-three-fiber.cjs.js
-rw-rw-r-- 1 sebastien sebastien  9187 févr.  4 14:43 react-three-fiber.cjs.prod.js
-rw-rw-r-- 1 sebastien sebastien  7708 févr.  4 14:43 react-three-fiber.esm.js



// Without class properties in babel
-rw-rw-r-- 1 sebastien sebastien 78400 févr.  4 14:52 index-661b9d11.cjs.prod.js
-rw-rw-r-- 1 sebastien sebastien 78443 févr.  4 14:52 index-bf8a2906.cjs.dev.js
-rw-rw-r-- 1 sebastien sebastien 76444 févr.  4 14:52 index-fb77d67d.esm.js
-rw-rw-r-- 1 sebastien sebastien  9186 févr.  4 14:52 react-three-fiber.cjs.dev.js
-rw-rw-r-- 1 sebastien sebastien    42 févr.  4 14:52 react-three-fiber.cjs.d.ts
-rw-rw-r-- 1 sebastien sebastien   196 févr.  4 14:52 react-three-fiber.cjs.js
-rw-rw-r-- 1 sebastien sebastien  9187 févr.  4 14:52 react-three-fiber.cjs.prod.js
-rw-rw-r-- 1 sebastien sebastien  7708 févr.  4 14:52 react-three-fiber.esm.js
sebastien@sebastien-ThinkPad-P1-Gen-3:~/github/react-three-fiber/packages/fiber/dist$ 

```

</details>

