### PR TITLE
docs:fix sandpack dependencies issue (#3412)

### DIFF
--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -33,8 +33,8 @@ Let's make a re-usable component that has its own state, reacts to user-input an
 <Sandpack
   customSetup={{
     dependencies: {
-      'react': 'latest',
-      'react-dom': 'latest',
+      'react': '18.3.1',
+      'react-dom': '18.3.1',
       'three': 'latest',
       '@react-three/fiber': 'latest'
     },
@@ -53,8 +53,8 @@ npm install @types/three
 <Sandpack
   customSetup={{
     dependencies: {
-      'react': 'latest',
-      'react-dom': 'latest',
+      'react': '18.3.1',
+      'react-dom': '18.3.1',
       'three': 'latest',
       '@types/three': 'latest',
       '@react-three/fiber': 'latest'


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/e4b92c76-e520-491a-8e14-5c220210627d)

Version `18.3.1` of react and react-dom are compatible with `'@react-three/fiber'` and works.
![image](https://github.com/user-attachments/assets/f60052ec-1cd9-4175-8db8-4eb8b1fa22ed)
