### PR TITLE
fix(RTTR): set initial size for NaN in viewport

### DIFF
--- a/packages/test-renderer/src/__tests__/RTTR.hooks.test.tsx
+++ b/packages/test-renderer/src/__tests__/RTTR.hooks.test.tsx
@@ -29,12 +29,12 @@ describe('ReactThreeTestRenderer Hooks', () => {
       return <group />
     }
 
-    await ReactThreeTestRenderer.create(<Component />)
+    await ReactThreeTestRenderer.create(<Component />, { width: 1280, height: 800 })
 
     expect(result.camera instanceof THREE.Camera).toBeTruthy()
     expect(result.scene instanceof THREE.Scene).toBeTruthy()
     expect(result.raycaster instanceof THREE.Raycaster).toBeTruthy()
-    expect(result.size).toEqual({ height: 0, width: 0, top: 0, left: 0, updateStyle: false })
+    expect(result.size).toEqual({ height: 800, width: 1280, top: 0, left: 0, updateStyle: true })
   })
 
   it('can handle useLoader hook', async () => {

--- a/packages/test-renderer/src/index.tsx
+++ b/packages/test-renderer/src/index.tsx
@@ -23,7 +23,18 @@ const act = _act as unknown as Act
 const create = async (element: React.ReactNode, options?: Partial<CreateOptions>): Promise<Renderer> => {
   const canvas = createCanvas(options)
 
-  const _root = createRoot(canvas).configure({ frameloop: 'never', ...options, events: undefined })
+  let size
+
+  if (typeof options !== 'undefined' && typeof options.width !== 'undefined' && typeof options.height !== 'undefined') {
+    size = { width: options.width, height: options.height, top: 0, left: 0 }
+  }
+
+  const _root = createRoot(canvas).configure({
+    frameloop: 'never',
+    ...options,
+    size,
+    events: undefined,
+  })
   const _store = mockRoots.get(canvas)!.store
 
   await act(async () => _root.render(element))

--- a/packages/test-renderer/src/index.tsx
+++ b/packages/test-renderer/src/index.tsx
@@ -23,16 +23,17 @@ const act = _act as unknown as Act
 const create = async (element: React.ReactNode, options?: Partial<CreateOptions>): Promise<Renderer> => {
   const canvas = createCanvas(options)
 
-  let size
-
-  if (typeof options !== 'undefined' && typeof options.width !== 'undefined' && typeof options.height !== 'undefined') {
-    size = { width: options.width, height: options.height, top: 0, left: 0 }
-  }
-
   const _root = createRoot(canvas).configure({
     frameloop: 'never',
+    // TODO: remove and use default behavior
+    size: {
+      width: options?.width ?? 1280,
+      height: options?.height ?? 800,
+      top: 0,
+      left: 0,
+      updateStyle: typeof HTMLCanvasElement !== 'undefined' && canvas instanceof HTMLCanvasElement,
+    },
     ...options,
-    size,
     events: undefined,
   })
   const _store = mockRoots.get(canvas)!.store


### PR DESCRIPTION
## Overview
This PR addresses issue #3133. It includes two main changes:

1. **Bug Fix**: Corrects the error in the `viewport` and `camera` objects by explicitly creating the size object in the `configure` function to ensure proper passing of width and height properties.
2. **Test Update**: Enhances the test for the `useThree` hook to accurately reflect and validate the size object's structure, using specific dimensions to improve test reliability.

These changes ensure that the `configure` function correctly handles size properties, and the updated test verifies this functionality effectively.

## Process
I began by inspecting the source files for the `fiber` package. I noticed that the [configure function](https://github.com/pmndrs/react-three-fiber/blob/master/packages/fiber/src/core/index.tsx#L182) (returned by the createRoot function) requires the desired width and height (among other size attributes) to be within a `size` object. It does not accept `width` and `height` directly. 

Upon inspecting source files for the `test-renderer` package, I noticed that the structure of the props were being passed to the configure function like so:
```js
const _root = createRoot(canvas).configure({ frameloop: 'never', ...options, events: undefined })
```
given that the [docs](https://github.com/pmndrs/react-three-fiber/blob/master/packages/test-renderer/markdown/rttr.md/#createoptions) show that the structure of the createOptions prop is 
```js
// RenderProps is from react-three-fiber
interface CreateOptions extends RenderProps<HTMLCanvasElement> {
  width?: number // width of canvas
  height?: number // height of canvas
}
```
This is not in agreement with the observation that, essentially, `width` and `height` should be part of a `size` object.

## Potential Fixes: 
1. The most simple fix would be to update the docs, such that the end-user explicitly passes a `size` object, containing the desired `width` and `height`, ALONG with `top` and `left`, as the second parameter of the create function, like so:
```js
const renderer = ReactThreeTestRenderer.create(element, {size: {/* desired width and height*/ })
```
however, this approach might cause issues with existing tests written with RTTR, which I believe may not be ideal. Moreover, it will require typescript users to explicitly pass `top` and `left` props, as `type Size` requires `top` and `left` to be defined. 

2. Another fix I came up with was to explicitly create a `size` object containing the user input `width` and `height` attributes, along with other default required attributes, in the `create` function and also passing any other props that may be added in the future. The code is: 
```js 
  let size

  if (typeof options !== 'undefined' && typeof options.width !== 'undefined' && typeof options.height !== 'undefined') {
    size = { width: options.width, height: options.height, top: 0, left: 0 }
  }

  const _root = createRoot(canvas).configure({
    frameloop: 'never',
    ...options,
    size,
    events: undefined,
  })
```
with this fix, no changes will be needed in the way the api is used, however the code is slightly complex and redundant. It may serve as a workable fix until the maintainers see fit to release a new version for the api.

**This PR is implementing the 2nd fix.**

## Results
The original issue is resolved. The `NaN` values are gone and the `viewport` is calculated as expected. Moreover, the `NaN` values in `camera` are also resolved. Here is an example result for the `viewport`, if the `width` is set to `1280` and `height` is set to `800`

```js
{
    initialDpr: 1,
    dpr: 1,
    width: 12.277231807663368,
    height: 7.673269879789604,
    top: 0,
    left: 0,
    aspect: 1.6,
    distance: 5,
    factor: 104.25802982729644,
    getCurrentViewport: [Function: getCurrentViewport]
}
 ``` 
The test for the `useThree()` hook was also updated to reflect the correct calculation of the `size` object.

Feedback and suggestions for improvements are welcome. @CodyJasonBennett, your guidance on enhancing this PR would be greatly appreciated.