### PR TITLE
RTTR: Prevent warn log in test

### DIFF
--- a/packages/test-renderer/src/__tests__/RTTR.events.test.tsx
+++ b/packages/test-renderer/src/__tests__/RTTR.events.test.tsx
@@ -39,6 +39,8 @@ describe('ReactThreeTestRenderer Events', () => {
   it('should not throw if the handle name is incorrect', async () => {
     const handlePointerDown = jest.fn()
 
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementationOnce(jest.fn())
+
     const Component = () => {
       return (
         <mesh onPointerDown={handlePointerDown}>
@@ -53,5 +55,10 @@ describe('ReactThreeTestRenderer Events', () => {
     expect(async () => await fireEvent(scene.children[0], 'onPointerUp')).not.toThrow()
 
     expect(handlePointerDown).not.toHaveBeenCalled()
+
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1)
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Handler for onPointerUp was not found. You must pass event names in camelCase or name of the handler https://github.com/pmndrs/react-three-fiber/blob/master/packages/test-renderer/markdown/rttr.md#create-fireevent',
+    )
   })
 })


### PR DESCRIPTION
The change prevents `console.warn` output log pollution, as well as covers it with test.

Example of log from the [latest run](https://github.com/pmndrs/react-three-fiber/actions/runs/7630812513/job/20787324972) in `master` branch:

```sh
PASS packages/test-renderer/src/__tests__/RTTR.events.test.tsx
  ● Console

    console.warn
      Handler for onPointerUp was not found. You must pass event names in camelCase or name of the handler https://github.com/pmndrs/react-three-fiber/blob/master/packages/test-renderer/markdown/rttr.md#create-fireevent

      28 |     }
      29 |
    > 30 |     console.warn(
         |             ^
      31 |       `Handler for ${eventName} was not found. You must pass event names in camelCase or name of the handler https://github.com/pmndrs/react-three-fiber/blob/master/packages/test-renderer/markdown/rttr.md#create-fireevent`,
      32 |     )
      33 |

      at findEventHandler (packages/test-renderer/src/fireEvent.ts:30:13)
      at packages/test-renderer/src/fireEvent.ts:50:[21](https://github.com/pmndrs/react-three-fiber/actions/runs/7630812513/job/20787324972#step:8:22)
      at packages/test-renderer/src/fireEvent.ts:1320:39
      at Object.<anonymous>.__awaiter (packages/test-renderer/src/fireEvent.ts:1269:10)
      at invokeEvent (packages/test-renderer/src/fireEvent.ts:49:119)
      at packages/test-renderer/src/fireEvent.ts:69:28
      at packages/test-renderer/src/fireEvent.ts:1320:39
      at Object.<anonymous>.__awaiter (packages/test-renderer/src/fireEvent.ts:1269:10)
      at fireEvent (packages/test-renderer/src/fireEvent.ts:69:21)
      at packages/test-renderer/src/__tests__/RTTR.events.test.tsx:53:30
      at packages/test-renderer/src/__tests__/RTTR.events.test.tsx:31:71
      at Object.<anonymous>.__awaiter (packages/test-renderer/src/__tests__/RTTR.events.test.tsx:27:12)
      at packages/test-renderer/src/__tests__/RTTR.events.test.tsx:53:[23](https://github.com/pmndrs/react-three-fiber/actions/runs/7630812513/job/20787324972#step:8:24)
      at Object.<anonymous> (node_modules/expect/build/toThrowMatchers.js:83:11)
      at Object.throwingMatcher [as toThrow] (node_modules/expect/build/index.js:382:21)
      at packages/test-renderer/src/__tests__/RTTR.events.test.tsx:53:79
      at fulfilled (packages/test-renderer/src/__tests__/RTTR.events.test.tsx:[28](https://github.com/pmndrs/react-three-fiber/actions/runs/7630812513/job/20787324972#step:8:29):58)
```