### PR TITLE
Fix/apply-texture-prop

### DIFF
--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -396,7 +396,8 @@ export function applyProps<T = any>(object: Instance<T>['object'], props: Instan
     if (
       target?.copy &&
       (value as ClassConstructor | undefined)?.constructor &&
-      (target as ClassConstructor).constructor === (value as ClassConstructor).constructor
+      (target as ClassConstructor).constructor === (value as ClassConstructor).constructor &&
+      target?.uuid == value?.uuid
     ) {
       target.copy(value)
     }

--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -397,7 +397,7 @@ export function applyProps<T = any>(object: Instance<T>['object'], props: Instan
       target?.copy &&
       (value as ClassConstructor | undefined)?.constructor &&
       (target as ClassConstructor).constructor === (value as ClassConstructor).constructor &&
-      target?.uuid == value?.uuid
+      !target?.uuid
     ) {
       target.copy(value)
     }


### PR DESCRIPTION
Currenty if a texture prop changes, the new texture gets copied into the previous one. This is incorrect, since the original texture might also be used elsewhere or be used later on.

The proposed fix is to check whether the target has an UUID. If that's the case, we assume it's an object we don't copy new values into with a prop change.