### PR TITLE
fix: play nice with OffscreenCanvas

### DIFF
--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -346,7 +346,7 @@ function render<TCanvas extends Canvas>(
   return root.render(children)
 }
 
-function Provider<TElement extends Element>({
+function Provider<TCanvas extends Canvas>({
   store,
   children,
   onCreated,
@@ -355,8 +355,7 @@ function Provider<TElement extends Element>({
   onCreated?: (state: RootState) => void
   store: UseBoundStore<RootState>
   children: React.ReactNode
-  rootElement: TElement
-  parent?: React.MutableRefObject<TElement | undefined>
+  rootElement: TCanvas
 }) {
   useIsomorphicLayoutEffect(() => {
     const state = store.getState()

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -32,7 +32,14 @@ export type Subscription = {
 }
 
 export type Dpr = number | [min: number, max: number]
-export type Size = { width: number; height: number; top: number; left: number; updateStyle?: boolean }
+export type Size = {
+  width: number
+  height: number
+  top: number
+  left: number
+  /** @deprecated `updateStyle` is now disabled for OffscreenCanvas and will be removed in v9. */
+  updateStyle?: boolean
+}
 export type Viewport = Size & {
   /** The initial pixel ratio */
   initialDpr: number
@@ -135,10 +142,15 @@ export type RootState = {
   setEvents: (events: Partial<EventManager<any>>) => void
   /**
    * Shortcut to manual sizing
-   *
-   * @todo before releasing next major version (v9), re-order arguments here to width, height, top, left, updateStyle
    */
-  setSize: (width: number, height: number, updateStyle?: boolean, top?: number, left?: number) => void
+  setSize: (
+    width: number,
+    height: number,
+    /** @deprecated `updateStyle` is now disabled for OffscreenCanvas and will be removed in v9. */
+    updateStyle?: boolean,
+    top?: number,
+    left?: number,
+  ) => void
   /** Shortcut to manual setting the pixel ratio */
   setDpr: (dpr: Dpr) => void
   /** Shortcut to frameloop flags */
@@ -333,7 +345,10 @@ const createStore = (
       // Update camera & renderer
       updateCamera(camera, size)
       gl.setPixelRatio(viewport.dpr)
-      gl.setSize(size.width, size.height, size.updateStyle)
+
+      const updateStyle =
+        size.updateStyle ?? (typeof HTMLCanvasElement !== 'undefined' && gl.domElement instanceof HTMLCanvasElement)
+      gl.setSize(size.width, size.height, updateStyle)
     }
 
     // Update viewport once the camera changes


### PR DESCRIPTION
Fixes #2765

```tsx
import * as THREE from 'three'
import { extend, createRoot } from '@react-three/fiber'

const canvas = document.createElement('canvas')
document.body.appendChild(canvas)

const offscreen = canvas.transferControlToOffscreen()

extend(THREE)

createRoot(offscreen).render(<gridHelper onBeforeRender={console.log} />)
```