### PR TITLE
fix(useLoader): don't dispose of memoized loader

### DIFF
--- a/packages/fiber/src/core/hooks.tsx
+++ b/packages/fiber/src/core/hooks.tsx
@@ -109,7 +109,7 @@ function loadingFn<L extends LoaderProto<any>>(
             ),
           ),
       ),
-    ).finally(() => (loader as any).dispose?.())
+    )
   }
 }
 


### PR DESCRIPTION
Fixes an issue with loaders who implement `dispose`. https://github.com/pmndrs/react-three-fiber/pull/2984#discussion_r1564074276