### PR TITLE
fix(native): restore polyfill conversions, drop networking

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "singleQuote": true,
   "tabWidth": 2,
   "printWidth": 120,
-  "jsxBracketSameLine": true
+  "jsxBracketSameLine": true,
+  "endOfLine": "auto"
 }

--- a/packages/fiber/package.json
+++ b/packages/fiber/package.json
@@ -44,6 +44,8 @@
   "dependencies": {
     "@babel/runtime": "^7.17.8",
     "@types/react-reconciler": "^0.26.7",
+    "base64-js": "^1.5.1",
+    "buffer": "^6.0.3",
     "its-fine": "^1.0.6",
     "react-reconciler": "^0.27.0",
     "react-use-measure": "^2.1.1",

--- a/packages/fiber/package.json
+++ b/packages/fiber/package.json
@@ -44,7 +44,6 @@
   "dependencies": {
     "@babel/runtime": "^7.17.8",
     "@types/react-reconciler": "^0.26.7",
-    "base64-js": "^1.5.1",
     "its-fine": "^1.0.6",
     "react-reconciler": "^0.27.0",
     "react-use-measure": "^2.1.1",

--- a/packages/fiber/src/native.tsx
+++ b/packages/fiber/src/native.tsx
@@ -21,6 +21,6 @@ export type { GlobalRenderCallback, GlobalEffectType } from './core/loop'
 export * from './core'
 
 import { Platform } from 'react-native'
-import { _polyfills } from './native/polyfills'
+import { polyfills } from './native/polyfills'
 
-if (Platform.OS !== 'web') _polyfills()
+if (Platform.OS !== 'web') polyfills()

--- a/packages/fiber/src/native.tsx
+++ b/packages/fiber/src/native.tsx
@@ -20,7 +20,4 @@ export { createTouchEvents as events } from './native/events'
 export type { GlobalRenderCallback, GlobalEffectType } from './core/loop'
 export * from './core'
 
-import { Platform } from 'react-native'
-import { polyfills } from './native/polyfills'
-
-if (Platform.OS !== 'web') polyfills()
+export { polyfills } from './native/polyfills'

--- a/packages/fiber/src/native.tsx
+++ b/packages/fiber/src/native.tsx
@@ -20,4 +20,7 @@ export { createTouchEvents as events } from './native/events'
 export type { GlobalRenderCallback, GlobalEffectType } from './core/loop'
 export * from './core'
 
-export { polyfills } from './native/polyfills'
+import { Platform } from 'react-native'
+import { polyfills } from './native/polyfills'
+
+if (Platform.OS !== 'web') polyfills()

--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -7,7 +7,6 @@ import { SetBlock, Block, ErrorBoundary, useMutableCallback } from '../core/util
 import { extend, createRoot, unmountComponentAtNode, RenderProps, ReconcilerRoot } from '../core'
 import { createTouchEvents } from './events'
 import { RootState, Size } from '../core/store'
-import { polyfills } from './polyfills'
 
 export interface CanvasProps extends Omit<RenderProps<HTMLCanvasElement>, 'size' | 'dpr'>, ViewProps {
   children: React.ReactNode
@@ -43,9 +42,6 @@ const CanvasImpl = /*#__PURE__*/ React.forwardRef<View, Props>(
     },
     forwardedRef,
   ) => {
-    // Eagerly polyfill
-    React.useMemo(() => polyfills(), [])
-
     // Create a known catalogue of Threejs-native elements
     // This will include the entire THREE namespace by default, users can extend
     // their own elements by using the createRoot API instead

--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -7,6 +7,7 @@ import { SetBlock, Block, ErrorBoundary, useMutableCallback } from '../core/util
 import { extend, createRoot, unmountComponentAtNode, RenderProps, ReconcilerRoot } from '../core'
 import { createTouchEvents } from './events'
 import { RootState, Size } from '../core/store'
+import { polyfills } from './polyfills'
 
 export interface CanvasProps extends Omit<RenderProps<HTMLCanvasElement>, 'size' | 'dpr'>, ViewProps {
   children: React.ReactNode
@@ -42,6 +43,9 @@ const CanvasImpl = /*#__PURE__*/ React.forwardRef<View, Props>(
     },
     forwardedRef,
   ) => {
+    // Eagerly polyfill
+    React.useMemo(() => polyfills(), [])
+
     // Create a known catalogue of Threejs-native elements
     // This will include the entire THREE namespace by default, users can extend
     // their own elements by using the createRoot API instead

--- a/packages/fiber/src/native/polyfills.ts
+++ b/packages/fiber/src/native/polyfills.ts
@@ -95,6 +95,8 @@ export function polyfills() {
 
         const uri = fs.cacheDirectory + uuidv4() + `.${type}`
         await fs.writeAsStringAsync(uri, data, { encoding: fs.EncodingType.Base64 })
+
+        return uri
       }
     }
 
@@ -124,15 +126,6 @@ export function polyfills() {
 
     getAsset(url)
       .then(async (uri) => {
-        // Create safe URI for JSI
-        if (uri.startsWith('data:')) {
-          const [header, data] = uri.split(',')
-          const [, type] = header.split('/')
-
-          uri = fs.cacheDirectory + uuidv4() + `.${type}`
-          await fs.writeAsStringAsync(uri, data, { encoding: fs.EncodingType.Base64 })
-        }
-
         const { width, height } = await new Promise<{ width: number; height: number }>((res, rej) =>
           Image.getSize(uri, (width, height) => res({ width, height }), rej),
         )

--- a/packages/fiber/src/native/polyfills.ts
+++ b/packages/fiber/src/native/polyfills.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three'
 import { Image, NativeModules } from 'react-native'
 import { Asset } from 'expo-asset'
 import * as fs from 'expo-file-system'
+import { fromByteArray } from 'base64-js'
 import { Buffer } from 'buffer'
 
 export function polyfills() {

--- a/packages/fiber/src/native/polyfills.ts
+++ b/packages/fiber/src/native/polyfills.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three'
 import { Image, NativeModules } from 'react-native'
 import { Asset } from 'expo-asset'
 import * as fs from 'expo-file-system'
-import { fromByteArray } from 'base64-js'
+import { Buffer } from 'buffer'
 
 export function polyfills() {
   function uuidv4() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3413,7 +3413,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.1.2, base64-js@^1.5.1:
+base64-js@^1.1.2, base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -3558,6 +3558,14 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 builtin-modules@^3.1.0:
   version "3.2.0"
@@ -5416,6 +5424,11 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore-walk@^3.0.3:
   version "3.0.4"


### PR DESCRIPTION
Fixes #1972
Fixes #3049

#3042 introduced a logical regression for Android APK, but also operated under a false premise that previous anonymous errors came from `Blob`/`FileReader` internals and instead was from `XMLHttpRequest`. Although `FileReader.readAsArrayBuffer` was since implemented in `react-native` (polyfill available for older versions), `fetch` still has issues loading data or local uris. I've mirrored https://github.com/pmndrs/react-three-fiber/issues/3049#issuecomment-1772568665 with `buffer` which implements such and restored enhancements from #2982.