### PR TITLE
fix(types): support @types/three@0.162.0

### DIFF
--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -9,6 +9,7 @@ import { Dpr, Renderer, RootState, Size } from './store'
 // < r141 shipped vendored types https://github.com/pmndrs/react-three-fiber/issues/2501
 /** @ts-ignore */
 type _DeprecatedXRFrame = THREE.XRFrame
+/** @ts-ignore */
 export type _XRFrame = THREE.WebGLRenderTargetOptions extends { samples?: number } ? XRFrame : _DeprecatedXRFrame
 
 /**

--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -274,6 +274,7 @@ export type QuaternionProps = Node<THREE.Quaternion, typeof THREE.Quaternion>
 export type BufferAttributeProps = Node<THREE.BufferAttribute, typeof THREE.BufferAttribute>
 export type Float16BufferAttributeProps = Node<THREE.Float16BufferAttribute, typeof THREE.Float16BufferAttribute>
 export type Float32BufferAttributeProps = Node<THREE.Float32BufferAttribute, typeof THREE.Float32BufferAttribute>
+/** @ts-ignore */
 export type Float64BufferAttributeProps = Node<THREE.Float64BufferAttribute, typeof THREE.Float64BufferAttribute>
 export type Int8BufferAttributeProps = Node<THREE.Int8BufferAttribute, typeof THREE.Int8BufferAttribute>
 export type Int16BufferAttributeProps = Node<THREE.Int16BufferAttribute, typeof THREE.Int16BufferAttribute>


### PR DESCRIPTION
- [`THREE.WebGLRenderTargetOptions` was removed in `@types/three@0.162.0`](https://github.com/three-types/three-ts-types/releases/tag/r162). Added a `@ts-ignore` since it's being used for feature/version detection.
- [`Float64BufferAttribute` was removed from three.js in r162](https://github.com/mrdoob/three.js/pull/27807). Added a `@ts-ignore` in accordance with how this is dealt with in the status quo.