### PR TITLE
[v9] fix(applyProps): narrow vector shorthand to object types

### DIFF
--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -407,12 +407,15 @@ export function applyProps<T = any>(object: Instance<T>['object'], props: Instan
     // Layers must be written to the mask property
     if (target instanceof THREE.Layers && value instanceof THREE.Layers) {
       target.mask = value.mask
-    } else if (target instanceof THREE.Color && isColorRepresentation(value)) {
+    }
+    // Set colors if valid color representation for automatic conversion (copy)
+    else if (target instanceof THREE.Color && isColorRepresentation(value)) {
       target.set(value)
     }
     // Copy if properties match signatures and implement math interface (likely read-only)
     else if (
-      target &&
+      target !== null &&
+      typeof target === 'object' &&
       typeof target.set === 'function' &&
       typeof target.copy === 'function' &&
       (value as ClassConstructor | null)?.constructor &&
@@ -421,12 +424,22 @@ export function applyProps<T = any>(object: Instance<T>['object'], props: Instan
       target.copy(value)
     }
     // Set array types
-    else if (target && typeof target.set === 'function' && Array.isArray(value)) {
+    else if (
+      target !== null &&
+      typeof target === 'object' &&
+      typeof target.set === 'function' &&
+      Array.isArray(value)
+    ) {
       if (typeof target.fromArray === 'function') target.fromArray(value)
       else target.set(...value)
     }
     // Set literal types
-    else if (target && typeof target.set === 'function' && typeof value === 'number') {
+    else if (
+      target !== null &&
+      typeof target === 'object' &&
+      typeof target.set === 'function' &&
+      typeof value === 'number'
+    ) {
       // Allow setting array scalars
       if (typeof target.setScalar === 'function') target.setScalar(value)
       // Otherwise just set single value

--- a/packages/fiber/tests/utils.test.ts
+++ b/packages/fiber/tests/utils.test.ts
@@ -431,6 +431,29 @@ describe('applyProps', () => {
 
     expect('onClick' in target).toBe(false)
   })
+
+  // https://github.com/pmndrs/koota/issues/47
+  it('should not fallthrough to set/copy for primitive types', () => {
+    const set = jest.fn()
+    const copy = jest.fn()
+
+    // @ts-ignore
+    Number.prototype.set = set
+    // @ts-ignore
+    Number.prototype.copy = copy
+
+    const target = { scale: 1 }
+    applyProps(target, { scale: 10 })
+
+    // @ts-ignore
+    delete Number.prototype.set
+    // @ts-ignore
+    delete Number.prototype.copy
+
+    expect(set).not.toHaveBeenCalled()
+    expect(copy).not.toHaveBeenCalled()
+    expect(target.scale).toBe(10)
+  })
 })
 
 describe('updateCamera', () => {


### PR DESCRIPTION
Continues #3457, where modifications to `Number.prototype` that implement a math interface would fallthrough to vector shorthand methods like `set`/`copy` and not mutate props.