### PR TITLE
fix(reconciler): prefer to resolve unprefixed instance types

### DIFF
--- a/packages/fiber/src/core/reconciler.tsx
+++ b/packages/fiber/src/core/reconciler.tsx
@@ -229,7 +229,7 @@ export function extend<T extends Catalogue | ConstructorRepresentation>(
 
 function validateInstance(type: string, props: HostConfig['props']): void {
   // Get target from catalogue
-  const name = `${type[0].toUpperCase()}${type.slice(1)}`
+  const name = toPascalCase(type)
   const target = catalogue[name]
 
   // Validate element target
@@ -246,8 +246,8 @@ function validateInstance(type: string, props: HostConfig['props']): void {
 }
 
 function createInstance(type: string, props: HostConfig['props'], root: RootStore): HostConfig['instance'] {
-  // Remove three* prefix from elements
-  type = type.replace(PREFIX_REGEX, '')
+  // Remove three* prefix from elements if native element not present
+  type = toPascalCase(type) in catalogue ? type : type.replace(PREFIX_REGEX, '')
 
   validateInstance(type, props)
 

--- a/packages/fiber/tests/renderer.test.tsx
+++ b/packages/fiber/tests/renderer.test.tsx
@@ -17,6 +17,7 @@ class Mock extends THREE.Group {
 declare module '@react-three/fiber' {
   interface ThreeElements {
     mock: ThreeElement<typeof Mock>
+    threeRandom: ThreeElement<typeof THREE.Group>
   }
 }
 
@@ -762,6 +763,8 @@ describe('renderer', () => {
   })
 
   it('resolves conflicting and prefixed elements', async () => {
+    extend({ ThreeRandom: THREE.Group })
+
     const store = await act(async () => root.render(<line />))
     expect(store.getState().scene.children[0]).toBeInstanceOf(THREE.Line)
 
@@ -770,5 +773,11 @@ describe('renderer', () => {
 
     await act(async () => root.render(<threeLine />))
     expect(store.getState().scene.children[0]).toBeInstanceOf(THREE.Line)
+
+    await act(async () => root.render(null))
+    expect(store.getState().scene.children.length).toBe(0)
+
+    await act(async () => root.render(<threeRandom />))
+    expect(store.getState().scene.children[0]).toBeInstanceOf(THREE.Group)
   })
 })


### PR DESCRIPTION
Fixes #3469, where resolution for JSX conflicts in #3451 erroneously removed `three*` from user-land elements.