### PR TITLE
fix(native): drop fsstat for react-native-web

### DIFF
--- a/packages/fiber/src/native/polyfills.ts
+++ b/packages/fiber/src/native/polyfills.ts
@@ -67,8 +67,7 @@ export function polyfills() {
     // Unpack assets in Android Release Mode
     if (!uri.includes(':')) {
       const file = `${fs.cacheDirectory}ExponentAsset-${asset.hash}.${asset.type}`
-      const stats = await fs.getInfoAsync(file, { size: false })
-      if (!stats.exists) await fs.copyAsync({ from: uri, to: file })
+      await fs.copyAsync({ from: uri, to: file })
       uri = file
     }
 


### PR DESCRIPTION
Drops use of `expo-file-system#getInfoAsync` which is not implemented on web.