### PR TITLE
fix: add use-sync-external-store dep

### DIFF
--- a/packages/fiber/package.json
+++ b/packages/fiber/package.json
@@ -52,13 +52,14 @@
     "react-use-measure": "^2.1.7",
     "scheduler": "^0.25.0",
     "suspend-react": "^0.1.3",
+    "use-sync-external-store": "^1.4.0",
     "zustand": "^5.0.3"
   },
   "peerDependencies": {
     "expo": ">=43.0",
     "expo-asset": ">=8.4",
-    "expo-gl": ">=11.0",
     "expo-file-system": ">=11.0",
+    "expo-gl": ">=11.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-native": ">=0.78",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10640,6 +10640,11 @@ use-sync-external-store@1.2.0, use-sync-external-store@^1.0.0:
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
+use-sync-external-store@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz#adbc795d8eeb47029963016cefdf89dc799fcebc"
+  integrity sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"


### PR DESCRIPTION
Adds `use-sync-external-store`, which is a peer dependency since Zustand v5.