### PR TITLE
fix: loosen instanceof checks for CSB issue

### DIFF
--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -255,8 +255,8 @@ function createRoot<TCanvas extends Canvas>(canvas: TCanvas): ReconcilerRoot<TCa
       if (!state.scene) {
         let scene: THREE.Scene
 
-        if (sceneOptions instanceof THREE.Scene) {
-          scene = sceneOptions
+        if ((sceneOptions as unknown as THREE.Scene | undefined)?.isScene) {
+          scene = sceneOptions as THREE.Scene
         } else {
           scene = new THREE.Scene()
           if (sceneOptions) applyProps(scene as any, sceneOptions as any)

--- a/packages/fiber/src/core/renderer.ts
+++ b/packages/fiber/src/core/renderer.ts
@@ -122,8 +122,8 @@ function createRenderer<TCanvas>(_roots: Map<TCanvas, Root>, _getEventPriority?:
 
     // Auto-attach geometries and materials
     if (instance.__r3f.attach === undefined) {
-      if (instance instanceof THREE.BufferGeometry) instance.__r3f.attach = 'geometry'
-      else if (instance instanceof THREE.Material) instance.__r3f.attach = 'material'
+      if ((instance as unknown as THREE.BufferGeometry).isBufferGeometry) instance.__r3f.attach = 'geometry'
+      else if ((instance as unknown as THREE.Material).isMaterial) instance.__r3f.attach = 'material'
     }
 
     // It should NOT call onUpdate on object instanciation, because it hasn't been added to the

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -177,8 +177,8 @@ const createStore = (invalidate: Invalidate, advance: Advance): UseBoundStore<Ro
     ): Omit<Viewport, 'dpr' | 'initialDpr'> {
       const { width, height, top, left } = size
       const aspect = width / height
-      if (target instanceof THREE.Vector3) tempTarget.copy(target)
-      else tempTarget.set(...target)
+      if ((target as THREE.Vector3).isVector3) tempTarget.copy(target as THREE.Vector3)
+      else tempTarget.set(...(target as Parameters<THREE.Vector3['set']>))
       const distance = camera.getWorldPosition(position).distanceTo(tempTarget)
       if (isOrthographicCamera(camera)) {
         return { width: width / camera.zoom, height: height / camera.zoom, top, left, factor: 1, distance, aspect }

--- a/packages/fiber/src/core/utils.ts
+++ b/packages/fiber/src/core/utils.ts
@@ -396,7 +396,7 @@ export function applyProps(instance: MaybeInstance, data: InstanceProps | DiffSe
       // If nothing else fits, just set the single value, ignore undefined
       // https://github.com/pmndrs/react-three-fiber/issues/274
       else if (value !== undefined) {
-        const isColor = targetProp instanceof THREE.Color
+        const isColor = (targetProp as unknown as THREE.Color | undefined)?.isColor
         // Allow setting array scalars
         if (!isColor && targetProp.setScalar) targetProp.setScalar(value)
         // Layers have no copy function, we must therefore copy the mask property
@@ -415,7 +415,7 @@ export function applyProps(instance: MaybeInstance, data: InstanceProps | DiffSe
       // Auto-convert sRGB textures, for now ...
       // https://github.com/pmndrs/react-three-fiber/issues/344
       if (
-        currentInstance[key] instanceof THREE.Texture &&
+        (currentInstance[key] as unknown as THREE.Texture | undefined)?.isTexture &&
         // sRGB textures must be RGBA8 since r137 https://github.com/mrdoob/three.js/pull/23129
         currentInstance[key].format === THREE.RGBAFormat &&
         currentInstance[key].type === THREE.UnsignedByteType &&


### PR DESCRIPTION
Loosens checks using `instanceof` for Codesandbox, which duplicates copies of three.js and breaks constructor identity. Materials/geometry won't automatically attach if they have a different constructor identity and break the `instanceof` check.

The `copy` codepath in `applyProps` and HMR still won't work entirely correctly, and this needs a proper fix on Codesandbox.