### PR TITLE
Allow custom THREE.Scene

### DIFF
--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -16,7 +16,7 @@ import {
   PrivateKeys,
   privateKeys,
 } from './store'
-import { createRenderer, extend, Root } from './renderer'
+import { createRenderer, extend, prepare, Root } from './renderer'
 import { createLoop, addEffect, addAfterEffect, addTail, flushGlobalEffects } from './loop'
 import { getEventPriority, EventManager, ComputeFunction } from './events'
 import {
@@ -81,6 +81,8 @@ export type RenderProps<TCanvas extends Element> = {
   dpr?: Dpr
   /** Props that go into the default raycaster */
   raycaster?: Partial<THREE.Raycaster>
+  /** Allows you to render your components to a custom scene */
+  scene?: THREE.Scene
   /** A `THREE.Camera` instance or props that go into the default camera */
   camera?: (
     | Camera
@@ -175,6 +177,7 @@ function createRoot<TCanvas extends Element>(canvas: TCanvas): ReconcilerRoot<TC
       let {
         gl: glConfig,
         size: propsSize,
+        scene,
         events,
         onCreated: onCreatedCallback,
         shadows = false,
@@ -221,6 +224,11 @@ function createRoot<TCanvas extends Element>(canvas: TCanvas): ReconcilerRoot<TC
           if (!cameraOptions?.rotation) camera.lookAt(0, 0, 0)
         }
         state.set({ camera })
+      }
+
+      // Set up scene (one time only!)
+      if (!state.scene) {
+        state.set({ scene: prepare(scene || new THREE.Scene()) })
       }
 
       // Set up XR (one time only!)

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -197,6 +197,7 @@ const createStore = (
       raycaster: null as unknown as THREE.Raycaster,
       events: { priority: 1, enabled: true, connected: false },
       xr: null as unknown as { connect: () => void; disconnect: () => void },
+      scene: null as unknown as THREE.Scene,
 
       invalidate: (frames = 1) => invalidate(get(), frames),
       advance: (timestamp: number, runGlobalEffects?: boolean) => advance(timestamp, runGlobalEffects, get()),
@@ -204,7 +205,6 @@ const createStore = (
       legacy: false,
       linear: false,
       flat: false,
-      scene: prepare<THREE.Scene>(new THREE.Scene()),
 
       controls: null,
       clock: new THREE.Clock(),

--- a/packages/fiber/tests/core/renderer.test.tsx
+++ b/packages/fiber/tests/core/renderer.test.tsx
@@ -697,6 +697,21 @@ describe('renderer', () => {
     expect(gl.physicallyCorrectLights).toBe(true)
   })
 
+  it('should set scene via scene prop', async () => {
+    let scene: THREE.Scene = null!
+
+    const prop = new THREE.Scene()
+
+    await act(async () => {
+      scene = root
+        .configure({ scene: prop })
+        .render(<group />)
+        .getState().scene
+    })
+
+    expect(prop).toBe(scene)
+  })
+
   it('should set a renderer via gl callback', async () => {
     class Renderer extends THREE.WebGLRenderer {}
 


### PR DESCRIPTION
Addresses: https://github.com/pmndrs/react-three-fiber/issues/2759

Adds `scene` option to the `root.configure` function so that one can use `react-three-fiber` to render objects to a custom scene:

```ts
import { createRoot } from "react-three-fiber";

const root = createRoot(gl.domElement);

root.configure({
  camera, // custom camera
  gl,  // custom renderer
  scene,  // custom scene, new parameter
  frameloop: "never",  // frameloop is managed externally
});

root.render(<ReactThreeFiberComponnet />); // add some objects to the custom scene
```