### PR TITLE
feat: export buildGraph

### DIFF
--- a/docs/API/additional-exports.mdx
+++ b/docs/API/additional-exports.mdx
@@ -8,6 +8,7 @@ nav: 9
 | addEffect          | Adds a global render callback which is called each frame       |
 | addAfterEffect     | Adds a global after-render callback which is called each frame |
 | addTail            | Adds a global callback which is called when rendering stops    |
+| buildGraph         | Collects nodes and materials from a THREE.Object3D             |
 | flushGlobalEffects | Flushes global render-effects for when manually driving a loop |
 | invalidate         | Forces view global invalidation                                |
 | advance            | Advances the frameloop (given that it's set to 'never')        |

--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -29,7 +29,7 @@ import {
   Camera,
   updateCamera,
   getColorManagement,
-  hasColorSpace,
+  buildGraph,
 } from './utils'
 import { useStore } from './hooks'
 import type { Properties } from '../three-types'
@@ -590,5 +590,6 @@ export {
   flushGlobalEffects,
   getRootState,
   act,
+  buildGraph,
   roots as _roots,
 }

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -153,7 +153,9 @@ export const is = {
   },
 }
 
-// Collects nodes and materials from a THREE.Object3D
+/**
+ * Collects nodes and materials from a THREE.Object3D.
+ */
 export function buildGraph(object: THREE.Object3D) {
   const data: ObjectMap = { nodes: {}, materials: {} }
   if (object) {


### PR DESCRIPTION
Resolves #2664
Resolves #3000

Exports `buildGraph` which is used internally by `useLoader` to populate `nodes` and `materials` since three.js upstream doesn't do so for `GLTFLoader`. It's possible we remove this in the future should this become a native feature despite its depart from glTF.
