### PR TITLE
Remove reference to `myMesh` ref

### DIFF
--- a/docs/tutorials/events-and-interaction.mdx
+++ b/docs/tutorials/events-and-interaction.mdx
@@ -35,7 +35,7 @@ From this we can see that what we need to do is use the old `onClick` event we u
 Let's add it then:
 
 ```jsx
-<mesh onClick={() => alert('Hellooo')} ref={myMesh}>
+<mesh onClick={() => alert('Hellooo')}>
   <boxGeometry />
   <meshPhongMaterial color="royalblue" />
 </mesh>
@@ -52,7 +52,7 @@ const [active, setActive] = useState(false)
 After we have this we can set the scale with a ternary operator like so:
 
 ```jsx
-<mesh scale={active ? 1.5 : 1} onClick={() => setActive(!active)} ref={myMesh}>
+<mesh scale={active ? 1.5 : 1} onClick={() => setActive(!active)}>
   <boxGeometry />
   <meshPhongMaterial color="royalblue" />
 </mesh>


### PR DESCRIPTION
I don't think it's required for these simple examples.