### PR TITLE
fix(types): add shell types for react-reconciler changes

### DIFF
--- a/packages/fiber/src/core/reconciler.tsx
+++ b/packages/fiber/src/core/reconciler.tsx
@@ -23,6 +23,7 @@ import { removeInteractivity, type EventHandlers } from './events'
 import type { ThreeElement } from '../three-types'
 
 // TODO: upstream to DefinitelyTyped for React 19
+// https://github.com/facebook/react/issues/28956
 type EventPriority = number
 
 const createReconciler = Reconciler as unknown as <

--- a/packages/fiber/src/core/reconciler.tsx
+++ b/packages/fiber/src/core/reconciler.tsx
@@ -59,7 +59,6 @@ const createReconciler = Reconciler as unknown as <
     >,
     'getCurrentEventPriority' | 'prepareUpdate' | 'commitUpdate'
   > & {
-    // Changed
     /**
      * This method should mutate the `instance` and perform prop diffing if needed.
      *
@@ -74,12 +73,17 @@ const createReconciler = Reconciler as unknown as <
     ): void
 
     // Undocumented
+    // https://github.com/facebook/react/pull/26722
     NotPendingTransition: TransitionStatus | null
+    // https://github.com/facebook/react/pull/28751
     setCurrentUpdatePriority(newPriority: EventPriority): void
     getCurrentUpdatePriority(): EventPriority
     resolveUpdatePriority(): EventPriority
+    // https://github.com/facebook/react/pull/28804
     resetFormInstance(form: FormInstance): void
+    // https://github.com/facebook/react/pull/25105
     requestPostPaintCallback(callback: (time: number) => void): void
+    // https://github.com/facebook/react/pull/26025
     shouldAttemptEagerTransition(): boolean
 
     /**
@@ -556,5 +560,5 @@ export const reconciler = createReconciler<
         return DefaultEventPriority
     }
   },
-  resetFormInstance(): void {},
+  resetFormInstance() {},
 })


### PR DESCRIPTION
Adds shell types for React 19 reconciler changes from canary and beta. [react-reconciler#readme](https://github.com/facebook/react/tree/main/packages/react-reconciler#readme) is still incomplete following https://github.com/facebook/react/pull/28750 which complicated our migration https://github.com/facebook/react/pull/28909.