### PR TITLE
[v9] fix(events): align default event offset behavior

### DIFF
--- a/packages/fiber/src/web/events.ts
+++ b/packages/fiber/src/web/events.ts
@@ -24,10 +24,7 @@ export function createPointerEvents(store: RootStore): EventManager<HTMLElement>
     compute(event: DomEvent, state: RootState, previous?: RootState) {
       // https://github.com/pmndrs/react-three-fiber/pull/782
       // Events trigger outside of canvas when moved, use offsetX/Y by default and allow overrides
-      state.pointer.set(
-        ((event.offsetX - state.size.left) / state.size.width) * 2 - 1,
-        -((event.offsetY - state.size.top) / state.size.height) * 2 + 1,
-      )
+      state.pointer.set((event.offsetX / state.size.width) * 2 - 1, -(event.offsetY / state.size.height) * 2 + 1)
       state.raycaster.setFromCamera(state.pointer, state.camera)
     },
 

--- a/packages/fiber/tests/events.test.tsx
+++ b/packages/fiber/tests/events.test.tsx
@@ -419,4 +419,32 @@ describe('events', () => {
     expect(handlePointerDownOuter).toHaveBeenCalled()
     expect(handlePointerDownInner).toHaveBeenCalled()
   })
+
+  it('can handle a DOM offset canvas', async () => {
+    const handlePointerDown = jest.fn()
+    await act(async () => {
+      render(
+        <Canvas
+          onCreated={(state) => {
+            state.size.left = 100
+            state.size.top = 100
+          }}>
+          <mesh onPointerDown={handlePointerDown}>
+            <boxGeometry args={[2, 2]} />
+            <meshBasicMaterial />
+          </mesh>
+        </Canvas>,
+      )
+    })
+
+    const evt = new PointerEvent('pointerdown')
+    Object.defineProperty(evt, 'offsetX', { get: () => 577 })
+    Object.defineProperty(evt, 'offsetY', { get: () => 480 })
+
+    fireEvent(getContainer(), evt)
+
+    expect(handlePointerDown).toHaveBeenCalled()
+  })
+
+  it.todo('can handle different event prefixes')
 })


### PR DESCRIPTION
Between https://github.com/pmndrs/react-three-fiber/commit/8e3b41ed05fc9160530ea27d59e6567e74bddf01 and https://github.com/pmndrs/react-three-fiber/commit/29ed73ffaf960af4dc231f4a5706dc8c37f3ee05, the default (client) behavior was lost and broken when adding left/right page offsets.