### PR TITLE
docs: common and readable useRef naming

### DIFF
--- a/docs/advanced/pitfalls.mdx
+++ b/docs/advanced/pitfalls.mdx
@@ -56,9 +56,9 @@ return <mesh position-x={x} />
 In general you should prefer useFrame. Consider mutating props safe as long as the component is the only entity that mutates. Use deltas instead of fixed values so that your app is refresh-rate independent and runs at the same speed everywhere!
 
 ```jsx
-const ref = useRef()
-useFrame((state, delta) => (ref.current.position.x += delta))
-return <mesh ref={ref} />
+const meshRef = useRef()
+useFrame((state, delta) => (meshRef.current.position.x += delta))
+return <mesh ref={meshRef} />
 ```
 
 Same goes for events, use references.
@@ -84,11 +84,11 @@ The frame loop is where you should place your animations. For instance using ler
 
 ```jsx
 function Signal({ active }) {
-  const ref = useRef()
+  const meshRef = useRef()
   useFrame((state, delta) => {
-    ref.current.position.x = THREE.MathUtils.lerp(ref.current.position.x, active ? 100 : 0, 0.1)
+    meshRef.current.position.x = THREE.MathUtils.lerp(meshRef.current.position.x, active ? 100 : 0, 0.1)
   })
-  return <mesh ref={ref} />
+  return <mesh ref={meshRef} />
 ```
 
 ### ✅ Or react-spring

--- a/docs/advanced/scaling-performance.mdx
+++ b/docs/advanced/scaling-performance.mdx
@@ -28,13 +28,13 @@ One major caveat is that if anything in the tree _mutates_ props, then React can
 
 ```jsx
 function Controls() {
-  const ref = useRef()
+  const orbitControlsRef = useRef()
   const { invalidate, camera, gl } = useThree()
   useEffect(() => {
-    ref.current.addEventListener('change', invalidate)
-    return () => ref.current.removeEventListener('change', invalidate)
+    orbitControlsRef.current.addEventListener('change', invalidate)
+    return () => orbitControlsRef.current.removeEventListener('change', invalidate)
   }, [])
-  return <orbitControls ref={ref} args={[camera, gl.domElement]} />
+  return <orbitControls ref={orbitControlsRef} args={[camera, gl.domElement]} />
 ```
 
 <Hint>Drei's controls do this automatically for you.</Hint>
@@ -114,19 +114,19 @@ Setting up instancing is not so hard, consult [the three.js docs](https://threej
 
 ```jsx
 function Instances({ count = 100000, temp = new THREE.Object3D() }) {
-  const ref = useRef()
+  const instancedMeshRef = useRef()
   useEffect(() => {
     // Set positions
     for (let i = 0; i < count; i++) {
       temp.position.set(Math.random(), Math.random(), Math.random())
       temp.updateMatrix()
-      ref.current.setMatrixAt(i, temp.matrix)
+      instancedMeshRef.current.setMatrixAt(i, temp.matrix)
     }
     // Update the instance
-    ref.current.instanceMatrix.needsUpdate = true
+    instancedMeshRef.current.instanceMatrix.needsUpdate = true
   }, [])
   return (
-    <instancedMesh ref={ref} args={[null, null, count]}>
+    <instancedMesh ref={instancedMeshRef} args={[null, null, count]}>
       <boxGeometry />
       <meshPhongMaterial />
     </instancedMesh>

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -110,13 +110,13 @@ import htm from 'https://esm.sh/htm'
 const html = htm.bind(React.createElement)
 
 function Box(props) {
-  const mesh = useRef()
+  const meshRef = useRef()
   const [hovered, setHover] = useState(false)
   const [active, setActive] = useState(false)
-  useFrame(() => (mesh.current.rotation.x = mesh.current.rotation.y += 0.01))
+  useFrame(() => (meshRef.current.rotation.x = meshRef.current.rotation.y += 0.01))
   return html` <mesh
     ...${props}
-    ref=${mesh}
+    ref=${meshRef}
     scale=${active ? 1.5 : 1}
     onClick=${() => setActive(!active)}
     onPointerOver=${() => setHover(true)}
@@ -190,14 +190,14 @@ import React, { useRef, useState } from 'react'
 import { Canvas, useFrame } from '@react-three/fiber/native'
 
 function Box(props) {
-  const mesh = useRef(null)
+  const meshRef = useRef(null)
   const [hovered, setHover] = useState(false)
   const [active, setActive] = useState(false)
-  useFrame((state, delta) => (mesh.current.rotation.x += 0.01))
+  useFrame((state, delta) => (meshRef.current.rotation.x += 0.01))
   return (
     <mesh
       {...props}
-      ref={mesh}
+      ref={meshRef}
       scale={active ? 1.5 : 1}
       onClick={(event) => setActive(!active)}
       onPointerOver={(event) => setHover(true)}

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -57,17 +57,17 @@ import { Canvas, useFrame } from '@react-three/fiber'
 
 function Box(props) {
   // This reference will give us direct access to the mesh
-  const mesh = useRef()
+  const meshRef = useRef()
   // Set up state for the hovered and active state
   const [hovered, setHover] = useState(false)
   const [active, setActive] = useState(false)
   // Subscribe this component to the render-loop, rotate the mesh every frame
-  useFrame((state, delta) => (mesh.current.rotation.x += delta))
+  useFrame((state, delta) => (meshRef.current.rotation.x += delta))
   // Return view, these are regular three.js elements expressed in JSX
   return (
     <mesh
       {...props}
-      ref={mesh}
+      ref={meshRef}
       scale={active ? 1.5 : 1}
       onClick={(event) => setActive(!active)}
       onPointerOver={(event) => setHover(true)}
@@ -102,14 +102,14 @@ import React, { useRef, useState } from 'react'
 import { Canvas, useFrame, ThreeElements } from '@react-three/fiber'
 
 function Box(props: ThreeElements['mesh']) {
-  const mesh = useRef<THREE.Mesh>(null!)
+  const meshRef = useRef<THREE.Mesh>(null!)
   const [hovered, setHover] = useState(false)
   const [active, setActive] = useState(false)
-  useFrame((state, delta) => (mesh.current.rotation.x += delta))
+  useFrame((state, delta) => (meshRef.current.rotation.x += delta))
   return (
     <mesh
       {...props}
-      ref={mesh}
+      ref={meshRef}
       scale={active ? 1.5 : 1}
       onClick={(event) => setActive(!active)}
       onPointerOver={(event) => setHover(true)}
@@ -144,14 +144,14 @@ import React, { useRef, useState } from 'react'
 import { Canvas, useFrame } from '@react-three/fiber/native'
 
 function Box(props) {
-  const mesh = useRef(null)
+  const meshRef = useRef(null)
   const [hovered, setHover] = useState(false)
   const [active, setActive] = useState(false)
-  useFrame((state, delta) => (mesh.current.rotation.x += delta))
+  useFrame((state, delta) => (meshRef.current.rotation.x += delta))
   return (
     <mesh
       {...props}
-      ref={mesh}
+      ref={meshRef}
       scale={active ? 1.5 : 1}
       onClick={(event) => setActive(!active)}
       onPointerOver={(event) => setHover(true)}

--- a/docs/tutorials/loading-models.mdx
+++ b/docs/tutorials/loading-models.mdx
@@ -53,10 +53,10 @@ import React, { useRef } from 'react'
 import { useGLTF } from '@react-three/drei'
 
 export default function Model(props) {
-  const group = useRef()
+  const groupRef = useRef()
   const { nodes, materials } = useGLTF('/Poimandres.gltf')
   return (
-    <group ref={group} {...props} dispose={null}>
+    <group ref={groupRef} {...props} dispose={null}>
       <mesh castShadow receiveShadow geometry={nodes.Curve007_1.geometry} material={materials['Material.001']} />
       <mesh castShadow receiveShadow geometry={nodes.Curve007_2.geometry} material={materials['Material.002']} />
     </group>

--- a/docs/tutorials/typescript.mdx
+++ b/docs/tutorials/typescript.mdx
@@ -17,14 +17,14 @@ import { useRef, useEffect } from 'react'
 import { Mesh } from 'three'
 
 function Box(props) {
-  const ref = useRef<Mesh>(null!)
+  const meshRef = useRef<Mesh>(null!)
 
   useEffect(() => {
-    console.log(Boolean(ref.current))
+    console.log(Boolean(meshRef.current))
   }, [])
 
   return (
-    <mesh {...props} ref={ref}>
+    <mesh {...props} ref={meshRef}>
       <boxGeometry />
       <meshBasicMaterial />
     </mesh>


### PR DESCRIPTION
There were some problems with the previous useRef naming

It was different every time:
```
const canvasRef = useRef...
const ref = useRef...
const mesh = useRef...
```

Now, every ref is named: `name of the component` + `Ref`
For example: a ref for a mesh would be: `meshRef`; a mesh for a canvas would be: `canvasRef`.
This also improves readability, because:
1. We don't have repeating names:
It would have usually been something like:
```
const mesh = useRef...
...
<mesh
   ref={mesh}
   ...
/>
```
2. We know where each ref belongs to:
Some refs would only have the name `ref`