### PR TITLE
[v9] fix(types): allow mutable ref in JSX

### DIFF
--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -38,7 +38,7 @@ export type EventProps<P> = P extends RaycastableRepresentation ? Partial<EventH
 
 export interface ReactProps<P> {
   children?: React.ReactNode
-  ref?: React.Ref<P>
+  ref?: React.Ref<P | undefined>
   key?: React.Key
 }
 


### PR DESCRIPTION
Fixes #3124.

Need a way of reproducing this. We have tests for all the different refs, but they don't run into this issue.