### PR TITLE
[v9] Fix syntax highlighting

### DIFF
--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -121,8 +121,9 @@ export function calculateDpr(dpr: Dpr): number {
 /**
  * Returns instance root state
  */
-export const getRootState = <T = THREE.Object3D,>(obj: T): RootState | undefined =>
-  (obj as Instance<T>['object']).__r3f?.root.getState()
+export function getRootState<T extends THREE.Object3D = THREE.Object3D>(obj: T) {
+  return (obj as Instance<T>['object']).__r3f?.root.getState()
+}
 
 export interface EquConfig {
   /** Compare arrays by reference equality a === b (default), or by shallow equality */


### PR DESCRIPTION
For some reason `getRootState` was causing my syntax highlighting to suicide. I rewrote the function so that it the highlighting is happy.