### PR TITLE
fix(applyProps): set could be used on non-object values

### DIFF
--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -420,11 +420,14 @@ export function applyProps<T = any>(object: Instance<T>['object'], props: Instan
       target.mask = value.mask
     }
     // Set array types
-    else if (target?.set && Array.isArray(value)) {
+    // Target is narrowed to an object to guard against prototype patching
+    else if (target?.set && Array.isArray(value) && typeof target === 'object') {
       if (target.fromArray) target.fromArray(value)
       else target.set(...value)
     }
+
     // Set literal types
+    // Target is narrowed to an object to guard against prototype patching
     else if (target?.set && typeof value !== 'object' && typeof target === 'object') {
       const isColor = (target as unknown as THREE.Color | undefined)?.isColor
       // Allow setting array scalars

--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -425,7 +425,7 @@ export function applyProps<T = any>(object: Instance<T>['object'], props: Instan
       else target.set(...value)
     }
     // Set literal types
-    else if (target?.set && typeof value !== 'object') {
+    else if (target?.set && typeof value !== 'object' && typeof target === 'object') {
       const isColor = (target as unknown as THREE.Color | undefined)?.isColor
       // Allow setting array scalars
       if (!isColor && target.setScalar && typeof value === 'number') target.setScalar(value)


### PR DESCRIPTION
In cases where a `set` method is added to a non-object prototype, `applyProps` would try to use it. This simply guards against that case. It is relevant for Koota which adds a `set` method to the Number prototype.