### PR TITLE
fix(native): parse file response type

### DIFF
--- a/packages/fiber/src/native/polyfills.ts
+++ b/packages/fiber/src/native/polyfills.ts
@@ -161,7 +161,18 @@ export function polyfills() {
       .then(async (uri) => {
         const base64 = await fs.readAsStringAsync(uri, { encoding: fs.EncodingType.Base64 })
         const data = Buffer.from(base64, 'base64')
-        onLoad?.(data.buffer)
+
+        switch (this.responseType) {
+          case 'arrayBuffer':
+            return onLoad?.(data.buffer)
+          case 'blob':
+            return onLoad?.(new Blob([data.buffer]) as any)
+          // case 'document':
+          case 'json':
+            return onLoad?.(JSON.parse(THREE.LoaderUtils.decodeText(data)))
+          default:
+            return onLoad?.(THREE.LoaderUtils.decodeText(data))
+        }
       })
       .catch((error) => {
         onError?.(error)


### PR DESCRIPTION
Fixes #3085. Most loaders expect an `ArrayBuffer` when calling their parse methods, but some require plain text. The other modes aren't used in three source ATM.