### PR TITLE
fix: reference dev-only act with computed key for Webpack

### DIFF
--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -30,14 +30,11 @@ export type Act = <T = any>(cb: () => Promise<T>) => Promise<T>
 
 /**
  * Safely flush async effects when testing, simulating a legacy root.
+ * @deprecated Import from React instead. import { act } from 'react'
  */
-export const act: Act = (cb) => {
-  if ('act' in React) {
-    return React.act(cb)
-  }
-
-  throw new Error('act(...) is not supported in production builds of React')
-}
+// Reference with computed key to break Webpack static analysis
+// https://github.com/webpack/webpack/issues/14814
+export const act: Act = React[('act' + '') as 'act']
 
 export type Camera = (THREE.OrthographicCamera | THREE.PerspectiveCamera) & { manual?: boolean }
 export const isOrthographicCamera = (def: Camera): def is THREE.OrthographicCamera =>


### PR DESCRIPTION
Fixes #3511 thanks to @eps1lon.

> https://github.com/pmndrs/react-three-fiber/pull/3508/ won't be sufficient for certain bundlers like Webpack. They treat namespace access like a named import (https://github.com/webpack/webpack/issues/14814) so you need to trick those bundlers e.g. `React['act' + '']`

`act` is deprecated since v9 and will be removed from react-three-fiber in the next major and should be imported from React instead https://r3f.docs.pmnd.rs/tutorials/v9-migration-guide#act.