### PR TITLE
Prevent usage of getElapsedTime

### DIFF
--- a/docs/tutorials/basic-animations.mdx
+++ b/docs/tutorials/basic-animations.mdx
@@ -36,7 +36,7 @@ For example, we can extract time information from the `clock` parameter, to know
 
 ```jsx
 useFrame(({ clock }) => {
-  const a = clock.getElapsedTime()
+  const a = clock.elapsedTime
   console.log(a) // the value will be 0 at scene initialization and grow each frame
 })
 ```
@@ -66,7 +66,7 @@ function MyAnimatedBox() {
 
 ```jsx
 useFrame(({ clock }) => {
-  myMesh.current.rotation.x = clock.getElapsedTime()
+  myMesh.current.rotation.x = clock.elapsedTime
 })
 ```
 
@@ -80,7 +80,7 @@ Let's have a closer look:
 
 **Exercises**
 
-- Try `Math.sin(clock.getElapsedTime())` and see how your animation changes
+- Try `Math.sin(clock.elapsedTime)` and see how your animation changes
 
 ## Next steps
 

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -165,6 +165,14 @@ export type RootState = {
 
 const context = React.createContext<UseBoundStore<RootState>>(null!)
 
+// Custom clock to prevent user from messing the delta 
+class R3FMainClock extends THREE.Clock {
+  getElapsedTime(): number {
+    console.warn('Warning: do not call getElapsedTime on the r3f state clock, it will mess up the delta. Read .elapsedTime instead');
+    return super.getElapsedTime();
+  }
+}
+
 const createStore = (invalidate: Invalidate, advance: Advance): UseBoundStore<RootState> => {
   const rootState = create<RootState>((set, get) => {
     const position = new THREE.Vector3()
@@ -216,7 +224,7 @@ const createStore = (invalidate: Invalidate, advance: Advance): UseBoundStore<Ro
       flat: false,
 
       controls: null,
-      clock: new THREE.Clock(),
+      clock: new R3FMainClock(),
       pointer,
       mouse: pointer,
 


### PR DESCRIPTION
Following this [PR](https://github.com/pmndrs/drei/pull/2341) to Drei 

The doc currently encourage people to use `.getElapsedTime()` for animations, while they should never ( as far as I can think of ) call it. If they need the elapsedTime they can read it from `.elapsedTime` that is updated by the internal call to getDelta.
Otherwise the next delta of the whole app will be affected.

This PR updates the doc and add a warning to each call to `getElapsedTime()` for the main state clock. 