### PR TITLE
chore: add rsbuild to CI test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Build
         run: yarn run build
 
+      - name: Rsbuild (strict)
+        run: yarn add @rsbuild/core -D -W && yarn rsbuild build --root ./packages/fiber
+
       - name: Jest run
         run: yarn run dev && yarn run test
 


### PR DESCRIPTION
Adds rsbuild to the CI tests since it does more strict checks than Vite and catches missing import errors, for example.