### PR TITLE
docs: Fix typos

### DIFF
--- a/docs/advanced/scaling-performance.mdx
+++ b/docs/advanced/scaling-performance.mdx
@@ -272,7 +272,7 @@ You can define defaults like so:
 
 ### This is how you can put the system into regression
 
-The only thing you have to do is call `regress()`. When exactly you do that, that is up to you, but it could be when when the mouse moves, or the scene is moving, for instance when controls fire their change-event.
+The only thing you have to do is call `regress()`. When exactly you do that, that is up to you, but it could be when the mouse moves, or the scene is moving, for instance when controls fire their change-event.
 
 Say you are using controls, then the following code puts the system in regress when they are active:
 

--- a/docs/tutorials/basic-animations.mdx
+++ b/docs/tutorials/basic-animations.mdx
@@ -66,7 +66,6 @@ function MyAnimatedBox() {
 
 ```jsx
 useFrame(({ clock }) => {
-  const a = clock.getElapsedTime()
   myMesh.current.rotation.x = clock.getElapsedTime()
 })
 ```

--- a/docs/tutorials/basic-animations.mdx
+++ b/docs/tutorials/basic-animations.mdx
@@ -66,6 +66,7 @@ function MyAnimatedBox() {
 
 ```jsx
 useFrame(({ clock }) => {
+  const a = clock.getElapsedTime()
   myMesh.current.rotation.x = clock.getElapsedTime()
 })
 ```

--- a/docs/tutorials/v8-migration-guide.mdx
+++ b/docs/tutorials/v8-migration-guide.mdx
@@ -217,7 +217,7 @@ This is also supported by all cameras that you create, be it a THREE.Perspective
 
 ```jsx
 import { PerspectiveCamera } from '@react-three/drei'
-;<Canvas>
+<Canvas>
   <PerspectiveCamera makeDefault manual />
 </Canvas>
 ```


### PR DESCRIPTION
Find small typos while researching fiber documentation and fix them