### PR TITLE
Fix builds failing from React.act being removed from the production bundle

### DIFF
--- a/.changeset/thick-rice-switch.md
+++ b/.changeset/thick-rice-switch.md
@@ -1,0 +1,5 @@
+---
+'@react-three/fiber': patch
+---
+
+Fix failing builds for production when React.act is unavailable. This fixes issues found in React@19.1.0 and up.

--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -31,7 +31,15 @@ export type Act = <T = any>(cb: () => Promise<T>) => Promise<T>
 /**
  * Safely flush async effects when testing, simulating a legacy root.
  */
-export const act: Act = (React as any).act
+export const act: Act = async (cb) => {
+  const React = await import('react')
+
+  if ('act' in React) {
+    return React.act(cb)
+  }
+
+  throw new Error('R3F: React.act is unavailable in this environment.')
+}
 
 export type Camera = (THREE.OrthographicCamera | THREE.PerspectiveCamera) & { manual?: boolean }
 export const isOrthographicCamera = (def: Camera): def is THREE.OrthographicCamera =>

--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -31,14 +31,12 @@ export type Act = <T = any>(cb: () => Promise<T>) => Promise<T>
 /**
  * Safely flush async effects when testing, simulating a legacy root.
  */
-export const act: Act = async (cb) => {
-  const React = await import('react')
-
+export const act: Act = (cb) => {
   if ('act' in React) {
     return React.act(cb)
   }
 
-  throw new Error('R3F: React.act is unavailable in this environment.')
+  throw new Error('act(...) is not supported in production builds of React')
 }
 
 export type Camera = (THREE.OrthographicCamera | THREE.PerspectiveCamera) & { manual?: boolean }


### PR DESCRIPTION
Removed here: https://github.com/facebook/react/pull/32200
Released in react@19.1.0, [changelog](https://github.com/facebook/react/blob/main/CHANGELOG.md#1910-march-28-2025).
Raised in Discord: https://discord.com/channels/740090768164651008/740093168770613279/1355564374319829235