### PR TITLE
experiment(native): implement readAsArrayBuffer for compat

### DIFF
--- a/packages/fiber/src/native/polyfills.ts
+++ b/packages/fiber/src/native/polyfills.ts
@@ -143,7 +143,7 @@ export function polyfills() {
   }
 
   // Special handling for bundler assets
-  const originalFileLoad = THREE.FileLoader.prototype.load.bind(THREE.FileLoader.prototype)
+  const originalFileLoad = THREE.FileLoader.prototype.load
   THREE.FileLoader.prototype.load = async function load(url, onLoad, onProgress, onError) {
     const path = this.path
     if (this.path) url = this.path + url
@@ -158,7 +158,7 @@ export function polyfills() {
     }
 
     this.path = ''
-    originalFileLoad(url, onLoad, onProgress, onError)
+    originalFileLoad.apply(this, [url, onLoad, onProgress, onError])
     this.path = path
   }
 }

--- a/packages/fiber/src/native/polyfills.ts
+++ b/packages/fiber/src/native/polyfills.ts
@@ -142,7 +142,7 @@ export function polyfills() {
     return texture
   }
 
-  // Fetches assets via XMLHttpRequest
+  // Special handling for bundler assets
   const originalFileLoad = THREE.FileLoader.prototype.load.bind(THREE.FileLoader.prototype)
   THREE.FileLoader.prototype.load = async function load(url, onLoad, onProgress, onError) {
     const path = this.path


### PR DESCRIPTION
Follow-up to #2982. Implements `FileReader.readAsArrayBuffer` for react-native <0.71, dropping `XMLHttpRequest` and falling back to three.js native `FileReader` implementation (https://github.com/facebook/react-native/pull/30769#issuecomment-996018144).