### PR TITLE
[v9] fix(applyProps): set color representation

### DIFF
--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -38,6 +38,9 @@ export const isOrthographicCamera = (def: Camera): def is THREE.OrthographicCame
   def && (def as THREE.OrthographicCamera).isOrthographicCamera
 export const isRef = (obj: any): obj is React.RefObject<unknown> => obj && obj.hasOwnProperty('current')
 
+export const isColorRepresentation = (value: unknown): value is THREE.ColorRepresentation =>
+  value != null && (typeof value === 'string' || typeof value === 'number' || (value as THREE.Color).isColor)
+
 /**
  * An SSR-friendly useLayoutEffect.
  *
@@ -404,6 +407,8 @@ export function applyProps<T = any>(object: Instance<T>['object'], props: Instan
     // Layers must be written to the mask property
     if (target instanceof THREE.Layers && value instanceof THREE.Layers) {
       target.mask = value.mask
+    } else if (target instanceof THREE.Color && isColorRepresentation(value)) {
+      target.set(value)
     }
     // Copy if properties match signatures and implement math interface (likely read-only)
     else if (
@@ -422,9 +427,8 @@ export function applyProps<T = any>(object: Instance<T>['object'], props: Instan
     }
     // Set literal types
     else if (target && typeof target.set === 'function' && typeof value === 'number') {
-      // Allow setting array scalars (don't call setScalar for Color since it skips conversions)
-      const isColor = (target as unknown as THREE.Color).isColor
-      if (!isColor && typeof target.setScalar === 'function') target.setScalar(value)
+      // Allow setting array scalars
+      if (typeof target.setScalar === 'function') target.setScalar(value)
       // Otherwise just set single value
       else target.set(value)
     }

--- a/packages/fiber/tests/utils.test.ts
+++ b/packages/fiber/tests/utils.test.ts
@@ -400,6 +400,10 @@ describe('applyProps', () => {
     const material = new THREE.MeshBasicMaterial()
     applyProps(material, { color: 0x000000 })
     expect(material.color.getHex()).toBe(0x000000)
+    applyProps(material, { color: 'white' })
+    expect(material.color.getHex()).toBe(0xffffff)
+    applyProps(material, { color: new THREE.Color('red') })
+    expect(material.color.getHex()).toBe(0xff0000)
 
     // No-op on undefined
     const mesh = new THREE.Mesh()


### PR DESCRIPTION
Fixes a regression in #3460 where `applyProps` excluded string colors from being applied. This is explicitly written as an exception like `Layers`, where a valid `ColorRepresentation` will be set if the receiving prop implements `Color`.