### PR TITLE
feat: add meshes to loader graph

### DIFF
--- a/example/src/demos/Gltf.tsx
+++ b/example/src/demos/Gltf.tsx
@@ -4,7 +4,7 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
 
 function Test() {
   const [flag, toggle] = useReducer((state) => !state, true)
-  const { scene } = useLoader(GLTFLoader, flag ? '/Stork.glb' : '/Parrot.glb') as any
+  const { scene } = useLoader(GLTFLoader, flag ? '/Stork.glb' : '/Parrot.glb')
 
   useEffect(() => {
     const interval = setInterval(toggle, 1000)

--- a/example/src/demos/MultiView.tsx
+++ b/example/src/demos/MultiView.tsx
@@ -35,14 +35,14 @@ function useHover() {
 
 export function Soda(props: ThreeElements['group']) {
   const [hovered, hoverProps] = useHover()
-  const { nodes, materials } = useGLTF('/bottle.gltf') as any
+  const { meshes, materials } = useGLTF('/bottle.gltf')
 
   return (
     <group {...props} {...hoverProps} dispose={null}>
-      <mesh geometry={nodes.Mesh_sodaBottle.geometry}>
+      <mesh geometry={meshes.Mesh_sodaBottle.geometry}>
         <meshStandardMaterial color={hovered ? 'red' : 'green'} roughness={0} metalness={0.8} envMapIntensity={2} />
       </mesh>
-      <mesh geometry={nodes.Mesh_sodaBottle_1.geometry} material={materials.red} material-envMapIntensity={0} />
+      <mesh geometry={meshes.Mesh_sodaBottle_1.geometry} material={materials.red} material-envMapIntensity={0} />
     </group>
   )
 }

--- a/example/src/demos/Portals.tsx
+++ b/example/src/demos/Portals.tsx
@@ -26,13 +26,13 @@ export function Ramen(props: ThreeElements['group']) {
 
 export function Soda(props: ThreeElements['group']) {
   const [hovered, spread] = useHover()
-  const { nodes, materials } = useGLTF('/bottle.gltf') as any
+  const { meshes, materials } = useGLTF('/bottle.gltf')
   return (
     <group {...(spread as any)} {...props} dispose={null}>
-      <mesh geometry={nodes.Mesh_sodaBottle.geometry}>
+      <mesh geometry={meshes.Mesh_sodaBottle.geometry}>
         <meshStandardMaterial color={hovered ? 'red' : 'green'} />
       </mesh>
-      <mesh geometry={nodes.Mesh_sodaBottle_1.geometry} material={materials.red} />
+      <mesh geometry={meshes.Mesh_sodaBottle_1.geometry} material={materials.red} />
     </group>
   )
 }

--- a/example/src/demos/StopPropagation.tsx
+++ b/example/src/demos/StopPropagation.tsx
@@ -17,19 +17,19 @@ function useHover() {
 
 function Soda(props: ThreeElements['group']) {
   const [hovered, spread] = useHover()
-  const { nodes, materials } = useGLTF('/bottle.gltf') as any
+  const { meshes, materials } = useGLTF('/bottle.gltf')
 
   return (
     <group {...props} {...spread} dispose={null}>
-      <mesh geometry={nodes.Mesh_sodaBottle.geometry}>
+      <mesh geometry={meshes.Mesh_sodaBottle.geometry}>
         <meshStandardMaterial color={hovered ? 'red' : 'green'} metalness={0.6} roughness={0} />
       </mesh>
-      <mesh geometry={nodes.Mesh_sodaBottle_1.geometry} material={materials.red} />
+      <mesh geometry={meshes.Mesh_sodaBottle_1.geometry} material={materials.red} />
     </group>
   )
 }
 
-function Hud({ priority = 1, children }: any) {
+function Hud({ priority = 1, children }: { priority?: number; children: React.ReactNode }) {
   const { gl, scene: defaultScene, camera: defaultCamera } = useThree()
   const [scene] = useState(() => new THREE.Scene())
 

--- a/example/src/demos/ViewTracking.tsx
+++ b/example/src/demos/ViewTracking.tsx
@@ -27,24 +27,22 @@ function useHover() {
 function Soda(props: ThreeElements['group']) {
   const ref = useRef<THREE.Group>(null!)
   const [hovered, spread] = useHover()
-  const { nodes, materials } = useGLTF('/bottle.gltf') as any
+  const { meshes, materials } = useGLTF('/bottle.gltf')
 
   useFrame((state, delta) => (ref.current.rotation.y += delta))
 
   return (
     <group ref={ref} {...props} {...spread} dispose={null}>
-      <mesh geometry={nodes.Mesh_sodaBottle.geometry}>
+      <mesh geometry={meshes.Mesh_sodaBottle.geometry}>
         <meshStandardMaterial color={hovered ? 'red' : 'green'} roughness={0} metalness={0.8} envMapIntensity={2} />
       </mesh>
-      <mesh geometry={nodes.Mesh_sodaBottle_1.geometry} material={materials.red} material-envMapIntensity={0} />
+      <mesh geometry={meshes.Mesh_sodaBottle_1.geometry} material={materials.red} material-envMapIntensity={0} />
     </group>
   )
 }
 
 function Duck(props: ThreeElements['group']) {
-  const { scene } = useGLTF(
-    'https://vazxmixjsiawhamofees.supabase.co/storage/v1/object/public/models/duck/model.gltf',
-  ) as any
+  const { scene } = useGLTF('https://vazxmixjsiawhamofees.supabase.co/storage/v1/object/public/models/duck/model.gltf')
   useFrame((state, delta) => (scene.rotation.x = scene.rotation.y += delta))
   return <primitive object={scene} {...props} />
 }
@@ -52,7 +50,7 @@ function Duck(props: ThreeElements['group']) {
 function Candy(props: ThreeElements['group']) {
   const { scene } = useGLTF(
     'https://vazxmixjsiawhamofees.supabase.co/storage/v1/object/public/models/candy-bucket/model.gltf',
-  ) as any
+  )
   useFrame((state, delta) => (scene.rotation.z = scene.rotation.y += delta))
   return <primitive object={scene} {...props} />
 }

--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -116,6 +116,7 @@ export const ErrorBoundary = /* @__PURE__ */ (() =>
 export interface ObjectMap {
   nodes: { [name: string]: THREE.Object3D }
   materials: { [name: string]: THREE.Material }
+  meshes: { [name: string]: THREE.Mesh }
 }
 
 export function calculateDpr(dpr: Dpr): number {
@@ -187,11 +188,12 @@ export const is = {
 
 // Collects nodes and materials from a THREE.Object3D
 export function buildGraph(object: THREE.Object3D): ObjectMap {
-  const data: ObjectMap = { nodes: {}, materials: {} }
+  const data: ObjectMap = { nodes: {}, materials: {}, meshes: {} }
   if (object) {
     object.traverse((obj: any) => {
       if (obj.name) data.nodes[obj.name] = obj
       if (obj.material && !data.materials[obj.material.name]) data.materials[obj.material.name] = obj.material
+      if (obj.isMesh && !data.meshes[obj.name]) data.meshes[obj.name] = obj
     })
   }
   return data

--- a/packages/fiber/tests/hooks.test.tsx
+++ b/packages/fiber/tests/hooks.test.tsx
@@ -240,6 +240,12 @@ describe('hooks', () => {
         [mat3.name]: mat3,
         [mat4.name]: mat4,
       },
+      meshes: {
+        [mesh1.name]: mesh1,
+        [mesh2.name]: mesh2,
+        [mesh3.name]: mesh3,
+        [mesh4.name]: mesh4,
+      },
     })
   })
 


### PR DESCRIPTION
Adds a typed meshes prop to the `ObjecgtMap` created by the loader graph. This allows for using meshes from `useLoader` or `useGltf` without needing to explicitly type the entire graph.