### PR TITLE
Revert "experiment: stable object sort (#3066)"

### DIFF
--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -172,13 +172,7 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
         added = true
       }
 
-      const objects = parentInstance.__r3f?.objects
-      if (!added && objects) {
-        const index = objects.indexOf(beforeChild)
-        if (index !== -1) objects.splice(index, 0, child)
-        else objects.push(child)
-      }
-
+      if (!added) parentInstance.__r3f?.objects.push(child)
       if (!child.__r3f) prepare(child, {})
       child.__r3f.parent = parentInstance
       updateInstance(child)
@@ -195,11 +189,8 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
       // Clear the parent reference
       if (child.__r3f) child.__r3f.parent = null
       // Remove child from the parents objects
-      const objects = parentInstance.__r3f?.objects
-      if (objects) {
-        const index = objects.indexOf(child)
-        if (index !== -1) objects.splice(index, 1)
-      }
+      if (parentInstance.__r3f?.objects)
+        parentInstance.__r3f.objects = parentInstance.__r3f.objects.filter((x) => x !== child)
       // Remove attachment
       if (child.__r3f?.attach) {
         detach(parentInstance, child, child.__r3f.attach)
@@ -272,16 +263,13 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
     instance.__r3f.objects.forEach((child) => appendChild(newInstance, child))
     instance.__r3f.objects = []
 
-    const autoRemovedBeforeAppend = !!newInstance.parent
-
     if (!instance.__r3f.autoRemovedBeforeAppend) {
-      insertBefore(parent, newInstance, instance)
       removeChild(parent, instance)
-    } else {
-      appendChild(parent, newInstance)
     }
-
-    newInstance.__r3f.autoRemovedBeforeAppend = autoRemovedBeforeAppend
+    if (newInstance.parent) {
+      newInstance.__r3f.autoRemovedBeforeAppend = true
+    }
+    appendChild(parent, newInstance)
 
     // Re-bind event handlers
     if (newInstance.raycast && newInstance.__r3f.eventCount) {

--- a/packages/test-renderer/src/__tests__/__snapshots__/RTTR.core.test.tsx.snap
+++ b/packages/test-renderer/src/__tests__/__snapshots__/RTTR.core.test.tsx.snap
@@ -296,19 +296,19 @@ Array [
           Object {
             "children": Array [],
             "props": Object {
+              "args": Array [],
+            },
+            "type": "meshBasicMaterial",
+          },
+          Object {
+            "children": Array [],
+            "props": Object {
               "args": Array [
                 2,
                 2,
               ],
             },
             "type": "boxGeometry",
-          },
-          Object {
-            "children": Array [],
-            "props": Object {
-              "args": Array [],
-            },
-            "type": "meshBasicMaterial",
           },
         ],
         "props": Object {


### PR DESCRIPTION
Reverts #3066 due to unwanted downstream effects. Investigating in #3068.