### PR TITLE
[v9] fix: JSX tag conflicts are prefixed with three

### DIFF
--- a/packages/fiber/src/core/reconciler.tsx
+++ b/packages/fiber/src/core/reconciler.tsx
@@ -203,7 +203,11 @@ interface HostConfig {
   TransitionStatus: null
 }
 
-export const catalogue: Catalogue = {}
+const catalogue: Catalogue = {}
+
+const PREFIX_REGEX = /^three(?=[A-Z])/
+
+const toPascalCase = (type: string): string => `${type[0].toUpperCase()}${type.slice(1)}`
 
 let i = 0
 
@@ -242,6 +246,9 @@ function validateInstance(type: string, props: HostConfig['props']): void {
 }
 
 function createInstance(type: string, props: HostConfig['props'], root: RootStore): HostConfig['instance'] {
+  // Remove three* prefix from elements
+  type = type.replace(PREFIX_REGEX, '')
+
   validateInstance(type, props)
 
   // Regenerate the R3F instance for primitives to simulate a new object
@@ -287,8 +294,7 @@ function handleContainerEffects(parent: Instance, child: Instance, beforeChild?:
   // Create & link object on first run
   if (!child.object) {
     // Get target from catalogue
-    const name = `${child.type[0].toUpperCase()}${child.type.slice(1)}`
-    const target = catalogue[name]
+    const target = catalogue[toPascalCase(child.type)]
 
     // Create object
     child.object = child.props.object ?? new target(...(child.props.args ?? []))
@@ -466,8 +472,7 @@ function swapInstances(): void {
     const parent = instance.parent
     if (parent) {
       // Get target from catalogue
-      const name = `${instance.type[0].toUpperCase()}${instance.type.slice(1)}`
-      const target = catalogue[name]
+      const target = catalogue[toPascalCase(instance.type)]
 
       // Create object
       instance.object = instance.props.object ?? new target(...(instance.props.args ?? []))

--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -1,7 +1,7 @@
 import * as THREE from 'three'
 import * as React from 'react'
 import { useFiber, traverseFiber, useContextBridge } from 'its-fine'
-import { Instance, catalogue } from './reconciler'
+import { Instance } from './reconciler'
 import type { Fiber } from 'react-reconciler'
 import type { EventHandlers } from './events'
 import type { Dpr, Renderer, RootStore, Size } from './store'

--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -60,11 +60,9 @@ type Conflicts = DuplicateKeys<JSX.IntrinsicElements, { [K in keyof ThreeExports
 
 // Create a new type that maps Three.js exports to JSX tags, with conflicts prefixed with 'three'.
 type ThreeElementsImpl = {
-  [K in keyof ThreeExports as K extends string
-    ? Uncapitalize<K> extends Conflicts
-      ? `three${Capitalize<K>}`
-      : Uncapitalize<K>
-    : never]: ThreeExports[K] extends ConstructorRepresentation ? ThreeElement<ThreeExports[K]> : never
+  [K in keyof ThreeExports as Uncapitalize<K> extends Conflicts
+    ? `three${Capitalize<K>}`
+    : Uncapitalize<K>]: ThreeExports[K] extends ConstructorRepresentation ? ThreeElement<ThreeExports[K]> : never
 }
 
 export interface ThreeElements extends ThreeElementsImpl {

--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -53,10 +53,18 @@ export type ThreeElement<T extends ConstructorRepresentation> = Mutable<
 >
 
 type ThreeExports = typeof THREE
+
+// Detect conflicts between Three.js and React types.
+type DuplicateKeys<T, U> = Extract<keyof T, keyof U>
+type Conflicts = DuplicateKeys<JSX.IntrinsicElements, { [K in keyof ThreeExports as Uncapitalize<K>]: any }>
+
+// Create a new type that maps Three.js exports to JSX tags, with conflicts prefixed with 'three'.
 type ThreeElementsImpl = {
-  [K in keyof ThreeExports as Uncapitalize<K>]: ThreeExports[K] extends ConstructorRepresentation
-    ? ThreeElement<ThreeExports[K]>
-    : never
+  [K in keyof ThreeExports as K extends string
+    ? Uncapitalize<K> extends Conflicts
+      ? `three${Capitalize<K>}`
+      : Uncapitalize<K>
+    : never]: ThreeExports[K] extends ConstructorRepresentation ? ThreeElement<ThreeExports[K]> : never
 }
 
 export interface ThreeElements extends ThreeElementsImpl {

--- a/packages/fiber/tests/renderer.test.tsx
+++ b/packages/fiber/tests/renderer.test.tsx
@@ -762,8 +762,6 @@ describe('renderer', () => {
   })
 
   it('resolves conflicting and prefixed elements', async () => {
-    await root.configure()
-
     const store = await act(async () => root.render(<line />))
     expect(store.getState().scene.children[0]).toBeInstanceOf(THREE.Line)
 

--- a/packages/fiber/tests/renderer.test.tsx
+++ b/packages/fiber/tests/renderer.test.tsx
@@ -760,4 +760,17 @@ describe('renderer', () => {
     expect(camera.top).toBe(0)
     expect(camera.bottom).toBe(0)
   })
+
+  it('resolves conflicting and prefixed elements', async () => {
+    await root.configure()
+
+    const store = await act(async () => root.render(<line />))
+    expect(store.getState().scene.children[0]).toBeInstanceOf(THREE.Line)
+
+    await act(async () => root.render(null))
+    expect(store.getState().scene.children.length).toBe(0)
+
+    await act(async () => root.render(<threeLine />))
+    expect(store.getState().scene.children[0]).toBeInstanceOf(THREE.Line)
+  })
 })


### PR DESCRIPTION
The affected tags are "audio", "source", "line" and "path". These get prefixed with "three" automatically so for example "audio" becomes "threeAudio". This disambiguates with DOM types.