### PR TITLE
feat(native): use PanResponder for react-native-web

### DIFF
--- a/packages/fiber/__mocks__/react-native.ts
+++ b/packages/fiber/__mocks__/react-native.ts
@@ -35,3 +35,7 @@ export const StyleSheet = {
     bottom: 0,
   },
 }
+
+export const PanResponder = {
+  create: () => ({ panHandlers: {} }),
+}

--- a/packages/fiber/__mocks__/react-native.ts
+++ b/packages/fiber/__mocks__/react-native.ts
@@ -15,9 +15,9 @@ const Container = React.memo(
           },
         },
       } as LayoutChangeEvent)
+    }, [onLayout])
 
-      ref = { current: { props } }
-    }, [])
+    React.useImperativeHandle(ref, () => props)
 
     return null
   }),

--- a/packages/fiber/__mocks__/react-native/Libraries/Blob/BlobManager.js
+++ b/packages/fiber/__mocks__/react-native/Libraries/Blob/BlobManager.js
@@ -1,4 +1,0 @@
-export default class BlobManager {
-  createFromParts() {}
-  createFromOptions() {}
-}

--- a/packages/fiber/__mocks__/react-native/Libraries/Pressability/Pressability.ts
+++ b/packages/fiber/__mocks__/react-native/Libraries/Pressability/Pressability.ts
@@ -1,2 +1,0 @@
-const mock = {}
-export default mock

--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as THREE from 'three'
-import { View, ViewProps, Pressable, ViewStyle, LayoutChangeEvent, StyleSheet, PixelRatio } from 'react-native'
+import { View, ViewProps, ViewStyle, LayoutChangeEvent, StyleSheet, PixelRatio } from 'react-native'
 import { ExpoWebGLRenderingContext, GLView } from 'expo-gl'
 import { useContextBridge, FiberProvider } from 'its-fine'
 import { SetBlock, Block, ErrorBoundary, useMutableCallback } from '../core/utils'
@@ -144,9 +144,9 @@ const CanvasImpl = /*#__PURE__*/ React.forwardRef<View, Props>(
     }, [canvas])
 
     return (
-      <Pressable {...props} ref={viewRef} onLayout={onLayout} style={{ flex: 1, ...style }} {...bind}>
+      <View {...props} ref={viewRef} onLayout={onLayout} style={{ flex: 1, ...style }} {...bind}>
         {width > 0 && <GLView onContextCreate={onContextCreate} style={StyleSheet.absoluteFill} />}
-      </Pressable>
+      </View>
     )
   },
 )

--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as THREE from 'three'
-import { View, ViewProps, ViewStyle, LayoutChangeEvent, StyleSheet, PixelRatio } from 'react-native'
+import { View, ViewProps, Pressable, ViewStyle, LayoutChangeEvent, StyleSheet, PixelRatio } from 'react-native'
 import { ExpoWebGLRenderingContext, GLView } from 'expo-gl'
 import { useContextBridge, FiberProvider } from 'its-fine'
 import { SetBlock, Block, ErrorBoundary, useMutableCallback } from '../core/utils'
@@ -115,8 +115,7 @@ const CanvasImpl = /*#__PURE__*/ React.forwardRef<View, Props>(
         // Overwrite onCreated to apply RN bindings
         onCreated: (state: RootState) => {
           // Bind events after creation
-          const handlers = state.events.connect?.(viewRef.current)
-          setBind(handlers)
+          setBind(state.events.handlers)
 
           // Bind render to RN bridge
           const context = state.gl.getContext() as ExpoWebGLRenderingContext
@@ -145,9 +144,9 @@ const CanvasImpl = /*#__PURE__*/ React.forwardRef<View, Props>(
     }, [canvas])
 
     return (
-      <View {...props} ref={viewRef} onLayout={onLayout} style={{ flex: 1, ...style }} {...bind}>
+      <Pressable {...props} ref={viewRef} onLayout={onLayout} style={{ flex: 1, ...style }} {...bind}>
         {width > 0 && <GLView onContextCreate={onContextCreate} style={StyleSheet.absoluteFill} />}
-      </View>
+      </Pressable>
     )
   },
 )

--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -115,7 +115,8 @@ const CanvasImpl = /*#__PURE__*/ React.forwardRef<View, Props>(
         // Overwrite onCreated to apply RN bindings
         onCreated: (state: RootState) => {
           // Bind events after creation
-          setBind(state.events.handlers)
+          const { onPressMove, ...handlers } = state.events.handlers as any
+          setBind({ ...handlers, android_rippleConfig: { onPressMove } })
 
           // Bind render to RN bridge
           const context = state.gl.getContext() as ExpoWebGLRenderingContext

--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -115,7 +115,7 @@ const CanvasImpl = /*#__PURE__*/ React.forwardRef<View, Props>(
         // Overwrite onCreated to apply RN bindings
         onCreated: (state: RootState) => {
           // Bind events after creation
-          if (state.events) setBind(state.events.handlers)
+          setBind(state.events.handlers)
 
           // Bind render to RN bridge
           const context = state.gl.getContext() as ExpoWebGLRenderingContext

--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -115,8 +115,7 @@ const CanvasImpl = /*#__PURE__*/ React.forwardRef<View, Props>(
         // Overwrite onCreated to apply RN bindings
         onCreated: (state: RootState) => {
           // Bind events after creation
-          const { onPressMove, ...handlers } = state.events.handlers as any
-          setBind({ ...handlers, android_rippleConfig: { onPressMove } })
+          if (state.events) setBind(state.events.handlers)
 
           // Bind render to RN bridge
           const context = state.gl.getContext() as ExpoWebGLRenderingContext

--- a/packages/fiber/src/native/events.ts
+++ b/packages/fiber/src/native/events.ts
@@ -1,35 +1,13 @@
 import { UseBoundStore } from 'zustand'
 import { RootState } from '../core/store'
 import { createEvents, DomEvent, EventManager, Events } from '../core/events'
-import type { GestureResponderEvent } from 'react-native'
-
-const EVENTS = {
-  PRESS: 'onPress',
-  PRESSIN: 'onPressIn',
-  PRESSOUT: 'onPressOut',
-  LONGPRESS: 'onLongPress',
-
-  HOVERIN: 'onHoverIn',
-  HOVEROUT: 'onHoverOut',
-  PRESSMOVE: 'onPressMove',
-}
-
-const DOM_EVENTS = {
-  [EVENTS.PRESS]: 'onClick',
-  [EVENTS.PRESSIN]: 'onPointerDown',
-  [EVENTS.PRESSOUT]: 'onPointerUp',
-  [EVENTS.LONGPRESS]: 'onDoubleClick',
-
-  [EVENTS.HOVERIN]: 'onPointerOver',
-  [EVENTS.HOVEROUT]: 'onPointerOut',
-  [EVENTS.PRESSMOVE]: 'onPointerMove',
-}
+import { type GestureResponderEvent, PanResponder } from 'react-native'
 
 /** Default R3F event manager for react-native */
 export function createTouchEvents(store: UseBoundStore<RootState>): EventManager<HTMLElement> {
   const { handlePointer } = createEvents(store)
 
-  const handleTouch = (event: GestureResponderEvent, name: keyof typeof EVENTS) => {
+  const handleTouch = (event: GestureResponderEvent, name: string): true => {
     event.persist()
 
     // Apply offset
@@ -37,9 +15,25 @@ export function createTouchEvents(store: UseBoundStore<RootState>): EventManager
     ;(event as any).nativeEvent.offsetY = event.nativeEvent.locationY
 
     // Emulate DOM event
-    const callback = handlePointer(DOM_EVENTS[name])
-    return callback(event.nativeEvent as any)
+    const callback = handlePointer(name)
+    callback(event.nativeEvent as any)
+
+    return true
   }
+
+  const responder = PanResponder.create({
+    onStartShouldSetPanResponder: () => true,
+    onMoveShouldSetPanResponder: () => true,
+    onMoveShouldSetPanResponderCapture: () => true,
+    onPanResponderTerminationRequest: () => true,
+    onStartShouldSetPanResponderCapture: (e) => handleTouch(e, 'onPointerCapture'),
+    onPanResponderStart: (e) => handleTouch(e, 'onPointerDown'),
+    onPanResponderMove: (e) => handleTouch(e, 'onPointerMove'),
+    onPanResponderEnd: (e) => handleTouch(e, 'onPointerUp'),
+    onPanResponderRelease: (e) => handleTouch(e, 'onPointerLeave'),
+    onPanResponderTerminate: (e) => handleTouch(e, 'onLostPointerCapture'),
+    onPanResponderReject: (e) => handleTouch(e, 'onLostPointerCapture'),
+  })
 
   return {
     priority: 1,
@@ -52,16 +46,12 @@ export function createTouchEvents(store: UseBoundStore<RootState>): EventManager
     },
 
     connected: undefined,
-    handlers: Object.values(EVENTS).reduce(
-      (acc, name) => ({
-        ...acc,
-        [name]: (event: GestureResponderEvent) => handleTouch(event, name as keyof typeof EVENTS),
-      }),
-      {},
-    ) as unknown as Events,
+    handlers: responder.panHandlers as unknown as Events,
     update: () => {
       const { events, internal } = store.getState()
-      if (internal.lastEvent?.current && events.handlers) events.handlers.onPointerMove(internal.lastEvent.current)
+      if (internal.lastEvent?.current && events.handlers) {
+        handlePointer('onPointerMove')(internal.lastEvent.current)
+      }
     },
     connect: () => {
       const { set, events } = store.getState()

--- a/packages/fiber/src/native/events.ts
+++ b/packages/fiber/src/native/events.ts
@@ -31,7 +31,7 @@ export function createTouchEvents(store: UseBoundStore<RootState>): EventManager
     onPanResponderMove: (e) => handleTouch(e, 'onPointerMove'),
     onPanResponderEnd: (e, state) => {
       handleTouch(e, 'onPointerUp')
-      if (Math.hypot(state.dx, state.dy) > 20) handleTouch(e, 'onClick')
+      if (Math.hypot(state.dx, state.dy) < 20) handleTouch(e, 'onClick')
     },
     onPanResponderRelease: (e) => handleTouch(e, 'onPointerLeave'),
     onPanResponderTerminate: (e) => handleTouch(e, 'onLostPointerCapture'),

--- a/packages/fiber/src/native/events.ts
+++ b/packages/fiber/src/native/events.ts
@@ -1,11 +1,7 @@
 import { UseBoundStore } from 'zustand'
 import { RootState } from '../core/store'
 import { createEvents, DomEvent, EventManager, Events } from '../core/events'
-import { GestureResponderEvent } from 'react-native'
-/* eslint-disable import/default, import/no-named-as-default, import/no-named-as-default-member */
-// @ts-ignore
-import Pressability from 'react-native/Libraries/Pressability/Pressability'
-/* eslint-enable import/default, import/no-named-as-default, import/no-named-as-default-member */
+import type { GestureResponderEvent } from 'react-native'
 
 const EVENTS = {
   PRESS: 'onPress',
@@ -71,19 +67,12 @@ export function createTouchEvents(store: UseBoundStore<RootState>): EventManager
       const { set, events } = store.getState()
       events.disconnect?.()
 
-      const connected = new Pressability(events.handlers)
-      set((state) => ({ events: { ...state.events, connected } }))
-
-      const handlers = connected.getEventHandlers()
-      return handlers
+      set((state) => ({ events: { ...state.events, connected: true } }))
     },
     disconnect: () => {
-      const { set, events } = store.getState()
+      const { set } = store.getState()
 
-      if (events.connected) {
-        events.connected.reset()
-        set((state) => ({ events: { ...state.events, connected: undefined } }))
-      }
+      set((state) => ({ events: { ...state.events, connected: false } }))
     },
   }
 }

--- a/packages/fiber/src/native/events.ts
+++ b/packages/fiber/src/native/events.ts
@@ -29,7 +29,10 @@ export function createTouchEvents(store: UseBoundStore<RootState>): EventManager
     onStartShouldSetPanResponderCapture: (e) => handleTouch(e, 'onPointerCapture'),
     onPanResponderStart: (e) => handleTouch(e, 'onPointerDown'),
     onPanResponderMove: (e) => handleTouch(e, 'onPointerMove'),
-    onPanResponderEnd: (e) => handleTouch(e, 'onPointerUp'),
+    onPanResponderEnd: (e, state) => {
+      handleTouch(e, 'onPointerUp')
+      if (Math.hypot(state.dx, state.dy) > 20) handleTouch(e, 'onClick')
+    },
     onPanResponderRelease: (e) => handleTouch(e, 'onPointerLeave'),
     onPanResponderTerminate: (e) => handleTouch(e, 'onLostPointerCapture'),
     onPanResponderReject: (e) => handleTouch(e, 'onLostPointerCapture'),


### PR DESCRIPTION
Uses `PanResponder` over `Pressability` internals for events (`Pressable` doesn't implement `onPressMove`). `react-native-web` crudely rewrites `react-native/*` which breaks fs paths or `package#exports`. Consequently, we can't leverage feature flags for W3C pointer events.