### PR TITLE
feat: expose expoGL object props

### DIFF
--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -8,8 +8,13 @@ import { extend, createRoot, unmountComponentAtNode, RenderProps, ReconcilerRoot
 import { createTouchEvents } from './events'
 import { RootState, Size } from '../core/store'
 
+interface ExpoGLProps {
+  ref?: React.Ref<GLView>
+}
+
 export interface CanvasProps extends Omit<RenderProps<HTMLCanvasElement>, 'size' | 'dpr'>, ViewProps {
   children: React.ReactNode
+  expoGL?: ExpoGLProps
   style?: ViewStyle
 }
 
@@ -23,6 +28,7 @@ const CanvasImpl = /*#__PURE__*/ React.forwardRef<View, Props>(
   (
     {
       children,
+      expoGL,
       style,
       gl,
       events = createTouchEvents,
@@ -141,7 +147,7 @@ const CanvasImpl = /*#__PURE__*/ React.forwardRef<View, Props>(
 
     return (
       <View {...props} ref={viewRef} onLayout={onLayout} style={{ flex: 1, ...style }} {...bind}>
-        {width > 0 && <GLView onContextCreate={onContextCreate} style={StyleSheet.absoluteFill} />}
+        {width > 0 && <GLView ref={expoGL?.ref} onContextCreate={onContextCreate} style={StyleSheet.absoluteFill} />}
       </View>
     )
   },


### PR DESCRIPTION
Hi hi,

I wanted to take a snapshot of my 3D scene in react-native, but the [recommended method](https://codesandbox.io/s/basic-demo-forked-rnuve?file=/src/App.js) for the web does not work with `expo-gl`.

I added a new object `expoGL` (that could be extended for additional props from the GLView) and passed it a `ref` props.

Here is a demo of the use case

```tsx
import { Canvas } from '@react-three/fiber/native';

const Demo = () => {
  const ref = React.useRef<GLView | null>(null)

  const snapshot = React.useCallback(async () => {
    const res = await ref.current?.takeSnapshotAsync()

    if (res?.localUri) {
      // Do something with the image, e.g. upload to R2
    }
  }, [])

  // Call snapshot() to take a snapshot of the canvas

  return <Canvas expoGL={{ ref }} {...} />
}
```