### PR TITLE
fix: ThreeEvent should not include initMouseEvent

### DIFF
--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three'
 import { EventHandlers } from './core/events'
 import { AttachType } from './core/renderer'
 
-export type Properties<T> = Pick<T, { [K in keyof T]: T[K] extends (_: any) => any ? never : K }[keyof T]>
+export type Properties<T> = { [K in keyof T as T[K] extends (...args: Array<any>) => any ? never : K]: T[K] }
 export type NonFunctionKeys<T> = { [K in keyof T]-?: T[K] extends Function ? never : K }[keyof T]
 export type Overwrite<T, O> = Omit<T, NonFunctionKeys<O>> & O
 


### PR DESCRIPTION
Currently, the types for all onClick, ... events expose the `initMouseEvent` function. The `Properties` type definition has the goal to remove all functions, but it only removes functions with one parameter. Therefore the `initMouseEvent` is not removed and the type is forwarded to the event, even though no `initMouseEvent` function exists on the actual event object.

This PR fixes that and uses a more modern way of filtering entries in the map using `as` supported from typescript 4.1 (4 years ago). https://www.typescriptlang.org/docs/handbook/2/mapped-types.html#key-remapping-via-as