### PR TITLE
fix(types): remove use of Object3D generic

### DIFF
--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -205,7 +205,7 @@ export function createEvents(store: UseBoundStore<RootState>) {
       state.events.compute?.(event, state)
     }
 
-    function handleRaycast(obj: THREE.Object3D<THREE.Event>) {
+    function handleRaycast(obj: THREE.Object3D) {
       const state = getRootState(obj)
       // Skip event handling when noEvents is set, or when the raycasters camera is null
       if (!state || !state.events.enabled || state.raycaster.camera === null) return []
@@ -222,7 +222,7 @@ export function createEvents(store: UseBoundStore<RootState>) {
     }
 
     // Collect events
-    let hits: THREE.Intersection<THREE.Object3D<THREE.Event>>[] = eventsObjects
+    let hits: THREE.Intersection<THREE.Object3D>[] = eventsObjects
       // Intersect objects
       .flatMap(handleRaycast)
       // Sort by event priority and distance


### PR DESCRIPTION
Mirrors the fix from https://github.com/pmndrs/drei/pull/1696 for events.