### PR TITLE
fix(types): harden colors overload since r153

### DIFF
--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -29,7 +29,6 @@ export type Vector4 = VectorLike<THREE.Vector4>
 export type Color = ConstructorParameters<typeof THREE.Color> | THREE.Color | number | string // Parameters<T> will not work here because of multiple function signatures in three.js types
 // r153 compat, same issue as above
 // https://github.com/pmndrs/react-three-fiber/issues/2926
-// https://github.com/three-types/three-ts-types/pull/484
 export type ColorArray = typeof THREE.Color | [color: THREE.ColorRepresentation]
 export type Layers = THREE.Layers | Parameters<THREE.Layers['set']>[0]
 export type Quaternion = THREE.Quaternion | Parameters<THREE.Quaternion['set']>

--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -27,7 +27,10 @@ export type Vector2 = VectorLike<THREE.Vector2>
 export type Vector3 = VectorLike<THREE.Vector3>
 export type Vector4 = VectorLike<THREE.Vector4>
 export type Color = ConstructorParameters<typeof THREE.Color> | THREE.Color | number | string // Parameters<T> will not work here because of multiple function signatures in three.js types
-export type ColorArray = typeof THREE.Color | Parameters<THREE.Color['set']>
+// r153 compat, same issue as above
+// https://github.com/pmndrs/react-three-fiber/issues/2926
+// https://github.com/three-types/three-ts-types/pull/484
+export type ColorArray = typeof THREE.Color | [color: THREE.ColorRepresentation]
 export type Layers = THREE.Layers | Parameters<THREE.Layers['set']>[0]
 export type Quaternion = THREE.Quaternion | Parameters<THREE.Quaternion['set']>
 


### PR DESCRIPTION
Fixes #2926 which broke since the introduction of overloads in https://github.com/three-types/three-ts-types/pull/484.

This will need to be vetted in v9 cc @krispya.