### PR TITLE
fix: make textinstance no-op instead of warn

### DIFF
--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -301,9 +301,8 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
     })
   }
 
-  // Don't handle text instances, warn on undefined behavior
-  const handleTextInstance = () =>
-    console.warn('Text is not allowed in the R3F tree! This could be stray whitespace or characters.')
+  // Don't handle text instances, make it no-op
+  const handleTextInstance = () => {}
 
   const reconciler = Reconciler<
     HostConfig['type'],


### PR DESCRIPTION
This PR aims to implement the behavior described in https://github.com/pmndrs/react-three-fiber/issues/3302

I did not achieve to test it on a local project (even though I succeeded a few months ago). Do you have some documentation to provide to compile and test on a project?