### PR TITLE
fix: update use-measure

### DIFF
--- a/packages/fiber/package.json
+++ b/packages/fiber/package.json
@@ -49,7 +49,7 @@
     "buffer": "^6.0.3",
     "its-fine": "^1.0.6",
     "react-reconciler": "^0.27.0",
-    "react-use-measure": "^2.1.6",
+    "react-use-measure": "^2.1.7",
     "scheduler": "^0.21.0",
     "suspend-react": "^0.1.3",
     "zustand": "^3.7.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8906,10 +8906,10 @@ react-test-renderer@^18.0.0:
     react-shallow-renderer "^16.13.1"
     scheduler "^0.21.0"
 
-react-use-measure@^2.1.6:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.1.6.tgz#d0dc826b2020361da8323adcd39f72a8191f7a19"
-  integrity sha512-IobUVRLFrtrpUX2RMDrdAfRTaEftVRXFlTEuTdJFgtrnbxAMhueimO7nFix4/X40KI8LnJFV7LHxPnMi9Tc1Cw==
+react-use-measure@^2.1.7:
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.1.7.tgz#36b8a2e7fd2fa58109ab851b3addcb0aad66ad1d"
+  integrity sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==
 
 react-use-refs@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Updates use measure to sidestep https://github.com/pmndrs/react-use-measure/issues/106 in some installations.