### PR TITLE
fix: createPortal effect merging stale data from initial render

### DIFF
--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -570,15 +570,21 @@ function Portal({
     const unsub = previousRoot.subscribe((prev) => usePortalStore.setState((state) => inject(prev, state)))
     return () => {
       unsub()
-      usePortalStore.destroy()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [inject])
 
   React.useEffect(() => {
     usePortalStore.setState((injectState) => inject(previousRoot.getState(), injectState))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inject])
+
+  React.useEffect(() => {
+    return () => {
+      usePortalStore.destroy()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
     <>


### PR DESCRIPTION
Fixes #3253 

- Added a missing dependency on the `inject` function, which caused the effect to update a portal's store with stale data from the initial render
- The store destruction has been moved to a separate hook, so it continues to run only on component unmount