### PR TITLE
[v9] feat(useLoader): support loader instances

### DIFF
--- a/packages/fiber/tests/hooks.test.tsx
+++ b/packages/fiber/tests/hooks.test.tsx
@@ -153,6 +153,24 @@ describe('hooks', () => {
     expect(extensions).toBeCalledTimes(1)
   })
 
+  it('can handle useLoader with an existing loader instance', async () => {
+    class Loader extends THREE.Loader {
+      load(_url: string, onLoad: (result: null) => void): void {
+        onLoad(null)
+      }
+    }
+
+    const loader = new Loader()
+    let proto!: Loader
+
+    function Test(): null {
+      return useLoader(loader, '', (loader) => (proto = loader))
+    }
+    await act(async () => root.render(<Test />))
+
+    expect(proto).toBe(loader)
+  })
+
   it('can handle useLoader with a loader extension', async () => {
     class Loader extends THREE.Loader {
       load(_url: string, onLoad: (result: null) => void): void {


### PR DESCRIPTION
Supports re-use of external loader instances:

```jsx
import { GLTFLoader } from 'three-stdlib'
import { useLoader } from '@react-three/fiber'

const loader = new GLTFLoader()

function Model() {
  const gltf = useLoader(loader, '/path/to/model.gltf')
}
```