### PR TITLE
fix(native): TextureLoader should remain consistent with FileLoader

### DIFF
--- a/packages/fiber/src/native/polyfills.ts
+++ b/packages/fiber/src/native/polyfills.ts
@@ -35,7 +35,7 @@ export function polyfills() {
   const prevTextureLoad = THREE.TextureLoader.prototype.load
   THREE.TextureLoader.prototype.load = function load(url, onLoad, onProgress, onError) {
     if (this.path) url = this.path + url
-    
+
     const texture = new THREE.Texture()
 
     // @ts-ignore

--- a/packages/fiber/src/native/polyfills.ts
+++ b/packages/fiber/src/native/polyfills.ts
@@ -34,6 +34,8 @@ export function polyfills() {
   // There's no Image in native, so create a data texture instead
   const prevTextureLoad = THREE.TextureLoader.prototype.load
   THREE.TextureLoader.prototype.load = function load(url, onLoad, onProgress, onError) {
+    if (this.path) url = this.path + url
+    
     const texture = new THREE.Texture()
 
     // @ts-ignore


### PR DESCRIPTION
Logic should be consistent with FileLoader

This fixes an issue when loading textures from app private storage, with paths such as `file://path/to/texture`.

If an FBX resides in a local path such as `file://path/to/scene.fbx`. `FBXLoader` parses this path, extracts the path from it: `file://path/to/` and calls `loader.parse` with the resource path.

`TextureLoader` should respect this setting and load the textures from the passed in asset directory.