### PR TITLE
feat(cache): promise based caching with workers

### DIFF
--- a/packages/fiber/src/core/cache.ts
+++ b/packages/fiber/src/core/cache.ts
@@ -1,0 +1,74 @@
+export const promiseCaches = new Set<PromiseCache>()
+
+export class PromiseCache {
+  promises = new Map<string, Promise<any>>()
+  cachePromise: Promise<Cache>
+
+  constructor(cache: string | Cache | Promise<Cache>) {
+    this.cachePromise = Promise.resolve(cache).then((cache) => {
+      if (typeof cache === 'string') return caches.open(cache)
+      return cache
+    })
+
+    promiseCaches.add(this)
+  }
+
+  async run(url: string, handler: (url: string) => any) {
+    if (this.promises.has(url)) {
+      return this.promises.get(url)!
+    }
+
+    const promise = new Promise<any>(async (resolve, reject) => {
+      const blob = await this.fetch(url)
+      const blobUrl = URL.createObjectURL(blob)
+
+      try {
+        const result = await handler(blobUrl)
+        resolve(result)
+      } catch (error) {
+        reject(error)
+      } finally {
+        URL.revokeObjectURL(blobUrl)
+      }
+    })
+
+    this.promises.set(url, promise)
+
+    return promise
+  }
+
+  async fetch(url: string): Promise<Blob> {
+    const cache = await this.cachePromise
+
+    let response = await cache.match(url)
+
+    if (!response) {
+      const fetchResponse = await fetch(url)
+      if (fetchResponse.ok) {
+        await cache.put(url, fetchResponse.clone())
+        response = fetchResponse
+      }
+    }
+
+    return response!.blob()
+  }
+
+  add(url: string, promise: Promise<any>) {
+    this.promises.set(url, promise)
+  }
+
+  get(url: string) {
+    return this.promises.get(url)
+  }
+
+  has(url: string) {
+    return this.promises.has(url)
+  }
+
+  async delete(url: string): Promise<boolean> {
+    this.promises.delete(url)
+    return this.cachePromise.then((cache) => cache.delete(url))
+  }
+}
+
+export const cacheName = 'assets'

--- a/packages/shared/setupTests.ts
+++ b/packages/shared/setupTests.ts
@@ -46,3 +46,45 @@ HTMLCanvasElement.prototype.getContext = function (this: HTMLCanvasElement) {
 
 // Extend catalogue for render API in tests
 extend(THREE as any)
+
+// Mock caches API
+class MockCache {
+  store: Map<string, Response>
+
+  constructor() {
+    this.store = new Map()
+  }
+
+  async match(url: string) {
+    return this.store.get(url)
+  }
+
+  async put(url: string, response: Response) {
+    this.store.set(url, response)
+  }
+
+  async delete(url: string) {
+    return this.store.delete(url)
+  }
+}
+
+class MockCacheStorage {
+  caches: Map<string, MockCache>
+
+  constructor() {
+    this.caches = new Map()
+  }
+
+  async open(cacheName: string) {
+    if (!this.caches.has(cacheName)) {
+      this.caches.set(cacheName, new MockCache())
+    }
+    return this.caches.get(cacheName)
+  }
+
+  async delete(cacheName: string) {
+    return this.caches.delete(cacheName)
+  }
+}
+
+globalThis.caches = new MockCacheStorage() as any


### PR DESCRIPTION
Caching was hidden behind `react-suspend` and did not offer any way to utilize browser APIs or extend it. This PR adds `PromiseCache` class that creates a local cache compatible with `React.use` backed by the web [`Cache` API](https://developer.mozilla.org/en-US/docs/Web/API/Cache). The `Cache` API offers many benefits such as:
- Fully integrated with `fetch`.
- Allows for caching resources across worker boundaries.
- Allows for downloading, processing and caching resources inside of a service worker.
- Allows for client side control over offline caching.
- Fully inspectable via dev tools

The `PromiseCache` accesses and processed resources from the global cache while handling promises for you. 
```ts
// Pass in the name of the global cache that backs it, or the cache itself if you have it.
const cache = new PromiseCache('assets') 
// Fetches resources from a url, caches it, then runs a handler on that data. Returns a promise with the handler's return value.
// ?? Should this just return a blob instead of a blob URL? ??
cache.run(url: string, handler: async (cacheUrl: string) => any)): Promise<any>
// Add a promise.
cache.add(url: string, promise: Promise<any>)
//  Get a promise from the cache.
cache.get(url:string): Promise<any>
// Check if the cache has a url stored.
cache.has(url:string): boolean
// Delete a cached response. Return true if successful, false if unsuccessful.
await cache.delete(url: string): Promise<boolean>
```

It looks like this when combined with `React.use`:
```js
const cache = loaderCaches.get(loaderInstance)!

if (!cache.has(url)) cache.run(url, async (cacheUrl) => loadAsset(cacheUrl, loaderInstance))
const result = React.use(cache.get(url)!)
```

## TODO
- Testing is broken. `jest` doesn't mock the `Cache` API or `fetch`. Trying to polyfill either proved harder than I expected.
- The API could use some tuning. 
- This should probably get split off into its own library.
