### PR TITLE
experiment: stable object sort

### DIFF
--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -31,6 +31,7 @@ export type LocalState = {
   attach?: AttachType
   previousAttach: any
   memoizedProps: { [key: string]: any }
+  autoRemovedBeforeAppend?: boolean
 }
 
 export type AttachFnType = (parent: Instance, self: Instance) => () => void
@@ -271,8 +272,16 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
     instance.__r3f.objects.forEach((child) => appendChild(newInstance, child))
     instance.__r3f.objects = []
 
-    insertBefore(parent, newInstance, instance)
-    removeChild(parent, instance)
+    const autoRemovedBeforeAppend = !!newInstance.parent
+
+    if (!instance.__r3f.autoRemovedBeforeAppend) {
+      insertBefore(parent, newInstance, instance)
+      removeChild(parent, instance)
+    } else {
+      appendChild(parent, newInstance)
+    }
+
+    newInstance.__r3f.autoRemovedBeforeAppend = autoRemovedBeforeAppend
 
     // Re-bind event handlers
     if (newInstance.raycast && newInstance.__r3f.eventCount) {

--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -172,7 +172,13 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
         added = true
       }
 
-      if (!added) parentInstance.__r3f?.objects.push(child)
+      const objects = parentInstance.__r3f?.objects
+      if (!added && objects) {
+        const index = objects.indexOf(beforeChild)
+        if (index !== -1) objects.splice(index, 0, child)
+        else objects.push(child)
+      }
+
       if (!child.__r3f) prepare(child, {})
       child.__r3f.parent = parentInstance
       updateInstance(child)
@@ -189,8 +195,11 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
       // Clear the parent reference
       if (child.__r3f) child.__r3f.parent = null
       // Remove child from the parents objects
-      if (parentInstance.__r3f?.objects)
-        parentInstance.__r3f.objects = parentInstance.__r3f.objects.filter((x) => x !== child)
+      const objects = parentInstance.__r3f?.objects
+      if (objects) {
+        const index = objects.indexOf(child)
+        if (index !== -1) objects.splice(index, 1)
+      }
       // Remove attachment
       if (child.__r3f?.attach) {
         detach(parentInstance, child, child.__r3f.attach)

--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -31,7 +31,6 @@ export type LocalState = {
   attach?: AttachType
   previousAttach: any
   memoizedProps: { [key: string]: any }
-  autoRemovedBeforeAppend?: boolean
 }
 
 export type AttachFnType = (parent: Instance, self: Instance) => () => void
@@ -272,13 +271,8 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
     instance.__r3f.objects.forEach((child) => appendChild(newInstance, child))
     instance.__r3f.objects = []
 
-    if (!instance.__r3f.autoRemovedBeforeAppend) {
-      removeChild(parent, instance)
-    }
-    if (newInstance.parent) {
-      newInstance.__r3f.autoRemovedBeforeAppend = true
-    }
-    appendChild(parent, newInstance)
+    insertBefore(parent, newInstance, instance)
+    removeChild(parent, instance)
 
     // Re-bind event handlers
     if (newInstance.raycast && newInstance.__r3f.eventCount) {

--- a/packages/fiber/tests/core/renderer.test.tsx
+++ b/packages/fiber/tests/core/renderer.test.tsx
@@ -500,16 +500,16 @@ describe('renderer', () => {
 
   it('can swap 4 array primitives', async () => {
     let state: RootState = null!
-    const a = new THREE.Group()
-    const b = new THREE.Group()
-    const c = new THREE.Group()
-    const d = new THREE.Group()
+    const a = Object.assign(new THREE.Group(), { name: 'a' })
+    const b = Object.assign(new THREE.Group(), { name: 'b' })
+    const c = Object.assign(new THREE.Group(), { name: 'c' })
+    const d = Object.assign(new THREE.Group(), { name: 'd' })
     const array = [a, b, c, d]
 
     const Test = ({ array }: { array: THREE.Group[] }) => (
       <>
-        {array.map((group, i) => (
-          <primitive key={i} object={group} />
+        {array.map((group) => (
+          <primitive key={group.name} object={group} />
         ))}
       </>
     )

--- a/packages/fiber/tests/core/renderer.test.tsx
+++ b/packages/fiber/tests/core/renderer.test.tsx
@@ -500,16 +500,16 @@ describe('renderer', () => {
 
   it('can swap 4 array primitives', async () => {
     let state: RootState = null!
-    const a = Object.assign(new THREE.Group(), { name: 'a' })
-    const b = Object.assign(new THREE.Group(), { name: 'b' })
-    const c = Object.assign(new THREE.Group(), { name: 'c' })
-    const d = Object.assign(new THREE.Group(), { name: 'd' })
+    const a = new THREE.Group()
+    const b = new THREE.Group()
+    const c = new THREE.Group()
+    const d = new THREE.Group()
     const array = [a, b, c, d]
 
     const Test = ({ array }: { array: THREE.Group[] }) => (
       <>
-        {array.map((group) => (
-          <primitive key={group.name} object={group} />
+        {array.map((group, i) => (
+          <primitive key={i} object={group} />
         ))}
       </>
     )

--- a/packages/test-renderer/src/__tests__/__snapshots__/RTTR.core.test.tsx.snap
+++ b/packages/test-renderer/src/__tests__/__snapshots__/RTTR.core.test.tsx.snap
@@ -296,19 +296,19 @@ Array [
           Object {
             "children": Array [],
             "props": Object {
-              "args": Array [],
-            },
-            "type": "meshBasicMaterial",
-          },
-          Object {
-            "children": Array [],
-            "props": Object {
               "args": Array [
                 2,
                 2,
               ],
             },
             "type": "boxGeometry",
+          },
+          Object {
+            "children": Array [],
+            "props": Object {
+              "args": Array [],
+            },
+            "type": "meshBasicMaterial",
           },
         ],
         "props": Object {


### PR DESCRIPTION
Follow-up to #2679. Tries to implement a stable `object` sort for non-scene-graph children.