### PR TITLE
chore(CI): GitHub Actions - Node 20

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,4 @@
 {
   "sandboxes": ["/example"],
-  "node": "20"
+  "node": "18"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,4 @@
 {
   "sandboxes": ["/example"],
-  "node": "18"
+  "node": "20"
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Use Node 18
+      - name: Use Node 20
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install deps and build (with cache)
         uses: bahmutov/npm-install@v1


### PR DESCRIPTION
In Spring 2024 GitHub will run its actions on Node 20 by default, so it's worth to follow up on that here either:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

CodeSandbox config supports only Node 18 maximum, however: 
https://codesandbox.io/docs/learn/ci#configuration-format