### PR TITLE
fix: useMeasure to include safer orientation handling

### DIFF
--- a/packages/fiber/src/web/use-measure.ts
+++ b/packages/fiber/src/web/use-measure.ts
@@ -131,23 +131,38 @@ export function useMeasure(
       state.current.resizeObserver.disconnect()
       state.current.resizeObserver = null
     }
+
     if (state.current.orientationHandler) {
-      screen.orientation.removeEventListener('orientationchange', state.current.orientationHandler)
+      if ('orientation' in screen && 'removeEventListener' in screen.orientation) {
+        screen.orientation.removeEventListener('change', state.current.orientationHandler)
+      } else if ('onorientationchange' in window) {
+        window.removeEventListener('orientationchange', state.current.orientationHandler)
+      }
     }
   }
 
   // add scroll-listeners / observers
   function addListeners() {
     if (!state.current.element) return
-    state.current.resizeObserver = new ResizeObserver(scrollChange)
-    state.current.resizeObserver!.observe(state.current.element)
+    state.current.resizeObserver = new ResizeObserver(resizeChange)
+    state.current.resizeObserver?.observe(state.current.element)
     if (scroll && state.current.scrollContainers) {
       state.current.scrollContainers.forEach((scrollContainer) =>
         scrollContainer.addEventListener('scroll', scrollChange, { capture: true, passive: true }),
       )
     }
+
+    // Handle orientation changes
     state.current.orientationHandler = () => {
       scrollChange()
+    }
+
+    // Use screen.orientation if available
+    if ('orientation' in screen && 'addEventListener' in screen.orientation) {
+      screen.orientation.addEventListener('change', state.current.orientationHandler)
+    } else if ('onorientationchange' in window) {
+      // Fallback to orientationchange event
+      window.addEventListener('orientationchange', state.current.orientationHandler)
     }
   }
 


### PR DESCRIPTION
The previous version supported the latest screenOrientation API: https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation

But of course iOS does not support this so was throwing errors.

This adds checks to make sure the objects exists and listeners can be added.

Falls back to depreciated method `orientationchange` on the window: https://developer.mozilla.org/en-US/docs/Web/API/Window/orientationchange_event

If that doesn't exist either we have to pray the resize events correctly fire.

closes #3371  