### PR TITLE
Use new JSX runtime

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -17,7 +17,7 @@ module.exports = {
         targets: '> 1%, not dead, not ie 11, not op_mini all',
       },
     ],
-    '@babel/preset-react',
+    ['@babel/preset-react', { runtime: 'automatic' }],
     '@babel/preset-typescript',
   ],
 }

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -13,7 +13,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react-jsx"
   },
   "include": ["./src", "./typings/*.d.ts", "../packages/*"]
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint:fix": "yarn run eslint --fix",
     "test": "jest --coverage",
     "test:watch": "jest --watchAll",
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false --strict --jsx react",
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false --strict",
     "validate": "preconstruct validate",
     "release": "yarn build && yarn changeset publish",
     "vers": "yarn changeset version",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "pretty": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
The new JSX runtime is faster than the legacy runtime using `React.createElement`