### PR TITLE
docs: usage trend

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -252,6 +252,8 @@ There is a vibrant and extensive eco system around three-fiber, full of librarie
 - [`triplex`](https://triplex.dev/) &ndash; scene editor for react-three-fiber
 - [`koestlich`](https://github.com/coconut-xr/koestlich) &ndash; UI component library for react-three-fiber
 
+[Usage Trend of the @react-three Family](https://npm-compare.com/@react-three/a11y,@react-three/cannon,@react-three/csg,@react-three/drei,@react-three/flex,@react-three/gltfjsx,@react-three/gpu-pathtracer,@react-three/offscreen,@react-three/p2,@react-three/postprocessing,@react-three/rapier,@react-three/test-renderer,@react-three/uikit,@react-three/xr)
+
 # Who is using Three-fiber
 
 A small selection of companies and projects relying on three-fiber.


### PR DESCRIPTION
I wanted to share an enhancement idea that could greatly benefit the community. I propose adding a link to a popularity trend page to the @react-three packages.

By including this link, we can provide valuable insights to new users who are exploring the `@react-three` ecosystem. Understanding the popularity trends of these packages can help developers make informed decisions.

If there's any further assistance or contribution I can provide to support this project, please do not hesitate to reach out. Working together, we can propel the `@react-three` packages' popularity and inspire more exciting developments for the 3D web ecosystem.
