### PR TITLE
fix: narrow React peer dep range

### DIFF
--- a/packages/fiber/package.json
+++ b/packages/fiber/package.json
@@ -60,8 +60,8 @@
     "expo-asset": ">=8.4",
     "expo-gl": ">=11.0",
     "expo-file-system": ">=11.0",
-    "react": ">=18.0",
-    "react-dom": ">=18.0",
+    "react": ">=18 <19",
+    "react-dom": ">=18 <19",
     "react-native": ">=0.64",
     "three": ">=0.133"
   },

--- a/packages/test-renderer/package.json
+++ b/packages/test-renderer/package.json
@@ -22,8 +22,8 @@
     ]
   },
   "peerDependencies": {
-    "react": ">=17.0",
-    "@react-three/fiber": ">=8.0.0",
-    "three": ">=0.126"
+    "react": ">=18 <19",
+    "@react-three/fiber": ">=8 < 9",
+    "three": ">=0.133"
   }
 }


### PR DESCRIPTION
Narrows the peer dep range for React to ^18 as we do not yet support React 19. See #2331.