### PR TITLE
[v9] Fix: Guard against constructing without params in diffProps

### DIFF
--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -342,7 +342,7 @@ export function diffProps<T = any>(
       // has no means to do this. Hence we curate a small collection of value-classes
       // with their respective constructor/set arguments
       // For removed props, try to set default values, if possible
-      if (root.constructor) {
+      if (root.constructor && root.constructor.length === 0) {
         // create a blank slate of the instance and copy the particular parameter.
         let ctor = DEFAULTS.get(root.constructor)
         if (!ctor) {

--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -26,6 +26,8 @@ export type Color = MathType<THREE.Color>
 export type Layers = MathType<THREE.Layers>
 export type Quaternion = MathType<THREE.Quaternion>
 export type Euler = MathType<THREE.Euler>
+export type Matrix3 = MathType<THREE.Matrix3>
+export type Matrix4 = MathType<THREE.Matrix4>
 
 export type WithMathProps<P> = { [K in keyof P]: P[K] extends MathRepresentation | THREE.Euler ? MathType<P[K]> : P[K] }
 


### PR DESCRIPTION
Adds a simple check to make sure a constructor has no required params before attempting to clone it for defaults.