### PR TITLE
[v9] fix: don't require configure before render

### DIFF
--- a/docs/API/canvas.mdx
+++ b/docs/API/canvas.mdx
@@ -178,20 +178,14 @@ import { Mesh, BoxGeometry, MeshStandardMaterial } from 'three'
 
 extend({ Mesh, BoxGeometry, MeshStandardMaterial })
 
-async function app() {
-  const root = createRoot(document.querySelector('canvas'))
-  await root.configure()
-  root.render(
-    <>
-      <mesh>
-        <boxGeometry />
-        <meshStandardMaterial />
-      </mesh>
-    </>,
-  )
-}
-
-app()
+createRoot(canvas).render(
+  <>
+    <mesh>
+      <boxGeometry />
+      <meshStandardMaterial />
+    </mesh>
+  </>,
+)
 ```
 
 There's an [official babel plugin](https://github.com/pmndrs/react-three-babel) which will do this for you automatically:
@@ -201,18 +195,12 @@ There's an [official babel plugin](https://github.com/pmndrs/react-three-babel) 
 
 import { createRoot } from '@react-three/fiber'
 
-async function app() {
-  const root = createRoot(document.querySelector('canvas'))
-  await root.configure()
-  root.render(
-    <mesh>
-      <boxGeometry />
-      <meshStandardMaterial />
-    </mesh>,
-  )
-}
-
-app()
+createRoot(canvasNode).render(
+  <mesh>
+    <boxGeometry />
+    <meshStandardMaterial />
+  </mesh>,
+)
 
 // Out:
 
@@ -225,16 +213,10 @@ extend({
   MeshStandardMaterial: _MeshStandardMaterial,
 })
 
-async function app() {
-  const root = createRoot(document.querySelector('canvas'))
-  await root.configure()
-  root.render(
-    <mesh>
-      <boxGeometry />
-      <meshStandardMaterial />
-    </mesh>,
-  )
-}
-
-app()
+createRoot(canvasNode).render(
+  <mesh>
+    <boxGeometry />
+    <meshStandardMaterial />
+  </mesh>,
+)
 ```

--- a/packages/fiber/tests/hooks.test.tsx
+++ b/packages/fiber/tests/hooks.test.tsx
@@ -52,7 +52,7 @@ describe('hooks', () => {
       return <group />
     }
 
-    await act(async () => (await root.configure()).render(<Component />))
+    await act(async () => root.render(<Component />))
 
     expect(result.camera instanceof THREE.Camera).toBeTruthy()
     expect(result.scene instanceof THREE.Scene).toBeTruthy()

--- a/packages/fiber/tests/index.test.tsx
+++ b/packages/fiber/tests/index.test.tsx
@@ -37,7 +37,7 @@ afterEach(async () => {
 
 describe('createRoot', () => {
   it('should return a Zustand store', async () => {
-    const store = await act(async () => (await root.configure()).render(null))
+    const store = await act(async () => root.render(null))
     expect(() => store.getState()).not.toThrow()
   })
 
@@ -119,7 +119,7 @@ describe('createRoot', () => {
     let state: RootState = null!
 
     await act(async () => {
-      state = (await root.configure()).render(<group />).getState()
+      state = root.render(<group />).getState()
       state.gl.xr.isPresenting = true
       state.gl.xr.dispatchEvent({ type: 'sessionstart' })
     })
@@ -247,7 +247,7 @@ describe('createPortal', () => {
     }
 
     await act(async () => {
-      ;(await root.configure()).render(
+      root.render(
         <>
           <Normal />
           {createPortal(<Portal />, scene, { scene })}
@@ -276,12 +276,12 @@ describe('createPortal', () => {
       )
     }
 
-    await act(async () => (await root.configure()).render(<Test key={0} />))
+    await act(async () => root.render(<Test key={0} />))
 
     expect(groupHandle).toBeDefined()
     const prevUUID = groupHandle!.uuid
 
-    await act(async () => (await root.configure()).render(<Test key={1} />))
+    await act(async () => root.render(<Test key={1} />))
 
     expect(groupHandle).toBeDefined()
     expect(prevUUID).not.toBe(groupHandle!.uuid)

--- a/packages/fiber/tests/renderer.test.tsx
+++ b/packages/fiber/tests/renderer.test.tsx
@@ -44,14 +44,14 @@ describe('renderer', () => {
   afterEach(async () => act(async () => root.unmount()))
 
   it('should render empty JSX', async () => {
-    const store = await act(async () => (await root.configure()).render(null))
+    const store = await act(async () => root.render(null))
     const { scene } = store.getState()
 
     expect(scene.children.length).toBe(0)
   })
 
   it('should render native elements', async () => {
-    const store = await act(async () => (await root.configure()).render(<group name="native" />))
+    const store = await act(async () => root.render(<group name="native" />))
     const { scene } = store.getState()
 
     expect(scene.children.length).toBe(1)
@@ -60,7 +60,7 @@ describe('renderer', () => {
   })
 
   it('should render extended elements', async () => {
-    const store = await act(async () => (await root.configure()).render(<mock name="mock" />))
+    const store = await act(async () => root.render(<mock name="mock" />))
     const { scene } = store.getState()
 
     expect(scene.children.length).toBe(1)
@@ -68,7 +68,7 @@ describe('renderer', () => {
     expect(scene.children[0].name).toBe('mock')
 
     const Component = extend(THREE.Mesh)
-    await act(async () => (await root.configure()).render(<Component />))
+    await act(async () => root.render(<Component />))
 
     expect(scene.children.length).toBe(1)
     expect(scene.children[0]).toBeInstanceOf(THREE.Mesh)
@@ -77,7 +77,7 @@ describe('renderer', () => {
   it('should render primitives', async () => {
     const object = new THREE.Object3D()
 
-    const store = await act(async () => (await root.configure()).render(<primitive name="primitive" object={object} />))
+    const store = await act(async () => root.render(<primitive name="primitive" object={object} />))
     const { scene } = store.getState()
 
     expect(scene.children.length).toBe(1)
@@ -101,14 +101,14 @@ describe('renderer', () => {
       )
     }
 
-    const store = await act(async () => (await root.configure()).render(<Component show={true} />))
+    const store = await act(async () => root.render(<Component show={true} />))
     const { scene } = store.getState()
 
     expect(scene.children.length).toBe(1)
     expect(scene.children[0]).toBe(object)
     expect(object.children.length).toBe(2)
 
-    await act(async () => (await root.configure()).render(<Component show={false} />))
+    await act(async () => root.render(<Component show={false} />))
 
     expect(scene.children.length).toBe(0)
     expect(object.children.length).toBe(0)
@@ -134,14 +134,14 @@ describe('renderer', () => {
       )
     }
 
-    const store = await act(async () => (await root.configure()).render(<Component primitiveKey="A" />))
+    const store = await act(async () => root.render(<Component primitiveKey="A" />))
     const { scene } = store.getState()
 
     expect(scene.children.length).toBe(1)
     expect(scene.children[0]).toBe(object)
     expect(object.children.length).toBe(2)
 
-    await act(async () => (await root.configure()).render(<Component primitiveKey="B" />))
+    await act(async () => root.render(<Component primitiveKey="B" />))
 
     expect(scene.children.length).toBe(1)
     expect(scene.children[0]).toBe(object)
@@ -162,7 +162,7 @@ describe('renderer', () => {
       lifecycle.push('render')
       return <group ref={() => void lifecycle.push('ref')} />
     }
-    await act(async () => (await root.configure()).render(<Test />))
+    await act(async () => root.render(<Test />))
 
     expect(lifecycle).toStrictEqual([
       'render',
@@ -194,7 +194,7 @@ describe('renderer', () => {
       )
     }
 
-    await act(async () => (await root.configure()).render(<RefTest />))
+    await act(async () => root.render(<RefTest />))
 
     expect(immutableRef.current).toBeInstanceOf(THREE.Mesh)
     expect(mutableRef.current).toBeInstanceOf(THREE.Mesh)
@@ -207,7 +207,7 @@ describe('renderer', () => {
         <mesh />
       </group>
     )
-    const store = await act(async () => (await root.configure()).render(<Test />))
+    const store = await act(async () => root.render(<Test />))
     const { scene } = store.getState()
 
     expect(scene.children.length).toBe(1)
@@ -232,7 +232,7 @@ describe('renderer', () => {
         </mesh>
       )
     }
-    const store = await act(async () => (await root.configure()).render(<Test />))
+    const store = await act(async () => root.render(<Test />))
     const { scene } = store.getState()
 
     expect(scene.children.length).toBe(1)
@@ -249,7 +249,7 @@ describe('renderer', () => {
   })
 
   it('should update props reactively', async () => {
-    const store = await act(async () => (await root.configure()).render(<group />))
+    const store = await act(async () => root.render(<group />))
     const { scene } = store.getState()
     const group = scene.children[0] as THREE.Group
 
@@ -257,20 +257,20 @@ describe('renderer', () => {
     expect(group.name).toBe(new THREE.Group().name)
 
     // Set
-    await act(async () => (await root.configure()).render(<group name="one" />))
+    await act(async () => root.render(<group name="one" />))
     expect(group.name).toBe('one')
 
     // Update
-    await act(async () => (await root.configure()).render(<group name="two" />))
+    await act(async () => root.render(<group name="two" />))
     expect(group.name).toBe('two')
 
     // Unset
-    await act(async () => (await root.configure()).render(<group />))
+    await act(async () => root.render(<group />))
     expect(group.name).toBe(new THREE.Group().name)
   })
 
   it('should handle event props reactively', async () => {
-    const store = await act(async () => (await root.configure()).render(<mesh />))
+    const store = await act(async () => root.render(<mesh />))
     const { scene, internal } = store.getState()
     const mesh = scene.children[0] as ComponentMesh
     mesh.name = 'current'
@@ -279,17 +279,17 @@ describe('renderer', () => {
     expect(internal.interaction.length).toBe(0)
 
     // Set
-    await act(async () => (await root.configure()).render(<mesh onClick={() => void 0} />))
+    await act(async () => root.render(<mesh onClick={() => void 0} />))
     expect(internal.interaction.length).toBe(1)
     expect(internal.interaction).toStrictEqual([mesh])
 
     // Update
-    await act(async () => (await root.configure()).render(<mesh onPointerOver={() => void 0} />))
+    await act(async () => root.render(<mesh onPointerOver={() => void 0} />))
     expect(internal.interaction.length).toBe(1)
     expect(internal.interaction).toStrictEqual([mesh])
 
     // Unset
-    await act(async () => (await root.configure()).render(<mesh />))
+    await act(async () => root.render(<mesh />))
     expect(internal.interaction.length).toBe(0)
   })
 
@@ -306,7 +306,7 @@ describe('renderer', () => {
     )
 
     // Initial
-    await act(async () => (await root.configure()).render(<Test />))
+    await act(async () => root.render(<Test />))
     expect(ref.current!.geometry).toBeInstanceOf(THREE.BufferGeometry)
     expect(ref.current!.geometry).not.toBeInstanceOf(THREE.BoxGeometry)
     expect(ref.current!.material).toBeInstanceOf(THREE.Material)
@@ -316,14 +316,14 @@ describe('renderer', () => {
 
     // Throw on non-array value
     await expectToThrow(
-      async () => await act(async () => (await root.configure()).render(<Test args={{} as any} />)),
+      async () => await act(async () => root.render(<Test args={{} as any} />)),
       'R3F: The args prop must be an array!',
     )
 
     // Set
     const geometry1 = new THREE.BoxGeometry()
     const material1 = new THREE.MeshStandardMaterial()
-    await act(async () => (await root.configure()).render(<Test args={[geometry1, material1]} />))
+    await act(async () => root.render(<Test args={[geometry1, material1]} />))
     expect(ref.current!.geometry).toBe(geometry1)
     expect(ref.current!.material).toBe(material1)
     expect(ref.current!.children[0]).toBe(child.current)
@@ -332,14 +332,14 @@ describe('renderer', () => {
     // Update
     const geometry2 = new THREE.BoxGeometry()
     const material2 = new THREE.MeshStandardMaterial()
-    await act(async () => (await root.configure()).render(<Test args={[geometry2, material2]} />))
+    await act(async () => root.render(<Test args={[geometry2, material2]} />))
     expect(ref.current!.geometry).toBe(geometry2)
     expect(ref.current!.material).toBe(material2)
     expect(ref.current!.children[0]).toBe(child.current)
     expect(ref.current!.userData.attach).toBe(attachedChild.current)
 
     // Unset
-    await act(async () => (await root.configure()).render(<Test />))
+    await act(async () => root.render(<Test />))
     expect(ref.current!.geometry).toBeInstanceOf(THREE.BufferGeometry)
     expect(ref.current!.geometry).not.toBeInstanceOf(THREE.BoxGeometry)
     expect(ref.current!.material).toBeInstanceOf(THREE.Material)
@@ -369,25 +369,25 @@ describe('renderer', () => {
     object2.add(child2)
 
     // Initial
-    await act(async () => (await root.configure()).render(<Test object={object1} />))
+    await act(async () => root.render(<Test object={object1} />))
     expect(ref.current).toBe(object1)
     expect(ref.current!.children).toStrictEqual([child1, child.current])
     expect(ref.current!.userData.attach).toBe(attachedChild.current)
 
     // Throw on undefined
     await expectToThrow(
-      async () => await act(async () => (await root.configure()).render(<Test object={undefined as any} />)),
+      async () => await act(async () => root.render(<Test object={undefined as any} />)),
       "R3F: Primitives without 'object' are invalid!",
     )
 
     // Update
-    await act(async () => (await root.configure()).render(<Test object={object2} />))
+    await act(async () => root.render(<Test object={object2} />))
     expect(ref.current).toBe(object2)
     expect(ref.current!.children).toStrictEqual([child2, child.current])
     expect(ref.current!.userData.attach).toBe(attachedChild.current)
 
     // Revert
-    await act(async () => (await root.configure()).render(<Test object={object1} />))
+    await act(async () => root.render(<Test object={object1} />))
     expect(ref.current).toBe(object1)
     expect(ref.current!.children).toStrictEqual([child1, child.current])
     expect(ref.current!.userData.attach).toBe(attachedChild.current)
@@ -447,8 +447,8 @@ describe('renderer', () => {
       </mesh>
     )
 
-    const store = await act(async () => (await root.configure()).render(<Test />))
-    await act(async () => (await root.configure()).render(null))
+    const store = await act(async () => root.render(<Test />))
+    await act(async () => root.render(null))
 
     const { scene, internal } = store.getState()
 
@@ -493,17 +493,17 @@ describe('renderer', () => {
     )
 
     const array = [a, b, c, d]
-    const store = await act(async () => (await root.configure()).render(<Test array={array} />))
+    const store = await act(async () => root.render(<Test array={array} />))
     const { scene } = store.getState()
 
     expect(scene.children.map((o) => o.name)).toStrictEqual(array.map((o) => o.name))
 
     const reversedArray = [d, c, b, a]
-    await act(async () => (await root.configure()).render(<Test array={reversedArray} />))
+    await act(async () => root.render(<Test array={reversedArray} />))
     expect(scene.children.map((o) => o.name)).toStrictEqual(reversedArray.map((o) => o.name))
 
     const mixedArray = [b, a, d, c]
-    await act(async () => (await root.configure()).render(<Test array={mixedArray} />))
+    await act(async () => root.render(<Test array={mixedArray} />))
     expect(scene.children.map((o) => o.name)).toStrictEqual(mixedArray.map((o) => o.name))
   })
 
@@ -528,33 +528,33 @@ describe('renderer', () => {
       </>
     )
 
-    const store = await act(async () => (await root.configure()).render(<Test array={array} />))
+    const store = await act(async () => root.render(<Test array={array} />))
     const { scene } = store.getState()
 
     expect(scene.children.length).toBe(0)
     expect(scene.userData.objects.map((o: THREE.Object3D) => o.name)).toStrictEqual(array.map((o) => o.name))
 
     const reversedArray = [d, c, b, a]
-    await act(async () => (await root.configure()).render(<Test array={reversedArray} />))
+    await act(async () => root.render(<Test array={reversedArray} />))
     expect(scene.children.length).toBe(0)
     expect(scene.userData.objects.map((o: THREE.Object3D) => o.name)).toStrictEqual(reversedArray.map((o) => o.name))
 
     const mixedArray = [b, a, d, c]
-    await act(async () => (await root.configure()).render(<Test array={mixedArray} />))
+    await act(async () => root.render(<Test array={mixedArray} />))
     expect(scene.children.length).toBe(0)
     expect(scene.userData.objects.map((o: THREE.Object3D) => o.name)).toStrictEqual(mixedArray.map((o) => o.name))
   })
 
   it('should gracefully handle text', async () => {
     // Mount
-    await act(async () => (await root.configure()).render(<>one</>))
+    await act(async () => root.render(<>one</>))
     // Update
-    await act(async () => (await root.configure()).render(<>two</>))
+    await act(async () => root.render(<>two</>))
     // Unmount
-    await act(async () => (await root.configure()).render(<></>))
+    await act(async () => root.render(<></>))
     // Suspense
     const Test = () => suspend(async () => <>four</>, [])
-    await act(async () => (await root.configure()).render(<Test />))
+    await act(async () => root.render(<Test />))
   })
 
   it('should gracefully interrupt when building up the tree', async () => {
@@ -590,14 +590,14 @@ describe('renderer', () => {
       )
     }
 
-    await act(async () => (await root.configure()).render(<Test />))
+    await act(async () => root.render(<Test />))
 
     // Should complete tree before layout-effects fire
     expect(calls).toStrictEqual(['attach', 'useLayoutEffect'])
     expect(lastAttached).toBe(lastMounted)
     expect(Mock.instances).toStrictEqual(['suspense', 'parent', 'child'])
 
-    await act(async () => (await root.configure()).render(<Test reconstruct />))
+    await act(async () => root.render(<Test reconstruct />))
 
     expect(calls).toStrictEqual(['attach', 'useLayoutEffect', 'detach', 'attach'])
     expect(lastAttached).toBe(lastMounted)

--- a/packages/fiber/tests/utils.test.ts
+++ b/packages/fiber/tests/utils.test.ts
@@ -16,13 +16,10 @@ import {
   findInitialRoot,
 } from '../src/core/utils'
 
-async function createMockStore(): Promise<RootStore> {
+function createMockStore(): RootStore {
   let store!: RootStore
   try {
-    await act(async () => {
-      const root = createRoot(document.createElement('canvas'))
-      store = (await root.configure()).render(null)
-    })
+    act(async () => (store = createRoot(document.createElement('canvas')).render(null))).then(() => null)
   } catch (e) {
     console.error(e)
   }
@@ -178,22 +175,22 @@ describe('getInstanceProps', () => {
 })
 
 describe('prepare', () => {
-  it('should create an instance descriptor', async () => {
+  it('should create an instance descriptor', () => {
     const object = new THREE.Object3D()
-    const instance = prepare(object, await store, 'object3D', { name: 'object' })
+    const instance = prepare(object, store, 'object3D', { name: 'object' })
 
-    expect(instance.root).toBe(await store)
+    expect(instance.root).toBe(store)
     expect(instance.type).toBe('object3D')
     expect(instance.props.name).toBe('object')
     expect(instance.object).toBe(object)
     expect((object as Instance<THREE.Object3D>['object']).__r3f).toBe(instance)
   })
 
-  it('should not overwrite descriptors', async () => {
+  it('should not overwrite descriptors', () => {
     const containerDesc = {}
     const container = { __r3f: containerDesc }
 
-    const instance = prepare(container, await store, 'container', {})
+    const instance = prepare(container, store, 'container', {})
     expect(container.__r3f).toBe(containerDesc)
     expect(instance).toBe(containerDesc)
   })
@@ -221,9 +218,9 @@ describe('resolve', () => {
 })
 
 describe('attach / detach', () => {
-  it('should attach & detach using string values', async () => {
-    const parent = prepare({ prop: null }, await store, '', {})
-    const child = prepare({}, await store, '', { attach: 'prop' })
+  it('should attach & detach using string values', () => {
+    const parent = prepare({ prop: null }, store, '', {})
+    const child = prepare({}, store, '', { attach: 'prop' })
 
     attach(parent, child)
     expect(parent.object.prop).toBe(child.object)
@@ -234,12 +231,12 @@ describe('attach / detach', () => {
     expect(child.previousAttach).toBe(undefined)
   })
 
-  it('should attach & detach using attachFns', async () => {
+  it('should attach & detach using attachFns', () => {
     const mount = jest.fn()
     const unmount = jest.fn()
 
-    const parent = prepare({}, await store, '', {})
-    const child = prepare({}, await store, '', { attach: () => (mount(), unmount) })
+    const parent = prepare({}, store, '', {})
+    const child = prepare({}, store, '', { attach: () => (mount(), unmount) })
 
     attach(parent, child)
     expect(mount).toHaveBeenCalledTimes(1)
@@ -252,9 +249,9 @@ describe('attach / detach', () => {
     expect(child.previousAttach).toBe(undefined)
   })
 
-  it('should create array when using array-index syntax', async () => {
-    const parent = prepare({ prop: null }, await store, '', {})
-    const child = prepare({}, await store, '', { attach: 'prop-0' })
+  it('should create array when using array-index syntax', () => {
+    const parent = prepare({ prop: null }, store, '', {})
+    const child = prepare({}, store, '', { attach: 'prop-0' })
 
     attach(parent, child)
     expect(parent.object.prop).toStrictEqual([child.object])
@@ -268,47 +265,47 @@ describe('attach / detach', () => {
 })
 
 describe('diffProps', () => {
-  it('should filter changed props', async () => {
-    const instance = prepare({}, await store, '', { foo: true })
+  it('should filter changed props', () => {
+    const instance = prepare({}, store, '', { foo: true })
     const newProps = { foo: true, bar: false }
 
     const filtered = diffProps(instance, newProps)
     expect(filtered).toStrictEqual({ bar: false })
   })
 
-  it('invalidates pierced props when root is changed', async () => {
+  it('invalidates pierced props when root is changed', () => {
     const texture1 = { needsUpdate: false, name: '' } as THREE.Texture
     const texture2 = { needsUpdate: false, name: '' } as THREE.Texture
 
     const oldProps = { map: texture1, 'map-needsUpdate': true, 'map-name': 'test' }
     const newProps = { map: texture2, 'map-needsUpdate': true, 'map-name': 'test' }
 
-    const instance = prepare({}, await store, '', oldProps)
+    const instance = prepare({}, store, '', oldProps)
     const filtered = diffProps(instance, newProps)
     expect(filtered).toStrictEqual(newProps)
   })
 
-  it('should pick removed props for HMR', async () => {
-    const instance = prepare(new THREE.Object3D(), await store, '', { position: [0, 0, 1] })
+  it('should pick removed props for HMR', () => {
+    const instance = prepare(new THREE.Object3D(), store, '', { position: [0, 0, 1] })
     const newProps = {}
 
     const filtered = diffProps(instance, newProps)
     expect(filtered).toStrictEqual({ position: new THREE.Object3D().position })
   })
 
-  it('should reset removed props for HMR', async () => {
-    const instance = prepare(new THREE.Object3D(), await store, '', { scale: 10 })
+  it('should reset removed props for HMR', () => {
+    const instance = prepare(new THREE.Object3D(), store, '', { scale: 10 })
     const filtered = diffProps(instance, {})
     expect((filtered.scale as THREE.Vector3).toArray()).toStrictEqual([1, 1, 1])
   })
 
-  it('should filter reserved props without accessing them', async () => {
+  it('should filter reserved props without accessing them', () => {
     const get = jest.fn()
     const set = jest.fn()
 
     const props = { foo: true }
     const filtered = diffProps(
-      prepare({}, await store, '', {}),
+      prepare({}, store, '', {}),
       RESERVED_PROPS.reduce((acc, key) => ({ ...acc, [key]: { get, set } }), props),
     )
 
@@ -349,7 +346,7 @@ describe('applyProps', () => {
     expect(target.foo.value).toBe(false)
   })
 
-  it('should prefer to copy from external props', async () => {
+  it('should prefer to copy from external props', () => {
     const copyMock = jest.fn()
 
     class MockedColor extends THREE.Color {
@@ -384,7 +381,7 @@ describe('applyProps', () => {
     expect(copyMock).toHaveBeenCalledTimes(1)
   })
 
-  it('should prefer to assign if origin null', async () => {
+  it('should prefer to assign if origin null', () => {
     const copyMock = jest.fn()
 
     class MockedTexture extends THREE.Texture {
@@ -417,14 +414,14 @@ describe('applyProps', () => {
     expect(copyMock).toHaveBeenCalledTimes(1)
   })
 
-  it('should prefer to set when props are an array', async () => {
+  it('should prefer to set when props are an array', () => {
     const target = new THREE.Object3D()
     applyProps(target, { position: [1, 2, 3] })
 
     expect(target.position.toArray()).toStrictEqual([1, 2, 3])
   })
 
-  it('should set with scalar shorthand where applicable', async () => {
+  it('should set with scalar shorthand where applicable', () => {
     // Vector3#setScalar
     const target = new THREE.Object3D()
     applyProps(target, { scale: 5 })
@@ -448,21 +445,21 @@ describe('applyProps', () => {
     expect(target.material.color.getHex()).toBe(0x000000)
   })
 
-  it('should not apply a prop if it is undefined', async () => {
+  it('should not apply a prop if it is undefined', () => {
     const target = { value: 'initial' }
     applyProps(target, { value: undefined })
 
     expect(target.value).toBe('initial')
   })
 
-  it('should not apply a prop to an instance if it is a reserved event', async () => {
-    const target = prepare(new THREE.Object3D(), await store, '', {})
+  it('should not apply a prop to an instance if it is a reserved event', () => {
+    const target = prepare(new THREE.Object3D(), store, '', {})
     applyProps(target.object, { onClick: () => null })
 
     expect('onClick' in target).toBe(false)
   })
 
-  it('should not copy if props are supersets of another', async () => {
+  it('should not copy if props are supersets of another', () => {
     const copy = jest.fn()
 
     class Material {
@@ -517,20 +514,20 @@ describe('updateCamera', () => {
 })
 
 describe('findInitialRoot', () => {
-  it('finds the nearest root for portals', async () => {
-    const portalStore = await createMockStore()
-    portalStore.getState().previousRoot = await store
+  it('finds the nearest root for portals', () => {
+    const portalStore = createMockStore()
+    portalStore.getState().previousRoot = store
 
     const instance = prepare(new THREE.Object3D(), portalStore, '', {})
     const root = findInitialRoot(instance)
 
-    expect(root).toBe(await store)
+    expect(root).toBe(store)
   })
 
-  it('falls back to the local root', async () => {
-    const instance = prepare(new THREE.Object3D(), await store, '', {})
+  it('falls back to the local root', () => {
+    const instance = prepare(new THREE.Object3D(), store, '', {})
     const root = findInitialRoot(instance)
 
-    expect(root).toBe(await store)
+    expect(root).toBe(store)
   })
 })


### PR DESCRIPTION
Partial revert of 76fca8f02be336ffa3d84b1b96075d7cb55aa783. Waits for a configured root to resolve or configures itself when calling `root.render()`.