### PR TITLE
fix: configure camera for raycaster

### DIFF
--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -227,6 +227,10 @@ function createRoot<TCanvas extends Canvas>(canvas: TCanvas): ReconcilerRoot<TCa
           if (!state.camera && !cameraOptions?.rotation) camera.lookAt(0, 0, 0)
         }
         state.set({ camera })
+
+        // Configure raycaster
+        // https://github.com/pmndrs/react-xr/issues/300
+        raycaster.camera = camera
       }
 
       // Set up scene (one time only!)


### PR DESCRIPTION
Fixes https://github.com/pmndrs/react-three-fiber/issues/3057 where `LineSegments2` requires camera access.