### PR TITLE
[v9] fix: only copy props if same constructor

### DIFF
--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -365,6 +365,8 @@ const colorMaps = ['map', 'emissiveMap', 'sheenColorMap', 'specularColorMap', 'e
 
 const EVENT_REGEX = /^on(Pointer|Click|DoubleClick|ContextMenu|Wheel)/
 
+type ClassConstructor = { new (): void }
+
 // This function applies a set of changes to the instance
 export function applyProps<T = any>(object: Instance<T>['object'], props: Instance<T>['props']): Instance<T>['object'] {
   const instance = object.__r3f
@@ -391,7 +393,11 @@ export function applyProps<T = any>(object: Instance<T>['object'], props: Instan
     let { root, key, target } = resolve(object, prop)
 
     // Copy if properties match signatures
-    if (typeof target?.copy === 'function' && target.copy === (value as any).copy) {
+    if (
+      target?.copy &&
+      (value as ClassConstructor | undefined)?.constructor &&
+      (target as ClassConstructor).constructor === (value as ClassConstructor).constructor
+    ) {
       target.copy(value)
     }
     // Layers have no copy function, we must therefore copy the mask property

--- a/packages/fiber/tests/utils.test.ts
+++ b/packages/fiber/tests/utils.test.ts
@@ -417,6 +417,27 @@ describe('applyProps', () => {
 
     expect(target.value).toBe('initial')
   })
+
+  it('should not copy if props are supersets of another', async () => {
+    const copy = jest.fn()
+
+    class Material {
+      copy = copy
+    }
+    class SuperMaterial extends Material {
+      copy = copy
+    }
+
+    const one = new Material()
+    const two = new SuperMaterial()
+
+    const target = { material: one }
+    applyProps(target, { material: two })
+
+    expect(one.copy).not.toHaveBeenCalled()
+    expect(two.copy).not.toHaveBeenCalled()
+    expect(target.material).toBe(two)
+  })
 })
 
 describe('updateCamera', () => {


### PR DESCRIPTION
Fixes an issue [reported on Discord](https://discord.com/channels/740090768164651008/1326482620522958888) where R3F will attempt to copy props even if they don't have the same constructor.

