### PR TITLE
fix: set primitive props after link

### DIFF
--- a/packages/fiber/src/core/reconciler.tsx
+++ b/packages/fiber/src/core/reconciler.tsx
@@ -294,10 +294,10 @@ function handleContainerEffects(parent: Instance, child: Instance, beforeChild?:
     // Create object
     child.object = child.props.object ?? new target(...(child.props.args ?? []))
     child.object.__r3f = child
-
-    // Set initial props
-    applyProps(child.object, child.props)
   }
+
+  // Set initial props
+  applyProps(child.object, child.props)
 
   // Append instance
   if (child.props.attach) {

--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -239,10 +239,8 @@ export function prepare<T = any>(target: T, root: RootStore, type: string, props
       handlers: {},
       isHidden: false,
     }
-    if (object) {
-      object.__r3f = instance
-      if (type) applyProps(object, instance.props)
-    }
+
+    if (object) object.__r3f = instance
   }
 
   return instance

--- a/packages/fiber/tests/events.test.tsx
+++ b/packages/fiber/tests/events.test.tsx
@@ -392,4 +392,26 @@ describe('events', () => {
       expect(handlePointerLeave).toHaveBeenCalledTimes(1)
     })
   })
+
+  it('can handle primitives', async () => {
+    const handlePointerDown = jest.fn()
+
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(2, 2), new THREE.MeshBasicMaterial())
+
+    await act(async () => {
+      render(
+        <Canvas>
+          <primitive name="test" object={mesh} onPointerDown={handlePointerDown} />
+        </Canvas>,
+      )
+    })
+
+    const evt = new PointerEvent('pointerdown')
+    Object.defineProperty(evt, 'offsetX', { get: () => 577 })
+    Object.defineProperty(evt, 'offsetY', { get: () => 480 })
+
+    fireEvent(getContainer(), evt)
+
+    expect(handlePointerDown).toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
Ensures primitives have their props set after container effects are fired and the subtree is completed.

This aligns behavior with native elements and fixes #3437 where event handlers were not registered on initial mount.