### PR TITLE
fix(types): fix React typings, fault tolerant Node type

### DIFF
--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -46,7 +46,9 @@ export interface NodeProps<T, P> {
 }
 
 export type ExtendedColors<T> = { [K in keyof T]: T[K] extends THREE.Color | undefined ? Color : T[K] }
-export type Node<T, P> = ExtendedColors<Overwrite<Partial<T>, NodeProps<T, P>>>
+export type Node<T, P> = [T] extends [{ thisShouldNeverHappen: 'unless the object is of type any' }]
+  ? ExtendedColors<Overwrite<Partial<{}>, NodeProps<{}, {}>>>
+  : ExtendedColors<Overwrite<Partial<T>, NodeProps<T, P>>>
 
 export type Object3DNode<T, P> = Overwrite<
   Node<T, P>,


### PR DESCRIPTION
Fixes https://github.com/pmndrs/react-three-fiber/issues/3361 by making the `Node` type fault tolarant: if the three object does not exist (and the type ends up as being `any`), the `Node` type will catch this and reduce the `any` type to `{}`