### PR TITLE
Update react-native deep imports for 0.79 compatibility

### DIFF
--- a/packages/fiber/src/native/polyfills.ts
+++ b/packages/fiber/src/native/polyfills.ts
@@ -77,7 +77,8 @@ export function polyfills() {
       const url = URL.createObjectURL(blob)
       URL.revokeObjectURL(url)
     } catch (_) {
-      const BlobManager = require('react-native/Libraries/Blob/BlobManager.js')
+      const BlobManagerModule = require('react-native/Libraries/Blob/BlobManager.js')
+      const BlobManager = BlobManagerModule.default ?? BlobManagerModule
 
       const createObjectURL = URL.createObjectURL
       URL.createObjectURL = function (blob: Blob): string {


### PR DESCRIPTION
## Summary

In the incoming React Native 0.79 release, we've converted a number of internal modules to `export` syntax — affecting usages with `require()`. This PR attempts to update these imports ahead of time, to work with both versions.

💡 Secondary note: In a future release, we are intending to omit each of these deep-imported modules from the public API of React Native. There will be a consultation period on opening up new APIs via the root `'react-native'` exports — e.g. `BlobManager` here.

## Test plan

**Needs testing**. CI should pass for integration with current RN versions.