### PR TITLE
Updated "Loading multiple assets at once".

### DIFF
--- a/docs/API/hooks.mdx
+++ b/docs/API/hooks.mdx
@@ -219,7 +219,12 @@ useLoader(GLTFLoader, url, (loader) => {
 It can also make multiple requests in parallel:
 
 ```jsx
-const [bumpMap, specMap, normalMap] = useLoader(TextureLoader, [url1, url2, url2])
+import { TextureLoader } from 'three'
+
+function Texture() {
+  // The constructor is being used with an array of texture URLs. Make sure that the array contains valid URLs to the textures you want to load.
+  const [bumpMap, specMap, normalMap] = useLoader(TextureLoader, ["/texture1.jpg","/texture1.jpg","/texture1.jpg"])  
+}
 ```
 
 ### Loading status


### PR DESCRIPTION
Fixed "TypeError: Proto is not a constructor" error when using TextureLoader at once. That happened because the import statement is incorrect or missing, leading to the `TextureLoader` not being recognized as a constructor. So I Verified that the useLoader function accepts TextureLoader as a valid constructor.