### PR TITLE
fix(eslint-plugin): include type declare files

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -27,6 +27,9 @@
   "main": "dist/react-three-eslint-plugin.cjs.js",
   "module": "dist/react-three-eslint-plugin.esm.js",
   "types": "dist/react-three-eslint-plugin.cjs.d.ts",
+  "files": [
+    "dist"
+  ],
   "sideEffects": false,
   "preconstruct": {
     "entrypoints": [


### PR DESCRIPTION

<img width="914" alt="image" src="https://github.com/user-attachments/assets/3622fc2f-e1c8-488f-a480-b4022a351f0c">

The publish files don't include type declare files.

<img width="850" alt="image" src="https://github.com/user-attachments/assets/d2916051-04d7-473c-b074-5d4fb3e52da5">

<img width="457" alt="image" src="https://github.com/user-attachments/assets/795360f6-5bd7-4b72-955d-0be6e6584e6d">
