### PR TITLE
feat: allow to override `invalidate` to give away render loop control

### DIFF
--- a/.changeset/silly-keys-bake.md
+++ b/.changeset/silly-keys-bake.md
@@ -2,4 +2,15 @@
 '@react-three/fiber': minor
 ---
 
-asdsd
+Allow to override `invalidate` so that you can do rendering on demand on canvases where R3F is not in charge of the loop.
+
+Example:
+
+```tsx
+import { createRoot } from '@react-three/fiber'
+const invalidate = () => {
+  sharedCanvas.triggerRepaint()
+  return 0
+}
+const root = createRoot(canvas, invalidate)
+```

--- a/.changeset/silly-keys-bake.md
+++ b/.changeset/silly-keys-bake.md
@@ -1,0 +1,5 @@
+---
+'@react-three/fiber': minor
+---
+
+asdsd

--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -142,7 +142,7 @@ function computeInitialSize(canvas: Canvas, defaultSize?: Size): Size {
   return { width: 0, height: 0, top: 0, left: 0 }
 }
 
-function createRoot<TCanvas extends Canvas>(canvas: TCanvas): ReconcilerRoot<TCanvas> {
+function createRoot<TCanvas extends Canvas>(canvas: TCanvas, thisInvalidate = invalidate): ReconcilerRoot<TCanvas> {
   // Check against mistaken use of createRoot
   const prevRoot = roots.get(canvas)
   const prevFiber = prevRoot?.fiber
@@ -161,7 +161,7 @@ function createRoot<TCanvas extends Canvas>(canvas: TCanvas): ReconcilerRoot<TCa
         console.error
 
   // Create store
-  const store = prevStore || createStore(invalidate, advance)
+  const store = prevStore || createStore(thisInvalidate, advance)
   // Create renderer
   const fiber =
     prevFiber || reconciler.createContainer(store, ConcurrentRoot, null, false, null, '', logRecoverableError, null)
@@ -257,7 +257,7 @@ function createRoot<TCanvas extends Canvas>(canvas: TCanvas): ReconcilerRoot<TCa
           state.gl.xr.enabled = state.gl.xr.isPresenting
 
           state.gl.xr.setAnimationLoop(state.gl.xr.isPresenting ? handleXRFrame : null)
-          if (!state.gl.xr.isPresenting) invalidate(state)
+          if (!state.gl.xr.isPresenting) thisInvalidate(state)
         }
 
         // WebXR session manager


### PR DESCRIPTION
Use case:

I am starting a new project that will let you use `react-three-fiber` inside MapLibre, Mapbox or Google Maps. ([link](https://github.com/RodrigoHamuy/react-three-map))

As part of that, I want to support on demand rendering.

These map providers are in charge of the render loop and allow you to request repaints. 

But in its current state, R3F doesn't have a way to notify that something has changed and request a third party to do repaint. It can only request repaints to itself.

This change allows custom R3F roots to have a custom `invalidate` function where you can write the logic to notify a repaint to a third party (rather than to R3F itself).

Example:

```tsx
import { createRoot } from '@react-three/fiber'
const invalidate = () => {
  sharedCanvas.triggerRepaint()
  return 0
}
const root = createRoot(canvas, invalidate)
```

(Will add later a CodeSandbox example too).

[on-demand.webm](https://github.com/pmndrs/react-three-fiber/assets/2405611/d1d3881d-c74b-409f-b168-a4befd48cf2b)