### PR TITLE
Mesh scale arg requires a Vector 3 type

### DIFF
--- a/docs/tutorials/events-and-interaction.mdx
+++ b/docs/tutorials/events-and-interaction.mdx
@@ -52,7 +52,7 @@ const [active, setActive] = useState(false)
 After we have this we can set the scale with a ternary operator like so:
 
 ```jsx
-<mesh scale={active ? 1.5 : 1} onClick={() => setActive(!active)} ref={myMesh}>
+<mesh scale={active ? [1.5,1.5] : [1,1]} onClick={() => setActive(!active)} ref={myMesh}>
   <boxGeometry />
   <meshPhongMaterial color="royalblue" />
 </mesh>

--- a/docs/tutorials/events-and-interaction.mdx
+++ b/docs/tutorials/events-and-interaction.mdx
@@ -52,7 +52,7 @@ const [active, setActive] = useState(false)
 After we have this we can set the scale with a ternary operator like so:
 
 ```jsx
-<mesh scale={active ? [1.5,1.5] : [1,1]} onClick={() => setActive(!active)} ref={myMesh}>
+<mesh scale={active ? [1.5,1.5,1.5] : [1,1,1]} onClick={() => setActive(!active)} ref={myMesh}>
   <boxGeometry />
   <meshPhongMaterial color="royalblue" />
 </mesh>


### PR DESCRIPTION
the demo as written doesn't work.  Providing this argument to scale causes the demo to work as intended I believe.