### PR TITLE
docs: update links to legacy react docs

### DIFF
--- a/docs/API/hooks.mdx
+++ b/docs/API/hooks.mdx
@@ -167,7 +167,7 @@ function B() {
 
 ## useLoader
 
-This hook loads assets and suspends for easier fallback- and error-handling. It can take any three.js loader as its first argument: GLTFLoader, OBJLoader, TextureLoader, FontLoader, etc. It is based on [React.Suspense](https://reactjs.org/docs/concurrent-mode-suspense.html), so fallback-handling and [error-handling](https://reactjs.org/docs/error-boundaries.html) happen at the parental level.
+This hook loads assets and suspends for easier fallback- and error-handling. It can take any three.js loader as its first argument: GLTFLoader, OBJLoader, TextureLoader, FontLoader, etc. It is based on [React.Suspense](https://react.dev/reference/react/Suspense), so fallback-handling and [error-handling](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) happen at the parental level.
 
 ```jsx
 import { Suspense } from 'react'

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -178,7 +178,7 @@ export default function App() {
 
 ## First steps
 
-You need to be versed in both React and Threejs before rushing into this. If you are unsure about React consult the official [React docs](https://reactjs.org/docs/getting-started.html), especially [the section about hooks](https://reactjs.org/docs/hooks-reference.html). As for Threejs, make sure you at least glance over the following links:
+You need to be versed in both React and Threejs before rushing into this. If you are unsure about React consult the official [React docs](https://react.dev/learn), especially [the section about hooks](https://react.dev/reference/react). As for Threejs, make sure you at least glance over the following links:
 
 1. Make sure you have a [basic grasp of Threejs](https://threejs.org/docs/index.html#manual/en/introduction/Creating-a-scene). Keep that site open.
 2. When you know what a scene is, a camera, mesh, geometry, material, fork the [demo above](https://github.com/pmndrs/react-three-fiber#what-does-it-look-like).

--- a/packages/fiber/readme.md
+++ b/packages/fiber/readme.md
@@ -201,7 +201,7 @@ Visit [docs.pmnd.rs](https://docs.pmnd.rs/react-three-fiber)
 
 # Fundamentals
 
-You need to be versed in both React and Threejs before rushing into this. If you are unsure about React consult the official [React docs](https://reactjs.org/docs/getting-started.html), especially [the section about hooks](https://reactjs.org/docs/hooks-reference.html). As for Threejs, make sure you at least glance over the following links:
+You need to be versed in both React and Threejs before rushing into this. If you are unsure about React consult the official [React docs](https://react.dev/learn), especially [the section about hooks](https://react.dev/reference/react). As for Threejs, make sure you at least glance over the following links:
 
 1. Make sure you have a [basic grasp of Threejs](https://threejs.org/docs/index.html#manual/en/introduction/Creating-a-scene). Keep that site open.
 2. When you know what a scene is, a camera, mesh, geometry, material, fork the [demo above](https://github.com/pmndrs/react-three-fiber#what-does-it-look-like).

--- a/readme.md
+++ b/readme.md
@@ -201,7 +201,7 @@ Visit [docs.pmnd.rs](https://docs.pmnd.rs/react-three-fiber)
 
 # First steps
 
-You need to be versed in both React and Threejs before rushing into this. If you are unsure about React consult the official [React docs](https://reactjs.org/docs/getting-started.html), especially [the section about hooks](https://reactjs.org/docs/hooks-reference.html). As for Threejs, make sure you at least glance over the following links:
+You need to be versed in both React and Threejs before rushing into this. If you are unsure about React consult the official [React docs](https://react.dev/learn), especially [the section about hooks](https://react.dev/reference/react). As for Threejs, make sure you at least glance over the following links:
 
 1. Make sure you have a [basic grasp of Threejs](https://threejs.org/docs/index.html#manual/en/introduction/Creating-a-scene). Keep that site open.
 2. When you know what a scene is, a camera, mesh, geometry, material, fork the [demo above](https://github.com/pmndrs/react-three-fiber#what-does-it-look-like).


### PR DESCRIPTION
React updated its docs, [reactjs.org](https://reactjs.org) is now legacy, long live [react.dev](https://react.dev)

I therefore upgraded these links:

- https://reactjs.org/docs/concurrent-mode-suspense.html -> https://react.dev/reference/react/Suspense
- https://reactjs.org/docs/error-boundaries.html -> https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary
- https://reactjs.org/docs/getting-started.html -> https://react.dev/learn
- https://reactjs.org/docs/hooks-reference.html -> https://react.dev/reference/react

because it was obvious replacement. However I didn't find obvious replacement for these links:

- https://reactjs.org/docs/codebase-overview.html#renderers: new docs don't document these, and it seems there was a paradigm shift in react with server components and stuff. I'm not well versed enough in the r3f internals to know about a good replacement
- https://reactjs.org/docs/test-renderer.html#overview: even the readme in the react package point the legacy react docs, so there doesn't seem to be a new replacement available yet

I suggest we leave them as-is for now :)