### PR TITLE
fix(ci): matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Use Node ${{ matrix.node }}
+      - name: Use Node 18
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 18
 
       - name: Install deps and build (with cache)
         uses: bahmutov/npm-install@v1


### PR DESCRIPTION
## Problem

The CI uses matrix notation for setting Node.js version, but there's no matrix strategy set, so it's getting ignored.

## Solution

The change sets Node.js version 18 expliticly, and removes unused `matrix.node` calls.

Why 18? Because this is the one that's actually being set by default, if you see the latest run: https://github.com/pmndrs/react-three-fiber/actions/runs/7384710806/job/20088098184 