### PR TITLE
[v9] fix(reconciler): don't implement (un)hideInstance methods

### DIFF
--- a/packages/fiber/src/core/reconciler.tsx
+++ b/packages/fiber/src/core/reconciler.tsx
@@ -65,7 +65,6 @@ export interface Instance<O = any> {
   handlers: Partial<EventHandlers>
   attach?: AttachType<O>
   previousAttach?: any
-  isHidden: boolean
   autoRemovedBeforeAppend?: boolean
 }
 
@@ -407,28 +406,8 @@ export const reconciler = Reconciler<
   resetAfterCommit: () => {},
   shouldSetTextContent: () => false,
   clearContainer: () => false,
-  hideInstance(instance) {
-    if (instance.props.attach && instance.parent?.object) {
-      detach(instance.parent, instance)
-    } else if (isObject3D(instance.object)) {
-      instance.object.visible = false
-    }
-
-    instance.isHidden = true
-    invalidateInstance(instance)
-  },
-  unhideInstance(instance) {
-    if (instance.isHidden) {
-      if (instance.props.attach && instance.parent?.object) {
-        attach(instance.parent, instance)
-      } else if (isObject3D(instance.object) && instance.props.visible !== false) {
-        instance.object.visible = true
-      }
-    }
-
-    instance.isHidden = false
-    invalidateInstance(instance)
-  },
+  hideInstance() {},
+  unhideInstance() {},
   createTextInstance: handleTextInstance,
   hideTextInstance: handleTextInstance,
   unhideTextInstance: handleTextInstance,

--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -240,7 +240,6 @@ export function prepare<T = any>(target: T, root: RootStore, type: string, props
       object,
       eventCount: 0,
       handlers: {},
-      isHidden: false,
     }
     if (object) {
       object.__r3f = instance


### PR DESCRIPTION
Fixes a regression from #3224 where React will hide but never unhide WIP instances during Suspense in the glTF example. Need to report upstream as we're uniquely sensitive to this behavior, although we work around WIP or Suspenseful instances in a more robust way. For that reason, we can remove these hooks as they are impure and produce an invalid tree.

I added a failing test in f1a296db1c45e19810089fb9c0efaa259287fb1c to demonstrate this behavior. Fails on v9, passes after this PR. This is since React 19.
