### PR TITLE
fix: harden XR init against Renderer shim

### DIFF
--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -275,7 +275,7 @@ function createRoot<TCanvas extends Canvas>(canvas: TCanvas): ReconcilerRoot<TCa
         }
 
         // Subscribe to WebXR session events
-        if (gl.xr) xr.connect()
+        if (typeof gl.xr?.addEventListener === 'function') xr.connect()
         state.set({ xr })
       }
 


### PR DESCRIPTION
Hardens XR initialization against WebXRManager shims from https://github.com/mrdoob/three.js/pull/26079.