### PR TITLE
Update introduction for three.js r155+

### DIFF
--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -80,8 +80,9 @@ function Box(props) {
 
 createRoot(document.getElementById('root')).render(
   <Canvas>
-    <ambientLight />
-    <pointLight position={[10, 10, 10]} />
+    <ambientLight intensity={Math.PI / 2} />
+    <spotLight position={[10, 10, 10]} angle={0.15} penumbra={1} decay={0} intensity={Math.PI} />
+    <pointLight position={[-10, -10, -10]} decay={0} intensity={Math.PI} />
     <Box position={[-1.2, 0, 0]} />
     <Box position={[1.2, 0, 0]} />
   </Canvas>,
@@ -122,8 +123,9 @@ function Box(props: ThreeElements['mesh']) {
 
 createRoot(document.getElementById('root')).render(
   <Canvas>
-    <ambientLight />
-    <pointLight position={[10, 10, 10]} />
+    <ambientLight intensity={Math.PI / 2} />
+    <spotLight position={[10, 10, 10]} angle={0.15} penumbra={1} decay={0} intensity={Math.PI} />
+    <pointLight position={[-10, -10, -10]} decay={0} intensity={Math.PI} />
     <Box position={[-1.2, 0, 0]} />
     <Box position={[1.2, 0, 0]} />
   </Canvas>,
@@ -165,8 +167,9 @@ function Box(props) {
 export default function App() {
   return (
     <Canvas>
-      <ambientLight />
-      <pointLight position={[10, 10, 10]} />
+      <ambientLight intensity={Math.PI / 2} />
+      <spotLight position={[10, 10, 10]} angle={0.15} penumbra={1} decay={0} intensity={Math.PI} />
+      <pointLight position={[-10, -10, -10]} decay={0} intensity={Math.PI} />
       <Box position={[-1.2, 0, 0]} />
       <Box position={[1.2, 0, 0]} />
     </Canvas>


### PR DESCRIPTION
If you follow the guidance on the introduction page you end up installing the latest three.js but the code sample was built for the pre-r155 lighting system. The linked codesandbox project has already been updated but the code sample on the page has not. This change aligns the page's code sample with the codesandbox code.

This has tripped a few people up: https://github.com/pmndrs/react-three-fiber/issues/3003 https://github.com/pmndrs/react-three-fiber/issues/2990 https://github.com/pmndrs/react-three-fiber/issues/2963

Before:
<img width="640" alt="Screenshot 2024-01-01 at 13 18 37" src="https://github.com/pmndrs/react-three-fiber/assets/3025659/f9467eeb-42f0-400c-9cc1-84adb3e6a56f">

After:
<img width="640" alt="Screenshot 2024-01-01 at 13 18 55" src="https://github.com/pmndrs/react-three-fiber/assets/3025659/200ff120-dd4e-447a-a31a-d0f399b622c8">
