### PR TITLE
chore(types): suppress errors with @ts-expect-error directive instead of @ts-ignore

### DIFF
--- a/example/src/demos/Lines.tsx
+++ b/example/src/demos/Lines.tsx
@@ -32,8 +32,8 @@ function useDrag(onDrag: any, onEnd: any) {
     setActive(true)
     toggle(false)
     event.stopPropagation()
-    // @ts-ignore
-    event.target.setPointerCapture(event.pointerId)
+    // @ts-expect-error
+    event.target?.setPointerCapture(event.pointerId)
   }
 
   const up = (event: ThreeEvent<PointerEvent>) => {
@@ -41,8 +41,8 @@ function useDrag(onDrag: any, onEnd: any) {
     setActive(false)
     toggle(true)
     event.stopPropagation()
-    // @ts-ignore
-    event.target.releasePointerCapture(event.pointerId)
+    // @ts-expect-error
+    event.target?.releasePointerCapture(event.pointerId)
     if (onEnd) onEnd()
   }
 

--- a/example/src/demos/Lines.tsx
+++ b/example/src/demos/Lines.tsx
@@ -32,8 +32,8 @@ function useDrag(onDrag: any, onEnd: any) {
     setActive(true)
     toggle(false)
     event.stopPropagation()
-    // @ts-expect-error
-    event.target?.setPointerCapture(event.pointerId)
+    // @ts-ignore
+    event.target.setPointerCapture(event.pointerId)
   }
 
   const up = (event: ThreeEvent<PointerEvent>) => {
@@ -41,8 +41,8 @@ function useDrag(onDrag: any, onEnd: any) {
     setActive(false)
     toggle(true)
     event.stopPropagation()
-    // @ts-expect-error
-    event.target?.releasePointerCapture(event.pointerId)
+    // @ts-ignore
+    event.target.releasePointerCapture(event.pointerId)
     if (onEnd) onEnd()
   }
 

--- a/example/src/demos/Lines.tsx
+++ b/example/src/demos/Lines.tsx
@@ -33,7 +33,7 @@ function useDrag(onDrag: any, onEnd: any) {
     toggle(false)
     event.stopPropagation()
     // @ts-expect-error
-    event.target?.setPointerCapture(event.pointerId)
+    event.target.setPointerCapture(event.pointerId)
   }
 
   const up = (event: ThreeEvent<PointerEvent>) => {
@@ -42,7 +42,7 @@ function useDrag(onDrag: any, onEnd: any) {
     toggle(true)
     event.stopPropagation()
     // @ts-expect-error
-    event.target?.releasePointerCapture(event.pointerId)
+    event.target.releasePointerCapture(event.pointerId)
     if (onEnd) onEnd()
   }
 

--- a/example/src/demos/Lines.tsx
+++ b/example/src/demos/Lines.tsx
@@ -33,7 +33,7 @@ function useDrag(onDrag: any, onEnd: any) {
     toggle(false)
     event.stopPropagation()
     // @ts-expect-error
-    event.target.setPointerCapture(event.pointerId)
+    event.target?.setPointerCapture(event.pointerId)
   }
 
   const up = (event: ThreeEvent<PointerEvent>) => {
@@ -42,7 +42,7 @@ function useDrag(onDrag: any, onEnd: any) {
     toggle(true)
     event.stopPropagation()
     // @ts-expect-error
-    event.target.releasePointerCapture(event.pointerId)
+    event.target?.releasePointerCapture(event.pointerId)
     if (onEnd) onEnd()
   }
 

--- a/example/src/demos/Lines.tsx
+++ b/example/src/demos/Lines.tsx
@@ -32,7 +32,7 @@ function useDrag(onDrag: any, onEnd: any) {
     setActive(true)
     toggle(false)
     event.stopPropagation()
-    // @ts-ignore
+    // @ts-expect-error
     event.target.setPointerCapture(event.pointerId)
   }
 
@@ -41,7 +41,7 @@ function useDrag(onDrag: any, onEnd: any) {
     setActive(false)
     toggle(true)
     event.stopPropagation()
-    // @ts-ignore
+    // @ts-expect-error
     event.target.releasePointerCapture(event.pointerId)
     if (onEnd) onEnd()
   }

--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -198,7 +198,7 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
         detach(parentInstance, child, child.__r3f.attach)
       } else if (child.isObject3D && parentInstance.isObject3D) {
         parentInstance.remove(child)
-        // @ts-expect-error
+        // @ts-ignore
         // Remove interactivity on the initial root
         if (child.__r3f?.root) {
           removeInteractivity(findInitialRoot(child), child as unknown as THREE.Object3D)
@@ -426,7 +426,7 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
     hideTextInstance: handleTextInstance,
     unhideTextInstance: handleTextInstance,
     // https://github.com/pmndrs/react-three-fiber/pull/2360#discussion_r916356874
-    // @ts-expect-error
+    // @ts-ignore
     getCurrentEventPriority: () => (_getEventPriority ? _getEventPriority() : DefaultEventPriority),
     beforeActiveInstanceBlur: () => {},
     afterActiveInstanceBlur: () => {},

--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -198,7 +198,7 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
         detach(parentInstance, child, child.__r3f.attach)
       } else if (child.isObject3D && parentInstance.isObject3D) {
         parentInstance.remove(child)
-        // @ts-ignore
+        // @ts-expect-error
         // Remove interactivity on the initial root
         if (child.__r3f?.root) {
           removeInteractivity(findInitialRoot(child), child as unknown as THREE.Object3D)
@@ -426,7 +426,7 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
     hideTextInstance: handleTextInstance,
     unhideTextInstance: handleTextInstance,
     // https://github.com/pmndrs/react-three-fiber/pull/2360#discussion_r916356874
-    // @ts-ignore
+    // @ts-expect-error
     getCurrentEventPriority: () => (_getEventPriority ? _getEventPriority() : DefaultEventPriority),
     beforeActiveInstanceBlur: () => {},
     afterActiveInstanceBlur: () => {},

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -7,9 +7,7 @@ import { AttachType, catalogue, Instance, InstanceProps, LocalState } from './re
 import { Dpr, Renderer, RootState, Size } from './store'
 
 // < r141 shipped vendored types https://github.com/pmndrs/react-three-fiber/issues/2501
-/** @ts-ignore */
 type _DeprecatedXRFrame = THREE.XRFrame
-/** @ts-ignore */
 export type _XRFrame = THREE.WebGLRenderTargetOptions extends { samples?: number } ? XRFrame : _DeprecatedXRFrame
 
 /**
@@ -352,7 +350,7 @@ export function applyProps(instance: Instance, data: InstanceProps | DiffSet) {
         // create a blank slate of the instance and copy the particular parameter.
         let ctor = DEFAULTS.get(currentInstance.constructor)
         if (!ctor) {
-          // @ts-ignore
+          // @ts-expect-error
           ctor = new currentInstance.constructor()
           DEFAULTS.set(currentInstance.constructor, ctor)
         }

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -7,6 +7,7 @@ import { AttachType, catalogue, Instance, InstanceProps, LocalState } from './re
 import { Dpr, Renderer, RootState, Size } from './store'
 
 // < r141 shipped vendored types https://github.com/pmndrs/react-three-fiber/issues/2501
+/** @ts-expect-error */
 type _DeprecatedXRFrame = THREE.XRFrame
 export type _XRFrame = THREE.WebGLRenderTargetOptions extends { samples?: number } ? XRFrame : _DeprecatedXRFrame
 

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -7,7 +7,9 @@ import { AttachType, catalogue, Instance, InstanceProps, LocalState } from './re
 import { Dpr, Renderer, RootState, Size } from './store'
 
 // < r141 shipped vendored types https://github.com/pmndrs/react-three-fiber/issues/2501
+/** @ts-ignore */
 type _DeprecatedXRFrame = THREE.XRFrame
+/** @ts-ignore */
 export type _XRFrame = THREE.WebGLRenderTargetOptions extends { samples?: number } ? XRFrame : _DeprecatedXRFrame
 
 /**
@@ -350,7 +352,7 @@ export function applyProps(instance: Instance, data: InstanceProps | DiffSet) {
         // create a blank slate of the instance and copy the particular parameter.
         let ctor = DEFAULTS.get(currentInstance.constructor)
         if (!ctor) {
-          // @ts-expect-error
+          // @ts-ignore
           ctor = new currentInstance.constructor()
           DEFAULTS.set(currentInstance.constructor, ctor)
         }

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -352,7 +352,7 @@ export function applyProps(instance: Instance, data: InstanceProps | DiffSet) {
         // create a blank slate of the instance and copy the particular parameter.
         let ctor = DEFAULTS.get(currentInstance.constructor)
         if (!ctor) {
-          // @ts-ignore
+          // @ts-expect-error
           ctor = new currentInstance.constructor()
           DEFAULTS.set(currentInstance.constructor, ctor)
         }

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -7,7 +7,6 @@ import { AttachType, catalogue, Instance, InstanceProps, LocalState } from './re
 import { Dpr, Renderer, RootState, Size } from './store'
 
 // < r141 shipped vendored types https://github.com/pmndrs/react-three-fiber/issues/2501
-/** @ts-expect-error */
 type _DeprecatedXRFrame = THREE.XRFrame
 export type _XRFrame = THREE.WebGLRenderTargetOptions extends { samples?: number } ? XRFrame : _DeprecatedXRFrame
 

--- a/packages/fiber/src/native/polyfills.ts
+++ b/packages/fiber/src/native/polyfills.ts
@@ -141,7 +141,7 @@ export function polyfills() {
         texture.needsUpdate = true
 
         // Force non-DOM upload for EXGL texImage2D
-        // @ts-ignore
+        // @ts-expect-error
         texture.isDataTexture = true
 
         onLoad?.(texture)

--- a/packages/fiber/src/native/polyfills.ts
+++ b/packages/fiber/src/native/polyfills.ts
@@ -141,7 +141,7 @@ export function polyfills() {
         texture.needsUpdate = true
 
         // Force non-DOM upload for EXGL texImage2D
-        // @ts-expect-error
+        // @ts-ignore
         texture.isDataTexture = true
 
         onLoad?.(texture)

--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -98,53 +98,81 @@ export type InstancedBufferGeometryProps = BufferGeometryNode<
   typeof THREE.InstancedBufferGeometry
 >
 export type BufferGeometryProps = BufferGeometryNode<THREE.BufferGeometry, typeof THREE.BufferGeometry>
+/** @ts-ignore */
 export type BoxBufferGeometryProps = BufferGeometryNode<THREE.BoxBufferGeometry, typeof THREE.BoxBufferGeometry>
 export type CircleBufferGeometryProps = BufferGeometryNode<
+  /** @ts-ignore */
   THREE.CircleBufferGeometry,
+  /** @ts-ignore */
   typeof THREE.CircleBufferGeometry
 >
+/** @ts-ignore */
 export type ConeBufferGeometryProps = BufferGeometryNode<THREE.ConeBufferGeometry, typeof THREE.ConeBufferGeometry>
 export type CylinderBufferGeometryProps = BufferGeometryNode<
+  /** @ts-ignore */
   THREE.CylinderBufferGeometry,
+  /** @ts-ignore */
   typeof THREE.CylinderBufferGeometry
 >
 export type DodecahedronBufferGeometryProps = BufferGeometryNode<
+  /** @ts-ignore */
   THREE.DodecahedronBufferGeometry,
+  /** @ts-ignore */
   typeof THREE.DodecahedronBufferGeometry
 >
 export type ExtrudeBufferGeometryProps = BufferGeometryNode<
+  /** @ts-ignore */
   THREE.ExtrudeBufferGeometry,
+  /** @ts-ignore */
   typeof THREE.ExtrudeBufferGeometry
 >
 export type IcosahedronBufferGeometryProps = BufferGeometryNode<
+  /** @ts-ignore */
   THREE.IcosahedronBufferGeometry,
+  /** @ts-ignore */
   typeof THREE.IcosahedronBufferGeometry
 >
+/** @ts-ignore */
 export type LatheBufferGeometryProps = BufferGeometryNode<THREE.LatheBufferGeometry, typeof THREE.LatheBufferGeometry>
 export type OctahedronBufferGeometryProps = BufferGeometryNode<
+  /** @ts-ignore */
   THREE.OctahedronBufferGeometry,
+  /** @ts-ignore */
   typeof THREE.OctahedronBufferGeometry
 >
+/** @ts-ignore */
 export type PlaneBufferGeometryProps = BufferGeometryNode<THREE.PlaneBufferGeometry, typeof THREE.PlaneBufferGeometry>
 export type PolyhedronBufferGeometryProps = BufferGeometryNode<
+  /** @ts-ignore */
   THREE.PolyhedronBufferGeometry,
+  /** @ts-ignore */
   typeof THREE.PolyhedronBufferGeometry
 >
+/** @ts-ignore */
 export type RingBufferGeometryProps = BufferGeometryNode<THREE.RingBufferGeometry, typeof THREE.RingBufferGeometry>
+/** @ts-ignore */
 export type ShapeBufferGeometryProps = BufferGeometryNode<THREE.ShapeBufferGeometry, typeof THREE.ShapeBufferGeometry>
 export type SphereBufferGeometryProps = BufferGeometryNode<
+  /** @ts-ignore */
   THREE.SphereBufferGeometry,
+  /** @ts-ignore */
   typeof THREE.SphereBufferGeometry
 >
 export type TetrahedronBufferGeometryProps = BufferGeometryNode<
+  /** @ts-ignore */
   THREE.TetrahedronBufferGeometry,
+  /** @ts-ignore */
   typeof THREE.TetrahedronBufferGeometry
 >
+/** @ts-ignore */
 export type TorusBufferGeometryProps = BufferGeometryNode<THREE.TorusBufferGeometry, typeof THREE.TorusBufferGeometry>
 export type TorusKnotBufferGeometryProps = BufferGeometryNode<
+  /** @ts-ignore */
   THREE.TorusKnotBufferGeometry,
+  /** @ts-ignore */
   typeof THREE.TorusKnotBufferGeometry
 >
+/** @ts-ignore */
 export type TubeBufferGeometryProps = BufferGeometryNode<THREE.TubeBufferGeometry, typeof THREE.TubeBufferGeometry>
 export type WireframeGeometryProps = BufferGeometryNode<THREE.WireframeGeometry, typeof THREE.WireframeGeometry>
 export type TetrahedronGeometryProps = BufferGeometryNode<THREE.TetrahedronGeometry, typeof THREE.TetrahedronGeometry>
@@ -202,7 +230,9 @@ export type DirectionalLightShadowProps = Node<THREE.DirectionalLightShadow, typ
 export type DirectionalLightProps = LightNode<THREE.DirectionalLight, typeof THREE.DirectionalLight>
 export type AmbientLightProps = LightNode<THREE.AmbientLight, typeof THREE.AmbientLight>
 export type LightShadowProps = Node<THREE.LightShadow, typeof THREE.LightShadow>
+/** @ts-ignore */
 export type AmbientLightProbeProps = LightNode<THREE.AmbientLightProbe, typeof THREE.AmbientLightProbe>
+/** @ts-ignore */
 export type HemisphereLightProbeProps = LightNode<THREE.HemisphereLightProbe, typeof THREE.HemisphereLightProbe>
 export type LightProbeProps = LightNode<THREE.LightProbe, typeof THREE.LightProbe>
 
@@ -226,6 +256,7 @@ export type AxesHelperProps = Object3DNode<THREE.AxesHelper, typeof THREE.AxesHe
 export type TextureProps = Node<THREE.Texture, typeof THREE.Texture>
 export type VideoTextureProps = Node<THREE.VideoTexture, typeof THREE.VideoTexture>
 export type DataTextureProps = Node<THREE.DataTexture, typeof THREE.DataTexture>
+/** @ts-ignore */
 export type DataTexture3DProps = Node<THREE.DataTexture3D, typeof THREE.DataTexture3D>
 export type CompressedTextureProps = Node<THREE.CompressedTexture, typeof THREE.CompressedTexture>
 export type CubeTextureProps = Node<THREE.CubeTexture, typeof THREE.CubeTexture>
@@ -243,6 +274,7 @@ export type QuaternionProps = Node<THREE.Quaternion, typeof THREE.Quaternion>
 export type BufferAttributeProps = Node<THREE.BufferAttribute, typeof THREE.BufferAttribute>
 export type Float16BufferAttributeProps = Node<THREE.Float16BufferAttribute, typeof THREE.Float16BufferAttribute>
 export type Float32BufferAttributeProps = Node<THREE.Float32BufferAttribute, typeof THREE.Float32BufferAttribute>
+/** @ts-ignore */
 export type Float64BufferAttributeProps = Node<THREE.Float64BufferAttribute, typeof THREE.Float64BufferAttribute>
 export type Int8BufferAttributeProps = Node<THREE.Int8BufferAttribute, typeof THREE.Int8BufferAttribute>
 export type Int16BufferAttributeProps = Node<THREE.Int16BufferAttribute, typeof THREE.Int16BufferAttribute>

--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -98,81 +98,53 @@ export type InstancedBufferGeometryProps = BufferGeometryNode<
   typeof THREE.InstancedBufferGeometry
 >
 export type BufferGeometryProps = BufferGeometryNode<THREE.BufferGeometry, typeof THREE.BufferGeometry>
-/** @ts-ignore */
 export type BoxBufferGeometryProps = BufferGeometryNode<THREE.BoxBufferGeometry, typeof THREE.BoxBufferGeometry>
 export type CircleBufferGeometryProps = BufferGeometryNode<
-  /** @ts-ignore */
   THREE.CircleBufferGeometry,
-  /** @ts-ignore */
   typeof THREE.CircleBufferGeometry
 >
-/** @ts-ignore */
 export type ConeBufferGeometryProps = BufferGeometryNode<THREE.ConeBufferGeometry, typeof THREE.ConeBufferGeometry>
 export type CylinderBufferGeometryProps = BufferGeometryNode<
-  /** @ts-ignore */
   THREE.CylinderBufferGeometry,
-  /** @ts-ignore */
   typeof THREE.CylinderBufferGeometry
 >
 export type DodecahedronBufferGeometryProps = BufferGeometryNode<
-  /** @ts-ignore */
   THREE.DodecahedronBufferGeometry,
-  /** @ts-ignore */
   typeof THREE.DodecahedronBufferGeometry
 >
 export type ExtrudeBufferGeometryProps = BufferGeometryNode<
-  /** @ts-ignore */
   THREE.ExtrudeBufferGeometry,
-  /** @ts-ignore */
   typeof THREE.ExtrudeBufferGeometry
 >
 export type IcosahedronBufferGeometryProps = BufferGeometryNode<
-  /** @ts-ignore */
   THREE.IcosahedronBufferGeometry,
-  /** @ts-ignore */
   typeof THREE.IcosahedronBufferGeometry
 >
-/** @ts-ignore */
 export type LatheBufferGeometryProps = BufferGeometryNode<THREE.LatheBufferGeometry, typeof THREE.LatheBufferGeometry>
 export type OctahedronBufferGeometryProps = BufferGeometryNode<
-  /** @ts-ignore */
   THREE.OctahedronBufferGeometry,
-  /** @ts-ignore */
   typeof THREE.OctahedronBufferGeometry
 >
-/** @ts-ignore */
 export type PlaneBufferGeometryProps = BufferGeometryNode<THREE.PlaneBufferGeometry, typeof THREE.PlaneBufferGeometry>
 export type PolyhedronBufferGeometryProps = BufferGeometryNode<
-  /** @ts-ignore */
   THREE.PolyhedronBufferGeometry,
-  /** @ts-ignore */
   typeof THREE.PolyhedronBufferGeometry
 >
-/** @ts-ignore */
 export type RingBufferGeometryProps = BufferGeometryNode<THREE.RingBufferGeometry, typeof THREE.RingBufferGeometry>
-/** @ts-ignore */
 export type ShapeBufferGeometryProps = BufferGeometryNode<THREE.ShapeBufferGeometry, typeof THREE.ShapeBufferGeometry>
 export type SphereBufferGeometryProps = BufferGeometryNode<
-  /** @ts-ignore */
   THREE.SphereBufferGeometry,
-  /** @ts-ignore */
   typeof THREE.SphereBufferGeometry
 >
 export type TetrahedronBufferGeometryProps = BufferGeometryNode<
-  /** @ts-ignore */
   THREE.TetrahedronBufferGeometry,
-  /** @ts-ignore */
   typeof THREE.TetrahedronBufferGeometry
 >
-/** @ts-ignore */
 export type TorusBufferGeometryProps = BufferGeometryNode<THREE.TorusBufferGeometry, typeof THREE.TorusBufferGeometry>
 export type TorusKnotBufferGeometryProps = BufferGeometryNode<
-  /** @ts-ignore */
   THREE.TorusKnotBufferGeometry,
-  /** @ts-ignore */
   typeof THREE.TorusKnotBufferGeometry
 >
-/** @ts-ignore */
 export type TubeBufferGeometryProps = BufferGeometryNode<THREE.TubeBufferGeometry, typeof THREE.TubeBufferGeometry>
 export type WireframeGeometryProps = BufferGeometryNode<THREE.WireframeGeometry, typeof THREE.WireframeGeometry>
 export type TetrahedronGeometryProps = BufferGeometryNode<THREE.TetrahedronGeometry, typeof THREE.TetrahedronGeometry>
@@ -230,9 +202,7 @@ export type DirectionalLightShadowProps = Node<THREE.DirectionalLightShadow, typ
 export type DirectionalLightProps = LightNode<THREE.DirectionalLight, typeof THREE.DirectionalLight>
 export type AmbientLightProps = LightNode<THREE.AmbientLight, typeof THREE.AmbientLight>
 export type LightShadowProps = Node<THREE.LightShadow, typeof THREE.LightShadow>
-/** @ts-ignore */
 export type AmbientLightProbeProps = LightNode<THREE.AmbientLightProbe, typeof THREE.AmbientLightProbe>
-/** @ts-ignore */
 export type HemisphereLightProbeProps = LightNode<THREE.HemisphereLightProbe, typeof THREE.HemisphereLightProbe>
 export type LightProbeProps = LightNode<THREE.LightProbe, typeof THREE.LightProbe>
 
@@ -256,7 +226,6 @@ export type AxesHelperProps = Object3DNode<THREE.AxesHelper, typeof THREE.AxesHe
 export type TextureProps = Node<THREE.Texture, typeof THREE.Texture>
 export type VideoTextureProps = Node<THREE.VideoTexture, typeof THREE.VideoTexture>
 export type DataTextureProps = Node<THREE.DataTexture, typeof THREE.DataTexture>
-/** @ts-ignore */
 export type DataTexture3DProps = Node<THREE.DataTexture3D, typeof THREE.DataTexture3D>
 export type CompressedTextureProps = Node<THREE.CompressedTexture, typeof THREE.CompressedTexture>
 export type CubeTextureProps = Node<THREE.CubeTexture, typeof THREE.CubeTexture>
@@ -274,7 +243,6 @@ export type QuaternionProps = Node<THREE.Quaternion, typeof THREE.Quaternion>
 export type BufferAttributeProps = Node<THREE.BufferAttribute, typeof THREE.BufferAttribute>
 export type Float16BufferAttributeProps = Node<THREE.Float16BufferAttribute, typeof THREE.Float16BufferAttribute>
 export type Float32BufferAttributeProps = Node<THREE.Float32BufferAttribute, typeof THREE.Float32BufferAttribute>
-/** @ts-ignore */
 export type Float64BufferAttributeProps = Node<THREE.Float64BufferAttribute, typeof THREE.Float64BufferAttribute>
 export type Int8BufferAttributeProps = Node<THREE.Int8BufferAttribute, typeof THREE.Int8BufferAttribute>
 export type Int16BufferAttributeProps = Node<THREE.Int16BufferAttribute, typeof THREE.Int16BufferAttribute>

--- a/packages/fiber/tests/core/renderer.test.tsx
+++ b/packages/fiber/tests/core/renderer.test.tsx
@@ -746,9 +746,9 @@ describe('renderer', () => {
     expect(gl.toneMapping).toBe(THREE.ACESFilmicToneMapping)
     expect(texture.encoding).toBe(sRGBEncoding)
 
-    // @ts-ignore
+    // @ts-expect-error
     THREE.WebGLRenderer.prototype.outputColorSpace ??= ''
-    // @ts-ignore
+    // @ts-expect-error
     THREE.Texture.prototype.colorSpace ??= ''
 
     await act(async () =>
@@ -780,9 +780,9 @@ describe('renderer', () => {
     expect(gl.outputColorSpace).toBe(SRGBColorSpace)
     expect(texture.colorSpace).toBe(SRGBColorSpace)
 
-    // @ts-ignore
+    // @ts-expect-error
     delete THREE.WebGLRenderer.prototype.outputColorSpace
-    // @ts-ignore
+    // @ts-expect-error
     delete THREE.Texture.prototype.colorSpace
   })
 

--- a/packages/fiber/tests/core/renderer.test.tsx
+++ b/packages/fiber/tests/core/renderer.test.tsx
@@ -746,9 +746,9 @@ describe('renderer', () => {
     expect(gl.toneMapping).toBe(THREE.ACESFilmicToneMapping)
     expect(texture.encoding).toBe(sRGBEncoding)
 
-    // @ts-expect-error
+    // @ts-ignore
     THREE.WebGLRenderer.prototype.outputColorSpace ??= ''
-    // @ts-expect-error
+    // @ts-ignore
     THREE.Texture.prototype.colorSpace ??= ''
 
     await act(async () =>
@@ -780,9 +780,9 @@ describe('renderer', () => {
     expect(gl.outputColorSpace).toBe(SRGBColorSpace)
     expect(texture.colorSpace).toBe(SRGBColorSpace)
 
-    // @ts-expect-error
+    // @ts-ignore
     delete THREE.WebGLRenderer.prototype.outputColorSpace
-    // @ts-expect-error
+    // @ts-ignore
     delete THREE.Texture.prototype.colorSpace
   })
 

--- a/packages/test-renderer/src/createTestCanvas.ts
+++ b/packages/test-renderer/src/createTestCanvas.ts
@@ -30,9 +30,9 @@ export const createCanvas = ({ beforeReturn, width = 1280, height = 800 }: Creat
   beforeReturn?.(canvas)
 
   class WebGLRenderingContext extends WebGL2RenderingContext {}
-  // @ts-ignore
+  // @ts-expect-error
   globalThis.WebGLRenderingContext ??= WebGLRenderingContext
-  // @ts-ignore
+  // @ts-expect-error
   globalThis.WebGL2RenderingContext ??= WebGL2RenderingContext
 
   return canvas

--- a/packages/test-renderer/src/createTestCanvas.ts
+++ b/packages/test-renderer/src/createTestCanvas.ts
@@ -30,9 +30,9 @@ export const createCanvas = ({ beforeReturn, width = 1280, height = 800 }: Creat
   beforeReturn?.(canvas)
 
   class WebGLRenderingContext extends WebGL2RenderingContext {}
-  // @ts-expect-error
+  // @ts-ignore
   globalThis.WebGLRenderingContext ??= WebGLRenderingContext
-  // @ts-expect-error
+  // @ts-ignore
   globalThis.WebGL2RenderingContext ??= WebGL2RenderingContext
 
   return canvas


### PR DESCRIPTION
## About

Using @ts-expect-error is preferred over @ts-ignore and considered a better practice.

To see why, check out this great article by @mattpocock: **[How to use @ts-expect-error
](https://www.totaltypescript.com/concepts/how-to-use-ts-expect-error#ts-expect-error-or-ts-ignore)**

## Exceptions

User-facing `/** @ts-ignore */` pragmas are preserved due to https://github.com/pmndrs/react-three-fiber/pull/3062