### PR TITLE
fix(types): preserve deprecated XR type annotations

### DIFF
--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -7,7 +7,7 @@ import { AttachType, catalogue, Instance, InstanceProps, LocalState } from './re
 import { Dpr, Renderer, RootState, Size } from './store'
 
 // < r141 shipped vendored types https://github.com/pmndrs/react-three-fiber/issues/2501
-// @ts-ignore
+/** @ts-ignore */
 type _DeprecatedXRFrame = THREE.XRFrame
 export type _XRFrame = THREE.WebGLRenderTargetOptions extends { samples?: number } ? XRFrame : _DeprecatedXRFrame
 


### PR DESCRIPTION
Fixes #3110. Mirrors #3062 for `XRFrame`.