### PR TITLE
fix(types): update import from three/examples

### DIFF
--- a/packages/fiber/src/core/hooks.tsx
+++ b/packages/fiber/src/core/hooks.tsx
@@ -1,7 +1,7 @@
 import * as THREE from 'three'
 import * as React from 'react'
 import { StateSelector, EqualityChecker } from 'zustand'
-import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader'
+import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader.js'
 import { suspend, preload, clear } from 'suspend-react'
 import { context, RootState, RenderCallback } from './store'
 import { buildGraph, ObjectMap, is, useMutableCallback, useIsomorphicLayoutEffect } from './utils'


### PR DESCRIPTION
The current types import from `three/examples/jsm/loaders/GLTFLoader` which is not a valid import path based on three.js's `package.json` "exports" and therfore produces a type error when using `"moduleResolution": "bundler"`:

```
Error: ./node_modules/@react-three/fiber/dist/declarations/src/core/hooks.d.ts(4,22): error TS2307: Cannot find module 'three/examples/jsm/loaders/GLTFLoader' or its corresponding type declarations.
```

Adding the `.js` extension allows TypeScript to resolve to the correct file.