### PR TITLE
Fixes THREE.ColorManagement warning in r150

### DIFF
--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -286,7 +286,7 @@ function createRoot<TCanvas extends Element>(canvas: TCanvas): ReconcilerRoot<TC
       // Safely set color management if available.
       // Avoid accessing THREE.ColorManagement to play nice with older versions
       if ('ColorManagement' in THREE) {
-        setDeep(THREE, legacy, ['ColorManagement', 'legacyMode'])
+        setDeep(THREE, !legacy, ['ColorManagement', 'enabled'])
       }
       const outputEncoding = linear ? THREE.LinearEncoding : THREE.sRGBEncoding
       const toneMapping = flat ? THREE.NoToneMapping : THREE.ACESFilmicToneMapping


### PR DESCRIPTION
> THREE.ColorManagement: .legacyMode=false renamed to .enabled=true in r150.

In three.js r150 `THREE.ColorManagement.legacyMode = false` has been replaced with `THREE.ColorManagement.enabled = true`; this PR removes that warning message by updating the way `ColorManagement` is assigned based on the `legacy` prop passed to the `<Canvas />` component.