### PR TITLE
fix: add orientation handling

### DIFF
--- a/packages/fiber/src/web/use-measure.ts
+++ b/packages/fiber/src/web/use-measure.ts
@@ -32,7 +32,7 @@ type State = {
   scrollContainers: HTMLOrSVGElement[] | null
   resizeObserver: ResizeObserver | null
   lastBounds: RectReadOnly,
-  orientationHandler: () => void
+  orientationHandler: () => void | null
 }
 
 export type Options = {

--- a/packages/fiber/src/web/use-measure.ts
+++ b/packages/fiber/src/web/use-measure.ts
@@ -31,14 +31,14 @@ type State = {
   element: HTMLOrSVGElement | null
   scrollContainers: HTMLOrSVGElement[] | null
   resizeObserver: ResizeObserver | null
-  lastBounds: RectReadOnly,
-  orientationHandler: () => void | null
+  lastBounds: RectReadOnly
+  orientationHandler: null | (() => void)
 }
 
 export type Options = {
   debounce?: number | { scroll: number; resize: number }
   scroll?: boolean
-  polyfill?: { new(cb: ResizeObserverCallback): ResizeObserver }
+  polyfill?: { new (cb: ResizeObserverCallback): ResizeObserver }
   offsetSize?: boolean
 }
 
@@ -64,11 +64,17 @@ export function useMeasure(
     bounds.width = 1280
     // @ts-ignore
     bounds.height = 800
-    return [() => { }, bounds, () => { }]
+    return [() => {}, bounds, () => {}]
   }
 
   // keep all state in a ref
-  const state = useRef<State>({ element: null, scrollContainers: null, resizeObserver: null, lastBounds: bounds, orientationHandler: null })
+  const state = useRef<State>({
+    element: null,
+    scrollContainers: null,
+    resizeObserver: null,
+    lastBounds: bounds,
+    orientationHandler: null,
+  })
 
   // set actual debounce values early, so effects know if they should react accordingly
   const scrollDebounce = debounce ? (typeof debounce === 'number' ? debounce : debounce.scroll) : null
@@ -126,7 +132,7 @@ export function useMeasure(
       state.current.resizeObserver = null
     }
     if (state.current.orientationHandler) {
-      screen.orientation.removeEventListener('orientationchange', state.current.orientationHandler);
+      screen.orientation.removeEventListener('orientationchange', state.current.orientationHandler)
     }
   }
 

--- a/packages/fiber/src/web/use-measure.ts
+++ b/packages/fiber/src/web/use-measure.ts
@@ -125,7 +125,7 @@ export function useMeasure(
       state.current.resizeObserver.disconnect()
       state.current.resizeObserver = null
     }
-    if (state.orientationHandler.current) {
+    if (state.current.orientationHandler) {
       screen.orientation.removeEventListener('orientationchange', state.current.orientationHandler);
     }
   }


### PR DESCRIPTION
This adds an [orientation handler](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation) to useMeasure so that when the device rotates it correctly adjusts the canvas. 

Right now, when a phone rotates the window resize event never fires so the canvas doesn't know it should change, and as the resize handler sets the css sizes directly on the canvas it causes it to bleed over the edge or if you go from horizontal to vertical causes it to leave a big black area in the viewport.

You can simulate this in chrome by using the developer tools device preview button. Load a mobile device, Load a canvas (typically a full size one) and then change the orientation with the orientation button.