### PR TITLE
[v9] fix(events): bubble up events from primitive children

### DIFF
--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -244,7 +244,20 @@ export function createEvents(store: RootStore) {
     if (intersections.length) {
       const localState = { stopped: false }
       for (const hit of intersections) {
-        const state = getRootState(hit.object)
+        let state = getRootState(hit.object)
+
+        // If the object is not managed by R3F, it might be parented to an element which is.
+        // Traverse upwards until we find a managed parent and use its state instead.
+        if (!state) {
+          hit.object.traverseAncestors((obj) => {
+            const parentState = getRootState(obj)
+            if (parentState) {
+              state = parentState
+              return false
+            }
+          })
+        }
+
         if (state) {
           const { raycaster, pointer, camera, internal } = state
           const unprojectedPoint = new THREE.Vector3(pointer.x, pointer.y, 0).unproject(camera)

--- a/packages/fiber/tests/events.test.tsx
+++ b/packages/fiber/tests/events.test.tsx
@@ -394,14 +394,18 @@ describe('events', () => {
   })
 
   it('can handle primitives', async () => {
-    const handlePointerDown = jest.fn()
+    const handlePointerDownOuter = jest.fn()
+    const handlePointerDownInner = jest.fn()
 
-    const mesh = new THREE.Mesh(new THREE.BoxGeometry(2, 2), new THREE.MeshBasicMaterial())
+    const object = new THREE.Group()
+    object.add(new THREE.Mesh(new THREE.BoxGeometry(2, 2), new THREE.MeshBasicMaterial()))
 
     await act(async () => {
       render(
         <Canvas>
-          <primitive name="test" object={mesh} onPointerDown={handlePointerDown} />
+          <group onPointerDown={handlePointerDownOuter}>
+            <primitive name="test" object={object} onPointerDown={handlePointerDownInner} />
+          </group>
         </Canvas>,
       )
     })
@@ -412,6 +416,7 @@ describe('events', () => {
 
     fireEvent(getContainer(), evt)
 
-    expect(handlePointerDown).toHaveBeenCalled()
+    expect(handlePointerDownOuter).toHaveBeenCalled()
+    expect(handlePointerDownInner).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Fixes #3437

Bubbles up events and state from children of primitives, which fixes an issue where glTF children are not interactive and events are swallowed (pointermiss is not forwarded).
