### PR TITLE
fix(types): remove usage of THREE.Vector

### DIFF
--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -17,7 +17,7 @@ export type Matrix4 = THREE.Matrix4 | Parameters<THREE.Matrix4['set']> | Readonl
 /**
  * Turn an implementation of THREE.Vector in to the type that an r3f component would accept as a prop.
  */
-type VectorLike<VectorClass extends THREE.Vector> =
+type VectorLike<VectorClass extends THREE.Vector2 | THREE.Vector3 | THREE.Vector4> =
   | VectorClass
   | Parameters<VectorClass['set']>
   | Readonly<Parameters<VectorClass['set']>>


### PR DESCRIPTION
`THREE.Vector` was [removed in `@types/three@0.161.0`](https://github.com/three-types/three-ts-types/releases/tag/r161) in favor of just using type unions.