### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/advanced/scaling-performance.mdx
+++ b/docs/advanced/scaling-performance.mdx
@@ -228,7 +228,7 @@ If you still experience flip flops despite the bounds you can define a limit of 
 PerformanceMonitor can also have children, if you wrap your app in it you get to use usePerformanceMonitor which allows individual components down the nested tree to respond to performance changes on their own.
 
 ```jsx
-;<PerformanceMonitor>
+<PerformanceMonitor>
   <Effects />
 </PerformanceMonitor>
 

--- a/docs/getting-started/your-first-scene.mdx
+++ b/docs/getting-started/your-first-scene.mdx
@@ -11,7 +11,7 @@ This tutorial will assume some React knowledge.
 We'll start by importing the `<Canvas />` component from `@react-three/fiber` and putting it in our React tree.
 
 ```jsx
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import { Canvas } from '@react-three/fiber'
 
 function App() {
@@ -22,7 +22,7 @@ function App() {
   )
 }
 
-ReactDOM.render(<App />, document.getElementById('root'))
+createRoot(document.getElementById('root')).render(<App />)
 ```
 
 The Canvas component does some important setup work behind the scenes:

--- a/docs/tutorials/typescript.mdx
+++ b/docs/tutorials/typescript.mdx
@@ -124,7 +124,7 @@ declare module '@react-three/fiber' {
 }
 
 // react-three-fiber will create your custom component and TypeScript will understand it
-;<customComponent />
+<customComponent />
 ```
 
 ## Exported types

--- a/docs/tutorials/v8-migration-guide.mdx
+++ b/docs/tutorials/v8-migration-guide.mdx
@@ -218,7 +218,7 @@ This is also supported by all cameras that you create, be it a THREE.Perspective
 ```jsx
 import { PerspectiveCamera } from '@react-three/drei'
 
-;<Canvas>
+<Canvas>
   <PerspectiveCamera makeDefault manual />
 </Canvas>
 ```


### PR DESCRIPTION
* Revised sample code in your-first-scene.mdx to use React 18 createRoot API

* Removed a few typos in multiple docs