### PR TITLE
offscreen support

### DIFF
--- a/packages/offscreen/.npmignore
+++ b/packages/offscreen/.npmignore
@@ -1,0 +1,9 @@
+examples/
+example/
+.codesandbox/
+.github/
+.husky/
+markdown/
+src/
+tests/
+__mocks__

--- a/packages/offscreen/package.json
+++ b/packages/offscreen/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@react-three/offscreen",
+  "version": "0.0.0",
+  "description": "A React offscreen renderer for Threejs",
+  "keywords": [
+    "react",
+    "renderer",
+    "offscreen",
+    "fiber",
+    "three",
+    "threejs"
+  ],
+  "author": "Paul Henschel (https://github.com/drcmda)",
+  "license": "MIT",
+  "maintainers": [
+    "Josh Ellis (https://github.com/joshuaellis)",
+    "Cody Bennett (https://github.com/codyjasonbennett)"
+  ],
+  "bugs": {
+    "url": "https://github.com/pmndrs/react-three-fiber/issues"
+  },
+  "homepage": "https://github.com/pmndrs/react-three-fiber#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pmndrs/react-three-fiber.git"
+  },
+  "collective": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/react-three-fiber"
+  },
+  "main": "dist/react-three-offscreen.cjs.js",
+  "module": "dist/react-three-offscreen.esm.js",
+  "types": "dist/react-three-offscreen.cjs.d.ts",
+  "sideEffects": false,
+  "preconstruct": {
+    "entrypoints": [
+      "index.tsx"
+    ]
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.17.8",
+    "@react-three/fiber": "latest",
+    "mitt": "^3.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0",
+    "react-dom": ">=18.0",
+    "three": ">=0.133"
+  },
+  "peerDependenciesMeta": {
+    "react-dom": {
+      "optional": true
+    }
+  }
+}

--- a/packages/offscreen/package.json
+++ b/packages/offscreen/package.json
@@ -39,12 +39,12 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.8",
-    "@react-three/fiber": "latest",
     "mitt": "^3.0.0"
   },
   "peerDependencies": {
     "react": ">=18.0",
     "react-dom": ">=18.0",
+    "@react-three/fiber": ">=8.0.0",
     "three": ">=0.133"
   },
   "peerDependenciesMeta": {

--- a/packages/offscreen/readme.md
+++ b/packages/offscreen/readme.md
@@ -1,0 +1,55 @@
+<h1>react-three-offscreen</h1>
+
+[![Version](https://img.shields.io/npm/v/@react-three/offscreen?style=flat&colorA=000000&colorB=000000)](https://npmjs.com/package/@react-three/offscreen)
+[![Downloads](https://img.shields.io/npm/dt/react-three-fiber.svg?style=flat&colorA=000000&colorB=000000)](https://npmjs.com/package/@react-three/offscreen)
+[![Twitter](https://img.shields.io/twitter/follow/pmndrs?label=%40pmndrs&style=flat&colorA=000000&colorB=000000&logo=twitter&logoColor=000000)](https://twitter.com/pmndrs)
+[![Discord](https://img.shields.io/discord/740090768164651008?style=flat&colorA=000000&colorB=000000&label=discord&logo=discord&logoColor=000000)](https://discord.gg/ZZjjNvJ)
+[![Open Collective](https://img.shields.io/opencollective/all/react-three-fiber?style=flat&colorA=000000&colorB=000000)](https://opencollective.com/react-three-fiber)
+[![ETH](https://img.shields.io/badge/ETH-f5f5f5?style=flat&colorA=000000&colorB=000000)](https://blockchain.com/eth/address/0x6E3f79Ea1d0dcedeb33D3fC6c34d2B1f156F2682)
+[![BTC](https://img.shields.io/badge/BTC-f5f5f5?style=flat&colorA=000000&colorB=000000)](https://blockchain.com/btc/address/36fuguTPxGCNnYZSRdgdh6Ea94brCAjMbH)
+
+react-three-fiber is a <a href="https://reactjs.org/docs/codebase-overview.html#renderers">React renderer</a> for threejs.
+
+Build your scene declaratively with re-usable, self-contained components that react to state, are readily interactive and can participate in React's ecosystem.
+
+```bash
+npm install three @react-three/offscreen
+```
+
+```jsx
+// App.jsx (main thread)
+import { Canvas } from '@react-three/offscreen'
+
+const worker = new Worker(new URL('./worker.js', import.meta.url))
+
+export default function App() {
+  return <Canvas shadows camera={{ position: [0, 5, 10], fov: 25 }} worker={worker} />
+}
+```
+
+```jsx
+// worker.js (worker thread)
+import { render } from '@react-three/offscreen'
+
+render(<Scene />)
+```
+
+# How to contribute
+
+If you like this project, please consider helping out. All contributions are welcome as well as donations to [Opencollective](https://opencollective.com/react-three-fiber), or in crypto `BTC: 36fuguTPxGCNnYZSRdgdh6Ea94brCAjMbH`, `ETH: 0x6E3f79Ea1d0dcedeb33D3fC6c34d2B1f156F2682`.
+
+#### Backers
+
+Thank you to all our backers! 🙏
+
+<a href="https://opencollective.com/react-three-fiber#backers" target="_blank">
+  <img src="https://opencollective.com/react-three-fiber/backers.svg?width=890"/>
+</a>
+
+#### Contributors
+
+This project exists thanks to all the people who contribute.
+
+<a href="https://github.com/pmndrs/react-three-fiber/graphs/contributors">
+  <img src="https://opencollective.com/react-three-fiber/contributors.svg?width=890" />
+</a>

--- a/packages/offscreen/readme.md
+++ b/packages/offscreen/readme.md
@@ -8,24 +8,38 @@
 [![ETH](https://img.shields.io/badge/ETH-f5f5f5?style=flat&colorA=000000&colorB=000000)](https://blockchain.com/eth/address/0x6E3f79Ea1d0dcedeb33D3fC6c34d2B1f156F2682)
 [![BTC](https://img.shields.io/badge/BTC-f5f5f5?style=flat&colorA=000000&colorB=000000)](https://blockchain.com/btc/address/36fuguTPxGCNnYZSRdgdh6Ea94brCAjMbH)
 
-react-three-fiber is a <a href="https://reactjs.org/docs/codebase-overview.html#renderers">React renderer</a> for threejs.
-
-Build your scene declaratively with re-usable, self-contained components that react to state, are readily interactive and can participate in React's ecosystem.
-
 ```bash
-npm install three @react-three/offscreen
+npm install three @react-three/fiber @react-three/offscreen
 ```
 
+This is an experimental package that allows you to render your [react-three-fiber](https://github.com/pmndrs/react-three-fiber) scene with an offscreen canvas in a web worker. This is mostly useful for self-contained webgl apps, and un-blocking the main thread.
+
+The package will forward DOM events to the worker so you can expect mostly everything to run fine. It will even shim a basic document/window interface so that camera controls and various threejs classes that must interact with the DOM have something to work with.
+
+For better interop all non-passive events (click, contextmenu, dlbclick) will preventDefault, pointerdown will capture, pointerup will release capture.
+
+## Usage
+
+Instead of importing `<Canvas>` from `@react-three/fiber` you can import it from `@react-three/offscreen` and pass a `worker` prop. The `fallback` prop is optional, your scene will be rendered on the main thread, in a regular canvas, where OffscreenCanvas is not supported (Safari).
+
+It takes all other props that `<Canvas>` takes (dpr, shadows, etc), you can use it as a drop-in replacement.
+
 ```jsx
-// App.jsx (main thread)
+// App.js (main thread)
 import { Canvas } from '@react-three/offscreen'
 
+// This is the fallback component that will be rendered on the main thread
+// This will happen on systems where OffscreenCanvas is not supported
+const Scene = React.lazy(() => import('./Scene'))
+// This is the worker thread that will render the scene
 const worker = new Worker(new URL('./worker.js', import.meta.url))
 
 export default function App() {
-  return <Canvas shadows camera={{ position: [0, 5, 10], fov: 25 }} worker={worker} />
+  return <Canvas shadows camera={{ position: [0, 5, 10], fov: 25 }} worker={worker} fallback={<Scene />} />
 }
 ```
+
+Your worker thread will be responsible for rendering the scene. The `render` function takes a single argument, a ReactNode.
 
 ```jsx
 // worker.js (worker thread)
@@ -34,11 +48,57 @@ import { render } from '@react-three/offscreen'
 render(<Scene />)
 ```
 
-# How to contribute
+Your app or scene should be self contained, meaning it shouldn't interact with the DOM. This is because offscreen canvas + webgl is still not supported in Safari. If you must communicate with the DOM, you can use the web broadcast API.
+
+```jsx
+// Scene.js (a self contained webgl app)
+import React, { useRef, useState } from 'react'
+import { useFrame } from '@react-three/fiber'
+import { ContactShadows, Environment, CameraControls } from '@react-three/drei'
+
+function Cube(props) {
+  const mesh = useRef()
+  const [hovered, setHover] = useState(false)
+  const [active, setActive] = useState(false)
+  useFrame((state, delta) => {
+    mesh.current.rotation.x += delta
+    mesh.current.rotation.y += delta
+  })
+  return (
+    <>
+      <mesh
+        {...props}
+        ref={mesh}
+        scale={active ? 1.25 : 1}
+        onClick={(e) => (e.stopPropagation(), setActive(!active))}
+        onPointerOver={(e) => (e.stopPropagation(), setHover(true))}
+        onPointerOut={(e) => setHover(false)}>
+        <boxGeometry args={[1, 1, 1]} />
+        <meshStandardMaterial color={hovered ? 'hotpink' : 'orange'} />
+      </mesh>
+      <ContactShadows color={hovered ? 'hotpink' : 'orange'} position={[0, -1.5, 0]} blur={3} opacity={0.75} />
+    </>
+  )
+}
+
+export default function App() {
+  return (
+    <>
+      <ambientLight />
+      <pointLight position={[10, 10, 10]} />
+      <Cube />
+      <Environment preset="city" />
+      <CameraControls />
+    </>
+  )
+}
+```
+
+## How to contribute
 
 If you like this project, please consider helping out. All contributions are welcome as well as donations to [Opencollective](https://opencollective.com/react-three-fiber), or in crypto `BTC: 36fuguTPxGCNnYZSRdgdh6Ea94brCAjMbH`, `ETH: 0x6E3f79Ea1d0dcedeb33D3fC6c34d2B1f156F2682`.
 
-#### Backers
+### Backers
 
 Thank you to all our backers! 🙏
 
@@ -46,7 +106,7 @@ Thank you to all our backers! 🙏
   <img src="https://opencollective.com/react-three-fiber/backers.svg?width=890"/>
 </a>
 
-#### Contributors
+### Contributors
 
 This project exists thanks to all the people who contribute.
 

--- a/packages/offscreen/src/index.tsx
+++ b/packages/offscreen/src/index.tsx
@@ -1,0 +1,268 @@
+import * as THREE from 'three'
+import React, { useEffect, useRef } from 'react'
+import mitt from 'mitt'
+
+import type { Options as ResizeOptions } from 'react-use-measure'
+import { UseBoundStore } from 'zustand'
+
+import {
+  extend,
+  createRoot,
+  createEvents,
+  RenderProps,
+  ReconcilerRoot,
+  Dpr,
+  Size,
+  RootState,
+  EventManager,
+  Events,
+  context,
+  createPortal,
+  reconciler,
+  applyProps,
+  dispose,
+  invalidate,
+  advance,
+  addEffect,
+  addAfterEffect,
+  addTail,
+  flushGlobalEffects,
+  getRootState,
+  act,
+  ReactThreeFiber,
+} from '@react-three/fiber'
+
+export type {
+  ObjectMap,
+  Camera,
+  ThreeEvent,
+  Events,
+  EventManager,
+  ComputeFunction,
+  GlobalRenderCallback,
+  GlobalEffectType,
+} from '@react-three/fiber'
+
+export {
+  ReactThreeFiber,
+  context,
+  createPortal,
+  reconciler,
+  applyProps,
+  dispose,
+  invalidate,
+  advance,
+  extend,
+  addEffect,
+  addAfterEffect,
+  addTail,
+  flushGlobalEffects,
+  getRootState,
+  act,
+}
+
+const DOM_EVENTS = {
+  onClick: ['click', false],
+  onContextMenu: ['contextmenu', false],
+  onDoubleClick: ['dblclick', false],
+  onWheel: ['wheel', true],
+  onPointerDown: ['pointerdown', true],
+  onPointerUp: ['pointerup', true],
+  onPointerLeave: ['pointerleave', true],
+  onPointerMove: ['pointermove', true],
+  onPointerCancel: ['pointercancel', true],
+  onLostPointerCapture: ['lostpointercapture', true],
+} as const
+
+export interface CanvasProps
+  extends Omit<RenderProps<HTMLCanvasElement>, 'size'>,
+    React.HTMLAttributes<HTMLDivElement> {
+  worker: Worker
+  /**
+   * Options to pass to useMeasure.
+   * @see https://github.com/pmndrs/react-use-measure#api
+   */
+  resize?: ResizeOptions
+  /** The target where events are being subscribed to, default: the div that wraps canvas */
+  eventSource?: HTMLElement | React.MutableRefObject<HTMLElement>
+  /** The event prefix that is cast into canvas pointer x/y events, default: "offset" */
+  eventPrefix?: 'offset' | 'client' | 'page' | 'layer' | 'screen'
+}
+
+export function Canvas({ worker, ...props }: CanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null!)
+
+  useEffect(() => {
+    if (!worker) return
+
+    const canvas = canvasRef.current
+    const offscreen = canvasRef.current.transferControlToOffscreen()
+
+    worker.postMessage(
+      {
+        type: 'init',
+        payload: {
+          props,
+          drawingSurface: offscreen,
+          width: canvas.clientWidth,
+          height: canvas.clientHeight,
+          top: canvas.offsetTop,
+          left: canvas.offsetLeft,
+          pixelRatio: window.devicePixelRatio,
+        },
+      },
+      [offscreen],
+    )
+
+    Object.values(DOM_EVENTS).forEach(([eventName, passive]) => {
+      canvas.addEventListener(
+        eventName,
+        (event: any) => {
+          worker.postMessage({
+            type: 'dom_events',
+            payload: {
+              eventName,
+              button: event.button,
+              buttons: event.buttons,
+              altKey: event.altKey,
+              ctrlKey: event.ctrlKey,
+              metaKey: event.metaKey,
+              shiftKey: event.shiftKey,
+              movementX: event.movementX,
+              movementY: event.movementY,
+              clientX: event.clientX,
+              clientY: event.clientY,
+              offsetX: event.offsetX,
+              offsetY: event.offsetY,
+              pageX: event.pageX,
+              pageY: event.pageY,
+              x: event.x,
+              y: event.y,
+            },
+          })
+        },
+        { passive },
+      )
+    })
+
+    const handleResize = () => {
+      worker.postMessage({
+        type: 'resize',
+        payload: {
+          width: canvas.clientWidth,
+          height: canvas.clientHeight,
+          top: canvas.offsetTop,
+          left: canvas.offsetLeft,
+        },
+      })
+    }
+
+    window.addEventListener('resize', handleResize)
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [worker])
+
+  useEffect(() => {
+    if (!worker) return
+    worker.postMessage({ type: 'props', payload: props })
+  }, [worker, props])
+
+  return <canvas ref={canvasRef} />
+}
+
+export function render(children: React.ReactNode) {
+  extend(THREE)
+
+  let root: ReconcilerRoot<HTMLCanvasElement>
+  let dpr: Dpr = [1, 2]
+  let size: Size = { width: 0, height: 0, top: 0, left: 0, updateStyle: false }
+  const emitter = mitt()
+
+  const handleInit = (payload: any) => {
+    const { props, drawingSurface: canvas, width, height, top, left, pixelRatio } = payload
+    root = createRoot(canvas)
+    root.configure({
+      events: createPointerEvents,
+      size: (size = { width, height, top, left, updateStyle: false }),
+      dpr: (dpr = Math.min(Math.max(1, pixelRatio), 2)),
+      ...props,
+    })
+    root.render(children)
+  }
+
+  const handleResize = ({ width, height, top, left }: Size) => {
+    if (!root) return
+    root.configure({ size: (size = { width, height, top, left, updateStyle: false }), dpr })
+  }
+
+  const handleEvents = (payload: any) => {
+    emitter.emit(payload.eventName, payload)
+    emitter.on('disconnect', () => self.postMessage({ type: 'dom_events_disconnect' }))
+  }
+
+  const handleProps = (payload: any) => {
+    if (!root) return
+    if (payload.dpr) dpr = payload.dpr
+    root.configure({ size, dpr, ...payload })
+  }
+
+  const handlerMap = {
+    resize: handleResize,
+    init: handleInit,
+    dom_events: handleEvents,
+    props: handleProps,
+  }
+
+  self.onmessage = (event) => {
+    const { type, payload } = event.data
+    const handler = handlerMap[type as keyof typeof handlerMap]
+    if (handler) handler(payload)
+  }
+
+  // Shim for web offscreen canvas
+  // @ts-ignore
+  self.window = {}
+
+  /** R3F event manager for web offscreen canvas */
+  function createPointerEvents(store: UseBoundStore<RootState>): EventManager<HTMLElement> {
+    const { handlePointer } = createEvents(store)
+
+    return {
+      priority: 1,
+      enabled: true,
+      compute(event, state) {
+        // https://github.com/pmndrs/react-three-fiber/pull/782
+        // Events trigger outside of canvas when moved, use offsetX/Y by default and allow overrides
+        state.pointer.set((event.offsetX / state.size.width) * 2 - 1, -(event.offsetY / state.size.height) * 2 + 1)
+        state.raycaster.setFromCamera(state.pointer, state.camera)
+      },
+
+      connected: undefined,
+      handlers: Object.keys(DOM_EVENTS).reduce(
+        (acc, key) => ({ ...acc, [key]: handlePointer(key) }),
+        {},
+      ) as unknown as Events,
+      connect: (target) => {
+        const { set, events } = store.getState()
+        events.disconnect?.()
+        set((state) => ({ events: { ...state.events, connected: target } }))
+        Object.entries(events?.handlers ?? []).forEach(([name, event]) => {
+          const [eventName] = DOM_EVENTS[name as keyof typeof DOM_EVENTS]
+          emitter.on(eventName as any, event as any)
+        })
+      },
+      disconnect: () => {
+        const { set, events } = store.getState()
+        if (events.connected) {
+          Object.entries(events.handlers ?? []).forEach(([name, event]) => {
+            const [eventName] = DOM_EVENTS[name as keyof typeof DOM_EVENTS]
+            emitter.off(eventName as any, event as any)
+          })
+          emitter.emit('disconnect')
+          set((state) => ({ events: { ...state.events, connected: undefined } }))
+        }
+      },
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7636,6 +7636,11 @@ minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
+mitt@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.0.tgz#69ef9bd5c80ff6f57473e8d89326d01c414be0bd"
+  integrity sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==
+
 mixin-deep@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"


### PR DESCRIPTION
see https://twitter.com/0xca0a/status/1648994507453526016

and a test repo https://github.com/drcmda/react-three-offscreen

<h1>react-three-offscreen</h1>

```bash
npm install three @react-three/fiber @react-three/offscreen
```

This is an experimental package that allows you to render your [react-three-fiber](https://github.com/pmndrs/react-three-fiber) scene with an offscreen canvas in a web worker. This is mostly useful for self-contained webgl apps, and un-blocking the main thread.

The package will forward DOM events to the worker so you can expect mostly everything to run fine. It will even shim a basic document/window interface so that camera controls and various threejs classes that must interact with the DOM have something to work with.

For better interop all non-passive events (click, contextmenu, dlbclick) will preventDefault, pointerdown will capture, pointerup will release capture.

## Usage

Instead of importing `<Canvas>` from `@react-three/fiber` you can import it from `@react-three/offscreen` and pass a `worker` prop. The `fallback` prop is optional, your scene will be rendered on the main thread, in a regular canvas, where OffscreenCanvas is not supported (Safari).

It takes all other props that `<Canvas>` takes (dpr, shadows, etc), you can use it as a drop-in replacement.

```jsx
// App.js (main thread)
import { Canvas } from '@react-three/offscreen'

// This is the fallback component that will be rendered on the main thread
// This will happen on systems where OffscreenCanvas is not supported
const Scene = React.lazy(() => import('./Scene'))
// This is the worker thread that will render the scene
const worker = new Worker(new URL('./worker.js', import.meta.url))

export default function App() {
  return <Canvas shadows camera={{ position: [0, 5, 10], fov: 25 }} worker={worker} fallback={<Scene />} />
}
```

Your worker thread will be responsible for rendering the scene. The `render` function takes a single argument, a ReactNode.

```jsx
// worker.js (worker thread)
import { render } from '@react-three/offscreen'

render(<Scene />)
```

Your app or scene should be self contained, meaning it shouldn't interact with the DOM. This is because offscreen canvas + webgl is still not supported in Safari. If you must communicate with the DOM, you can use the web broadcast API.

```jsx
// Scene.js (a self contained webgl app)
import React, { useRef, useState } from 'react'
import { useFrame } from '@react-three/fiber'
import { ContactShadows, Environment, CameraControls } from '@react-three/drei'

function Cube(props) {
  const mesh = useRef()
  const [hovered, setHover] = useState(false)
  const [active, setActive] = useState(false)
  useFrame((state, delta) => {
    mesh.current.rotation.x += delta
    mesh.current.rotation.y += delta
  })
  return (
    <>
      <mesh
        {...props}
        ref={mesh}
        scale={active ? 1.25 : 1}
        onClick={(e) => (e.stopPropagation(), setActive(!active))}
        onPointerOver={(e) => (e.stopPropagation(), setHover(true))}
        onPointerOut={(e) => setHover(false)}>
        <boxGeometry args={[1, 1, 1]} />
        <meshStandardMaterial color={hovered ? 'hotpink' : 'orange'} />
      </mesh>
      <ContactShadows color={hovered ? 'hotpink' : 'orange'} position={[0, -1.5, 0]} blur={3} opacity={0.75} />
    </>
  )
}

export default function App() {
  return (
    <>
      <ambientLight />
      <pointLight position={[10, 10, 10]} />
      <Cube />
      <Environment preset="city" />
      <CameraControls />
    </>
  )
}
```
