### PR TITLE
fix(native): missing pointerId in pointer events

### DIFF
--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -149,6 +149,7 @@ const CanvasImpl = /*#__PURE__*/ React.forwardRef<View, Props>(
             offsetX: gestureEvent.nativeEvent.locationX,
             offsetY: gestureEvent.nativeEvent.locationY,
             pointerType: 'touch',
+            pointerId: gestureEvent.nativeEvent.identifier,
           }) as unknown as Event,
         )
 


### PR DESCRIPTION
Fixes issue related to `@react-three/drei` repository: [#2067](https://github.com/pmndrs/drei/issues/2067).

### Analysis and explanation

The problem exists in [`handleTouchMoveDolly` method of `OrbitControls` class in `three-stdlib`](https://github.com/pmndrs/three-stdlib/blob/main/src/controls/OrbitControls.ts#L787). `dollyDelta.y` value is `NaN`, because `dollyStart.y` and `dollyEnd.y` in `dollyEnd.y / dollyStart.y` are 0. It happens because of [`getSecondPointerPosition` function](https://github.com/pmndrs/three-stdlib/blob/main/src/controls/OrbitControls.ts#L1077) which uses `event.pointerId` to identify pointers in arrays. Because `event.pointerId` is missing the method always returns the same pointer position, giving zero in the next calculations. 

Please also look at `removePointer` and `trackPointer` methods above - they use `event.pointerId` as well. 