### PR TITLE
chore: Prettier CI/CD, remove deprecated options

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,6 @@ jobs:
 
       - name: Report Test Renderer size
         run: yarn run analyze-test
+
+      - name: Check formatting
+        run: yarn run format

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,6 @@
 dist/
+coverage/
 node_modules/
 .yarn/
 *.gltf
+*.mdx

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+dist/
+node_modules/
+.yarn/
+*.gltf

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,6 +4,6 @@
   "singleQuote": true,
   "tabWidth": 2,
   "printWidth": 120,
-  "jsxBracketSameLine": true,
+  "bracketSameLine": true,
   "endOfLine": "auto"
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "vers": "yarn changeset version",
     "codegen:eslint": "cd packages/eslint-plugin && yarn codegen",
     "analyze-fiber": "cd packages/fiber && npm publish --dry-run",
-    "analyze-test": "cd packages/test-renderer && npm publish --dry-run"
+    "analyze-test": "cd packages/test-renderer && npm publish --dry-run",
+    "format": "prettier --check .",
+    "format:fix": "prettier --write ."
   },
   "devDependencies": {
     "@babel/core": "7.17.8",

--- a/packages/fiber/tests/core/events.test.tsx
+++ b/packages/fiber/tests/core/events.test.tsx
@@ -275,11 +275,16 @@ describe('events', () => {
     const handlePointerLeave = jest.fn()
 
     /* This component lets us unmount the event-handling object */
-    function PointerCaptureTest(props: { hasMesh: boolean, manualRelease?: boolean }) {
+    function PointerCaptureTest(props: { hasMesh: boolean; manualRelease?: boolean }) {
       return (
         <Canvas>
           {props.hasMesh && (
-            <mesh onPointerDown={handlePointerDown} onPointerMove={handlePointerMove} onPointerUp={props.manualRelease ? handlePointerUp : undefined} onPointerLeave={handlePointerLeave} onPointerEnter={handlePointerEnter}>
+            <mesh
+              onPointerDown={handlePointerDown}
+              onPointerMove={handlePointerMove}
+              onPointerUp={props.manualRelease ? handlePointerUp : undefined}
+              onPointerLeave={handlePointerLeave}
+              onPointerEnter={handlePointerEnter}>
               <boxGeometry args={[2, 2]} />
               <meshBasicMaterial />
             </mesh>
@@ -350,9 +355,9 @@ describe('events', () => {
 
       /* testing-utils/react's fireEvent wraps the event like React does, so it doesn't match how our event handlers are called in production, so we call dispatchEvent directly. */
       await act(async () => canvas.dispatchEvent(moveIn))
-      expect(handlePointerEnter).toHaveBeenCalledTimes(1);
-      expect(handlePointerMove).toHaveBeenCalledTimes(1);
-  
+      expect(handlePointerEnter).toHaveBeenCalledTimes(1)
+      expect(handlePointerMove).toHaveBeenCalledTimes(1)
+
       const down = new PointerEvent('pointerdown', { pointerId })
       Object.defineProperty(down, 'offsetX', { get: () => 577 })
       Object.defineProperty(down, 'offsetY', { get: () => 480 })
@@ -362,11 +367,11 @@ describe('events', () => {
       // If we move the pointer now, when it is captured, it should raise the onPointerMove event even though the pointer is not over the element,
       // and NOT raise the onPointerLeave event.
       await act(async () => canvas.dispatchEvent(moveOut))
-      expect(handlePointerMove).toHaveBeenCalledTimes(2);
-      expect(handlePointerLeave).not.toHaveBeenCalled();
+      expect(handlePointerMove).toHaveBeenCalledTimes(2)
+      expect(handlePointerLeave).not.toHaveBeenCalled()
 
       await act(async () => canvas.dispatchEvent(moveIn))
-      expect(handlePointerMove).toHaveBeenCalledTimes(3);
+      expect(handlePointerMove).toHaveBeenCalledTimes(3)
 
       const up = new PointerEvent('pointerup', { pointerId })
       Object.defineProperty(up, 'offsetX', { get: () => 577 })
@@ -377,11 +382,11 @@ describe('events', () => {
       await act(async () => canvas.dispatchEvent(lostpointercapture))
 
       // The pointer is still over the element, so onPointerLeave should not have been called.
-      expect(handlePointerLeave).not.toHaveBeenCalled();
+      expect(handlePointerLeave).not.toHaveBeenCalled()
 
       // The element pointer should no longer be captured, so moving it away should call onPointerLeave.
-      await act(async () => canvas.dispatchEvent(moveOut));
-      expect(handlePointerEnter).toHaveBeenCalledTimes(1);
+      await act(async () => canvas.dispatchEvent(moveOut))
+      expect(handlePointerEnter).toHaveBeenCalledTimes(1)
       expect(handlePointerLeave).toHaveBeenCalledTimes(1)
     })
   })


### PR DESCRIPTION
## What's changed

- Replaced [[Deprecated] jsxBracketSameLine](https://prettier.io/docs/en/options.html#deprecated-jsx-brackets) option with [bracketSameLine](https://prettier.io/docs/en/options.html#bracket-line)
- Added check for code formatting in CI