### PR TITLE
fix: correctly pass frames in invalidate

### DIFF
--- a/packages/fiber/src/core/loop.ts
+++ b/packages/fiber/src/core/loop.ts
@@ -120,7 +120,7 @@ export function createLoop<TCanvas>(roots: Map<TCanvas, Root>) {
   }
 
   function invalidate(state?: RootState, frames = 1): void {
-    if (!state) return roots.forEach((root) => invalidate(root.store.getState()), frames)
+    if (!state) return roots.forEach((root) => invalidate(root.store.getState(), frames))
     if (state.gl.xr?.isPresenting || !state.internal.active || state.frameloop === 'never') return
     // Increase frames, do not go higher than 60
     state.internal.frames = Math.min(60, state.internal.frames + frames)


### PR DESCRIPTION
Currently frames is passed as a second argument of forEach, which does nothing in the way we use invalidate.
I assume it's a mistake and was intended to be passed as a second parameters of invalidate()