### PR TITLE
fix(native): harden Blob URI check for Android

### DIFF
--- a/packages/fiber/__mocks__/react-native.ts
+++ b/packages/fiber/__mocks__/react-native.ts
@@ -49,3 +49,5 @@ export const Image = {
 export const Platform = {
   OS: 'web',
 }
+
+export const NativeModules = {}

--- a/packages/fiber/src/native/polyfills.ts
+++ b/packages/fiber/src/native/polyfills.ts
@@ -103,7 +103,7 @@ export function polyfills() {
         if (!NativeModules.BlobModule?.BLOB_URI_SCHEME) {
           blob.data._base64 = ''
           for (const part of parts) {
-            blob.data._base64 += (part as any).data._base64 ?? part
+            blob.data._base64 += (part as any).data?._base64 ?? part
           }
         }
 
@@ -135,6 +135,7 @@ export function polyfills() {
           width,
           height,
         }
+        texture.flipY = true // Since expo-gl@12.4.0
         texture.needsUpdate = true
 
         // Force non-DOM upload for EXGL texImage2D

--- a/packages/fiber/src/native/polyfills.ts
+++ b/packages/fiber/src/native/polyfills.ts
@@ -41,7 +41,7 @@ async function getAsset(input: string | number): Promise<string> {
       input = `data:${blob.type};base64,${data}`
     }
 
-    // Create safe URI for JSI
+    // Create safe URI for JSI serialization
     if (input.startsWith('data:')) {
       const [header, data] = input.split(';base64,')
       const [, type] = header.split('/')

--- a/packages/fiber/src/native/polyfills.ts
+++ b/packages/fiber/src/native/polyfills.ts
@@ -28,7 +28,7 @@ export function polyfills() {
       const createObjectURL = URL.createObjectURL
       URL.createObjectURL = function (blob: Blob): string {
         if ((blob as any)._base64) {
-          return `data:${blob.type};base64,${(blob as any)._base64}`
+          return `data:${blob.type};base64,${(blob as any).data._base64}`
         }
 
         return createObjectURL(blob)
@@ -44,14 +44,14 @@ export function polyfills() {
           }
 
           if (!NativeModules.BlobModule?.BLOB_URI_SCHEME) {
-            base64 += (part as any)._base64 ?? part
+            base64 += (part as any).data._base64 ?? part
           }
 
           return part
         })
 
         const blob = createFromParts(parts, options)
-        blob._base64 = base64
+        blob.data._base64 = base64
 
         return blob
       }
@@ -64,6 +64,7 @@ export function polyfills() {
       if (input.startsWith('file:')) return input
 
       // Unpack Blobs from react-native BlobManager
+      // https://github.com/facebook/react-native/issues/22681#issuecomment-523258955
       if (input.startsWith('blob:') || input.startsWith(NativeModules.BlobModule?.BLOB_URI_SCHEME)) {
         const blob = await new Promise<Blob>((res, rej) => {
           const xhr = new XMLHttpRequest()


### PR DESCRIPTION
Follow-up to #3059. Unpacks blobs from Android content urls when specified by the native `BlobModule`. When not configured as per https://github.com/pmndrs/react-three-fiber/issues/3058#issuecomment-1774039376, we fallback to a base64 uri since internal parts data is already encoded.