### PR TITLE
feat(Canvas): alias Props => CanvasProps

### DIFF
--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -9,10 +9,12 @@ import { createTouchEvents } from './events'
 import { RootState, Size } from '../core/store'
 import { polyfills } from './polyfills'
 
-export interface Props extends Omit<RenderProps<HTMLCanvasElement>, 'size' | 'dpr'>, ViewProps {
+export interface CanvasProps extends Omit<RenderProps<HTMLCanvasElement>, 'size' | 'dpr'>, ViewProps {
   children: React.ReactNode
   style?: ViewStyle
 }
+
+export interface Props extends CanvasProps {}
 
 /**
  * A native canvas which accepts threejs elements as children.

--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -8,7 +8,9 @@ import { ReconcilerRoot, extend, createRoot, unmountComponentAtNode, RenderProps
 import { createPointerEvents } from './events'
 import { DomEvent } from '../core/events'
 
-export interface Props extends Omit<RenderProps<HTMLCanvasElement>, 'size'>, React.HTMLAttributes<HTMLDivElement> {
+export interface CanvasProps
+  extends Omit<RenderProps<HTMLCanvasElement>, 'size'>,
+    React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode
   /** Canvas fallback content, similar to img's alt prop */
   fallback?: React.ReactNode
@@ -22,6 +24,8 @@ export interface Props extends Omit<RenderProps<HTMLCanvasElement>, 'size'>, Rea
   /** The event prefix that is cast into canvas pointer x/y events, default: "offset" */
   eventPrefix?: 'offset' | 'client' | 'page' | 'layer' | 'screen'
 }
+
+export interface Props extends CanvasProps {}
 
 const CanvasImpl = /*#__PURE__*/ React.forwardRef<HTMLCanvasElement, Props>(function Canvas(
   {


### PR DESCRIPTION
Aliases the `Props` type as `CanvasProps`. This is already renamed on the v9 branch.