### PR TITLE
[v9] fix(events): bubble up primitives

### DIFF
--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -245,7 +245,17 @@ export function createEvents(store: RootStore) {
     if (intersections.length) {
       const localState = { stopped: false }
       for (const hit of intersections) {
-        const state = getRootState(hit.object)
+        let state = getRootState(hit.object)
+
+        if (!state)
+          hit.object.traverseAncestors((obj) => {
+            const _state = getRootState(obj)
+            if (_state) {
+              state = _state
+              return false
+            }
+          })
+
         if (state) {
           const { raycaster, pointer, camera, internal } = state
           const unprojectedPoint = new THREE.Vector3(pointer.x, pointer.y, 0).unproject(camera)

--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -121,8 +121,9 @@ export function calculateDpr(dpr: Dpr): number {
 /**
  * Returns instance root state
  */
-export const getRootState = <T = THREE.Object3D,>(obj: T): RootState | undefined =>
-  (obj as Instance<T>['object']).__r3f?.root.getState()
+export function getRootState<T extends THREE.Object3D = THREE.Object3D>(obj: T) {
+  return (obj as Instance<T>['object']).__r3f?.root.getState()
+}
 
 export interface EquConfig {
   /** Compare arrays by reference equality a === b (default), or by shallow equality */

--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -121,9 +121,8 @@ export function calculateDpr(dpr: Dpr): number {
 /**
  * Returns instance root state
  */
-export function getRootState<T extends THREE.Object3D = THREE.Object3D>(obj: T) {
-  return (obj as Instance<T>['object']).__r3f?.root.getState()
-}
+export const getRootState = <T = THREE.Object3D,>(obj: T): RootState | undefined =>
+  (obj as Instance<T>['object']).__r3f?.root.getState()
 
 export interface EquConfig {
   /** Compare arrays by reference equality a === b (default), or by shallow equality */


### PR DESCRIPTION
Events were completely broken for `primitive` elements. The main reason is that with a `primitive` you can add a tree fragment to the scene but only the top most element gets processed for an `___r3f` property. Since all children are missing this, when they get hit by a raycaster they then fail the `getRootState` call. Similarly, `primitive` elements were failing to get added to `ineternal.interactions` object as a `primitive` would get processed with `applyProps` before it had a parent. I don't know why this is. This PR does the following:
- Filters out events from being written to objects unnecessarily.
- Removes the parent check from the `ineternal.interactions` function. I'm not sure what this check was doing in the first place. If we need it, we'll have to figure out why `applyProps` is run before it has a parent.
- When a hit is processed for handlers, recursively look up the tree until we get a state from `getRootState`.

An alternative would be to process all children of a `primitive` fragment to give them R3F metadata.