### PR TITLE
chore(tests): use React act implementation

### DIFF
--- a/packages/fiber/tests/canvas.native.test.tsx
+++ b/packages/fiber/tests/canvas.native.test.tsx
@@ -2,11 +2,11 @@ import * as React from 'react'
 import { View } from 'react-native'
 // @ts-ignore TS2305 remove with modern TS config
 import { render } from 'react-nil'
-import { Canvas, act } from '../src/native'
+import { Canvas } from '../src/native'
 
 describe('native Canvas', () => {
   it('should correctly mount', async () => {
-    const container = await act(async () =>
+    const container = await React.act(async () =>
       render(
         <Canvas>
           <group />
@@ -20,7 +20,7 @@ describe('native Canvas', () => {
   it('should forward ref', async () => {
     const ref = React.createRef<View>()
 
-    await act(async () =>
+    await React.act(async () =>
       render(
         <Canvas ref={ref}>
           <group />
@@ -40,7 +40,7 @@ describe('native Canvas', () => {
       return null
     }
 
-    await act(async () => {
+    await React.act(async () => {
       render(
         <ParentContext.Provider value={true}>
           <Canvas>
@@ -54,7 +54,7 @@ describe('native Canvas', () => {
   })
 
   it('should correctly unmount', async () => {
-    await act(async () =>
+    await React.act(async () =>
       render(
         <Canvas>
           <group />
@@ -62,6 +62,6 @@ describe('native Canvas', () => {
       ),
     )
 
-    expect(async () => await act(async () => render(null))).not.toThrow()
+    expect(async () => await React.act(async () => render(null))).not.toThrow()
   })
 })

--- a/packages/fiber/tests/canvas.test.tsx
+++ b/packages/fiber/tests/canvas.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import { Canvas, act } from '../src'
+import { Canvas } from '../src'
 
 describe('web Canvas', () => {
   it('should correctly mount', async () => {
-    const renderer = await act(async () =>
+    const renderer = await React.act(async () =>
       render(
         <Canvas>
           <group />
@@ -18,7 +18,7 @@ describe('web Canvas', () => {
   it('should forward ref', async () => {
     const ref = React.createRef<HTMLCanvasElement>()
 
-    await act(async () =>
+    await React.act(async () =>
       render(
         <Canvas ref={ref}>
           <group />
@@ -38,7 +38,7 @@ describe('web Canvas', () => {
       return null
     }
 
-    await act(async () => {
+    await React.act(async () => {
       render(
         <ParentContext.Provider value={true}>
           <Canvas>
@@ -52,7 +52,7 @@ describe('web Canvas', () => {
   })
 
   it('should correctly unmount', async () => {
-    const renderer = await act(async () =>
+    const renderer = await React.act(async () =>
       render(
         <Canvas>
           <group />
@@ -66,7 +66,7 @@ describe('web Canvas', () => {
   it('plays nice with react SSR', async () => {
     const useLayoutEffect = jest.spyOn(React, 'useLayoutEffect')
 
-    await act(async () =>
+    await React.act(async () =>
       render(
         <Canvas>
           <group />

--- a/packages/fiber/tests/events.test.tsx
+++ b/packages/fiber/tests/events.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { render, fireEvent, RenderResult } from '@testing-library/react'
-import { Canvas, act, extend } from '../src'
+import { Canvas, extend } from '../src'
 import THREE from 'three'
 
 extend(THREE as any)
@@ -11,7 +11,7 @@ describe('events', () => {
   it('can handle onPointerDown', async () => {
     const handlePointerDown = jest.fn()
 
-    await act(async () => {
+    await React.act(async () => {
       render(
         <Canvas>
           <mesh onPointerDown={handlePointerDown}>
@@ -35,7 +35,7 @@ describe('events', () => {
     const handleClick = jest.fn()
     const handleMissed = jest.fn()
 
-    await act(async () => {
+    await React.act(async () => {
       render(
         <Canvas>
           <mesh onPointerMissed={handleMissed} onClick={handleClick}>
@@ -60,7 +60,7 @@ describe('events', () => {
     const handleClick = jest.fn()
     const handleMissed = jest.fn()
 
-    await act(async () => {
+    await React.act(async () => {
       render(
         <Canvas>
           <mesh onPointerMissed={handleMissed} onClick={handleClick}>
@@ -95,7 +95,7 @@ describe('events', () => {
     const handleClick = jest.fn()
     const handleMissed = jest.fn()
 
-    await act(async () => {
+    await React.act(async () => {
       render(
         <Canvas>
           <group onPointerMissed={handleMissed}>
@@ -131,7 +131,7 @@ describe('events', () => {
   it('can handle onPointerMissed on Canvas', async () => {
     const handleMissed = jest.fn()
 
-    await act(async () => {
+    await React.act(async () => {
       render(
         <Canvas onPointerMissed={handleMissed}>
           <mesh>
@@ -156,7 +156,7 @@ describe('events', () => {
     const handlePointerEnter = jest.fn()
     const handlePointerOut = jest.fn()
 
-    await act(async () => {
+    await React.act(async () => {
       render(
         <Canvas>
           <mesh
@@ -196,7 +196,7 @@ describe('events', () => {
     })
     const handlePointerLeave = jest.fn()
 
-    await act(async () => {
+    await React.act(async () => {
       render(
         <Canvas>
           <mesh onPointerLeave={handlePointerLeave} onPointerEnter={handlePointerEnter}>
@@ -232,7 +232,7 @@ describe('events', () => {
     const handleClickFront = jest.fn((e) => e.stopPropagation())
     const handleClickRear = jest.fn()
 
-    await act(async () => {
+    await React.act(async () => {
       render(
         <Canvas>
           <mesh onClick={handleClickFront}>
@@ -299,7 +299,7 @@ describe('events', () => {
 
     it('should release when the capture target is unmounted', async () => {
       let renderResult: RenderResult = undefined!
-      await act(async () => {
+      await React.act(async () => {
         renderResult = render(<PointerCaptureTest hasMesh={true} />)
         return renderResult
       })
@@ -314,7 +314,7 @@ describe('events', () => {
       Object.defineProperty(down, 'offsetY', { get: () => 480 })
 
       /* testing-utils/react's fireEvent wraps the event like React does, so it doesn't match how our event handlers are called in production, so we call dispatchEvent directly. */
-      await act(async () => canvas.dispatchEvent(down))
+      await React.act(async () => canvas.dispatchEvent(down))
 
       /* This should have captured the DOM pointer */
       expect(handlePointerDown).toHaveBeenCalledTimes(1)
@@ -322,7 +322,7 @@ describe('events', () => {
       expect(canvas.releasePointerCapture).not.toHaveBeenCalled()
 
       /* Now remove the mesh */
-      await act(async () => renderResult.rerender(<PointerCaptureTest hasMesh={false} />))
+      await React.act(async () => renderResult.rerender(<PointerCaptureTest hasMesh={false} />))
 
       expect(canvas.releasePointerCapture).toHaveBeenCalledWith(pointerId)
 
@@ -330,7 +330,7 @@ describe('events', () => {
       Object.defineProperty(move, 'offsetX', { get: () => 577 })
       Object.defineProperty(move, 'offsetY', { get: () => 480 })
 
-      await act(async () => canvas.dispatchEvent(move))
+      await React.act(async () => canvas.dispatchEvent(move))
 
       /* There should now be no pointer capture */
       expect(handlePointerMove).not.toHaveBeenCalled()
@@ -338,7 +338,7 @@ describe('events', () => {
 
     it('should not leave when captured', async () => {
       let renderResult: RenderResult = undefined!
-      await act(async () => {
+      await React.act(async () => {
         renderResult = render(<PointerCaptureTest hasMesh manualRelease />)
         return renderResult
       })
@@ -356,7 +356,7 @@ describe('events', () => {
       Object.defineProperty(moveOut, 'offsetY', { get: () => -10000 })
 
       /* testing-utils/react's fireEvent wraps the event like React does, so it doesn't match how our event handlers are called in production, so we call dispatchEvent directly. */
-      await act(async () => canvas.dispatchEvent(moveIn))
+      await React.act(async () => canvas.dispatchEvent(moveIn))
       expect(handlePointerEnter).toHaveBeenCalledTimes(1)
       expect(handlePointerMove).toHaveBeenCalledTimes(1)
 
@@ -364,15 +364,15 @@ describe('events', () => {
       Object.defineProperty(down, 'offsetX', { get: () => 577 })
       Object.defineProperty(down, 'offsetY', { get: () => 480 })
 
-      await act(async () => canvas.dispatchEvent(down))
+      await React.act(async () => canvas.dispatchEvent(down))
 
       // If we move the pointer now, when it is captured, it should raise the onPointerMove event even though the pointer is not over the element,
       // and NOT raise the onPointerLeave event.
-      await act(async () => canvas.dispatchEvent(moveOut))
+      await React.act(async () => canvas.dispatchEvent(moveOut))
       expect(handlePointerMove).toHaveBeenCalledTimes(2)
       expect(handlePointerLeave).not.toHaveBeenCalled()
 
-      await act(async () => canvas.dispatchEvent(moveIn))
+      await React.act(async () => canvas.dispatchEvent(moveIn))
       expect(handlePointerMove).toHaveBeenCalledTimes(3)
 
       const up = new PointerEvent('pointerup', { pointerId })
@@ -380,14 +380,14 @@ describe('events', () => {
       Object.defineProperty(up, 'offsetY', { get: () => 480 })
       const lostpointercapture = new PointerEvent('lostpointercapture', { pointerId })
 
-      await act(async () => canvas.dispatchEvent(up))
-      await act(async () => canvas.dispatchEvent(lostpointercapture))
+      await React.act(async () => canvas.dispatchEvent(up))
+      await React.act(async () => canvas.dispatchEvent(lostpointercapture))
 
       // The pointer is still over the element, so onPointerLeave should not have been called.
       expect(handlePointerLeave).not.toHaveBeenCalled()
 
       // The element pointer should no longer be captured, so moving it away should call onPointerLeave.
-      await act(async () => canvas.dispatchEvent(moveOut))
+      await React.act(async () => canvas.dispatchEvent(moveOut))
       expect(handlePointerEnter).toHaveBeenCalledTimes(1)
       expect(handlePointerLeave).toHaveBeenCalledTimes(1)
     })
@@ -400,7 +400,7 @@ describe('events', () => {
     const object = new THREE.Group()
     object.add(new THREE.Mesh(new THREE.BoxGeometry(2, 2), new THREE.MeshBasicMaterial()))
 
-    await act(async () => {
+    await React.act(async () => {
       render(
         <Canvas>
           <group onPointerDown={handlePointerDownOuter}>
@@ -422,7 +422,7 @@ describe('events', () => {
 
   it('can handle a DOM offset canvas', async () => {
     const handlePointerDown = jest.fn()
-    await act(async () => {
+    await React.act(async () => {
       render(
         <Canvas
           onCreated={(state) => {

--- a/packages/fiber/tests/hooks.test.tsx
+++ b/packages/fiber/tests/hooks.test.tsx
@@ -6,7 +6,6 @@ import {
   createRoot,
   advance,
   useLoader,
-  act,
   useThree,
   useGraph,
   useFrame,
@@ -52,7 +51,7 @@ describe('hooks', () => {
       return <group />
     }
 
-    await act(async () => root.render(<Component />))
+    await React.act(async () => root.render(<Component />))
 
     expect(result.camera instanceof THREE.Camera).toBeTruthy()
     expect(result.scene instanceof THREE.Scene).toBeTruthy()
@@ -78,7 +77,7 @@ describe('hooks', () => {
       )
     }
 
-    const store = await act(async () => (await root.configure({ frameloop: 'never' })).render(<Component />))
+    const store = await React.act(async () => (await root.configure({ frameloop: 'never' })).render(<Component />))
     const { scene } = store.getState()
 
     advance(Date.now())
@@ -105,7 +104,7 @@ describe('hooks', () => {
       return <primitive object={gltf.scene} />
     }
 
-    const store = await act(async () => root.render(<Component />))
+    const store = await React.act(async () => root.render(<Component />))
     const { scene } = store.getState()
 
     expect(scene.children[0]).toBe(MockMesh)
@@ -151,7 +150,7 @@ describe('hooks', () => {
       )
     }
 
-    const store = await act(async () => root.render(<Component />))
+    const store = await React.act(async () => root.render(<Component />))
     const { scene } = store.getState()
 
     expect(scene.children[0]).toBe(MockMesh)
@@ -172,7 +171,7 @@ describe('hooks', () => {
     function Test(): null {
       return useLoader(loader, '', (loader) => (proto = loader))
     }
-    await act(async () => root.render(<Test />))
+    await React.act(async () => root.render(<Test />))
 
     expect(proto).toBe(loader)
   })
@@ -189,7 +188,7 @@ describe('hooks', () => {
     function Test(): null {
       return useLoader(Loader, '', (loader) => (proto = loader))
     }
-    await act(async () => root.render(<Test />))
+    await React.act(async () => root.render(<Test />))
 
     expect(proto).toBeInstanceOf(Loader)
   })
@@ -225,7 +224,7 @@ describe('hooks', () => {
       return <mesh />
     }
 
-    await act(async () => root.render(<Component />))
+    await React.act(async () => root.render(<Component />))
 
     expect(result).toEqual({
       nodes: {
@@ -257,7 +256,7 @@ describe('hooks', () => {
       instance = useInstanceHandle(ref)
       return <group ref={ref} />
     }
-    await act(async () => root.render(<Component />))
+    await React.act(async () => root.render(<Component />))
 
     expect(instance.current).toBe((ref.current as unknown as Instance<THREE.Group>['object']).__r3f)
   })

--- a/packages/fiber/tests/index.test.tsx
+++ b/packages/fiber/tests/index.test.tsx
@@ -6,7 +6,6 @@ import { createCanvas } from '@react-three/test-renderer/src/createTestCanvas'
 import {
   ReconcilerRoot,
   createRoot as createRootImpl,
-  act,
   useFrame,
   useThree,
   createPortal,
@@ -30,19 +29,19 @@ beforeEach(() => (root = createRoot()))
 
 afterEach(async () => {
   for (const root of roots) {
-    await act(async () => root.unmount())
+    await React.act(async () => root.unmount())
   }
   roots.length = 0
 })
 
 describe('createRoot', () => {
   it('should return a Zustand store', async () => {
-    const store = await act(async () => root.render(null))
+    const store = await React.act(async () => root.render(null))
     expect(() => store.getState()).not.toThrow()
   })
 
   it('will make an Orthographic Camera & set the position', async () => {
-    const store = await act(async () =>
+    const store = await React.act(async () =>
       (await root.configure({ orthographic: true, camera: { position: [0, 0, 5] } })).render(<group />),
     )
     const { camera } = store.getState()
@@ -54,7 +53,7 @@ describe('createRoot', () => {
   // TODO: deprecate
   it('should handle an performance changing functions', async () => {
     let store: RootStore = null!
-    await act(async () => {
+    await React.act(async () => {
       store = (await root.configure({ dpr: [1, 2], performance: { min: 0.2 } })).render(<group />)
     })
 
@@ -62,7 +61,7 @@ describe('createRoot', () => {
     expect(store.getState().performance.min).toEqual(0.2)
     expect(store.getState().performance.current).toEqual(1)
 
-    await act(async () => {
+    await React.act(async () => {
       store.getState().setDpr(0.1)
     })
 
@@ -70,14 +69,14 @@ describe('createRoot', () => {
 
     jest.useFakeTimers()
 
-    await act(async () => {
+    await React.act(async () => {
       store.getState().performance.regress()
       jest.advanceTimersByTime(100)
     })
 
     expect(store.getState().performance.current).toEqual(0.2)
 
-    await act(async () => {
+    await React.act(async () => {
       jest.advanceTimersByTime(200)
     })
 
@@ -88,27 +87,27 @@ describe('createRoot', () => {
 
   it('should handle the DPR prop reactively', async () => {
     // Initial clamp
-    const store = await act(async () => (await root.configure({ dpr: [1, 2] })).render(<group />))
+    const store = await React.act(async () => (await root.configure({ dpr: [1, 2] })).render(<group />))
     expect(store.getState().viewport.dpr).toEqual(window.devicePixelRatio)
 
     // Reactive update
-    await act(async () => store.getState().setDpr(0.1))
+    await React.act(async () => store.getState().setDpr(0.1))
     expect(store.getState().viewport.dpr).toEqual(0.1)
 
     // Reactive clamp
-    await act(async () => store.getState().setDpr([1, 2]))
+    await React.act(async () => store.getState().setDpr([1, 2]))
     expect(store.getState().viewport.dpr).toEqual(window.devicePixelRatio)
   })
 
   it('should set PCFSoftShadowMap as the default shadow map', async () => {
-    const store = await act(async () => (await root.configure({ shadows: true })).render(<group />))
+    const store = await React.act(async () => (await root.configure({ shadows: true })).render(<group />))
     const { gl } = store.getState()
 
     expect(gl.shadowMap.type).toBe(THREE.PCFSoftShadowMap)
   })
 
   it('should set tonemapping to ACESFilmicToneMapping and outputColorSpace to SRGBColorSpace if linear is false', async () => {
-    const store = await act(async () => (await root.configure({ linear: false })).render(<group />))
+    const store = await React.act(async () => (await root.configure({ linear: false })).render(<group />))
     const { gl } = store.getState()
 
     expect(gl.toneMapping).toBe(THREE.ACESFilmicToneMapping)
@@ -118,7 +117,7 @@ describe('createRoot', () => {
   it('should toggle render mode in xr', async () => {
     let state: RootState = null!
 
-    await act(async () => {
+    await React.act(async () => {
       state = root.render(<group />).getState()
       state.gl.xr.isPresenting = true
       state.gl.xr.dispatchEvent({ type: 'sessionstart' })
@@ -126,7 +125,7 @@ describe('createRoot', () => {
 
     expect(state.gl.xr.enabled).toEqual(true)
 
-    await act(async () => {
+    await React.act(async () => {
       state.gl.xr.isPresenting = false
       state.gl.xr.dispatchEvent({ type: 'sessionend' })
     })
@@ -139,7 +138,7 @@ describe('createRoot', () => {
 
     const Test = () => useFrame(() => (respected = false))
 
-    await act(async () => {
+    await React.act(async () => {
       const state = (await root.configure({ frameloop: 'never' })).render(<Test />).getState()
       state.gl.xr.isPresenting = true
       state.gl.xr.dispatchEvent({ type: 'sessionstart' })
@@ -149,7 +148,7 @@ describe('createRoot', () => {
   })
 
   it('should set renderer props via gl prop', async () => {
-    const store = await act(async () =>
+    const store = await React.act(async () =>
       (await root.configure({ gl: { logarithmicDepthBuffer: true } })).render(<group />),
     )
     const { gl } = store.getState()
@@ -160,7 +159,7 @@ describe('createRoot', () => {
   it('should update scene via scene prop', async () => {
     let scene: THREE.Scene = null!
 
-    await act(async () => {
+    await React.act(async () => {
       scene = (await root.configure({ scene: { name: 'test' } })).render(<group />).getState().scene
     })
 
@@ -172,7 +171,7 @@ describe('createRoot', () => {
 
     const prop = new THREE.Scene()
 
-    await act(async () => {
+    await React.act(async () => {
       scene = (await root.configure({ scene: prop })).render(<group />).getState().scene
     })
 
@@ -183,7 +182,7 @@ describe('createRoot', () => {
     class Renderer extends THREE.WebGLRenderer {}
 
     let gl: Renderer = null!
-    await act(async () => {
+    await React.act(async () => {
       gl = (await root.configure({ gl: (props) => new Renderer(props) })).render(<group />).getState().gl
     })
 
@@ -201,11 +200,11 @@ describe('createRoot', () => {
       return <meshBasicMaterial key={key++} map={texture} />
     }
 
-    await act(async () => (await createRoot().configure({ linear: true })).render(<Test />))
+    await React.act(async () => (await createRoot().configure({ linear: true })).render(<Test />))
     expect(gl.outputColorSpace).toBe(THREE.LinearSRGBColorSpace)
     expect(texture.colorSpace).toBe(THREE.NoColorSpace)
 
-    await act(async () => (await createRoot().configure({ linear: false })).render(<Test />))
+    await React.act(async () => (await createRoot().configure({ linear: false })).render(<Test />))
     expect(gl.outputColorSpace).toBe(THREE.SRGBColorSpace)
     expect(texture.colorSpace).toBe(THREE.SRGBColorSpace)
   })
@@ -213,12 +212,12 @@ describe('createRoot', () => {
   it('should respect legacy prop', async () => {
     THREE.ColorManagement.enabled = true
 
-    await act(async () => {
+    await React.act(async () => {
       ;(await root.configure({ legacy: true })).render(<group />)
     })
     expect(THREE.ColorManagement.enabled).toBe(false)
 
-    await act(async () => {
+    await React.act(async () => {
       ;(await root.configure({ legacy: false })).render(<group />)
     })
     expect(THREE.ColorManagement.enabled).toBe(true)
@@ -246,7 +245,7 @@ describe('createPortal', () => {
       return <group />
     }
 
-    await act(async () => {
+    await React.act(async () => {
       root.render(
         <>
           <Normal />
@@ -276,12 +275,12 @@ describe('createPortal', () => {
       )
     }
 
-    await act(async () => root.render(<Test key={0} />))
+    await React.act(async () => root.render(<Test key={0} />))
 
     expect(groupHandle).toBeDefined()
     const prevUUID = groupHandle!.uuid
 
-    await act(async () => root.render(<Test key={1} />))
+    await React.act(async () => root.render(<Test key={1} />))
 
     expect(groupHandle).toBeDefined()
     expect(prevUUID).not.toBe(groupHandle!.uuid)

--- a/packages/fiber/tests/renderer.test.tsx
+++ b/packages/fiber/tests/renderer.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as THREE from 'three'
-import { ReconcilerRoot, createRoot, act, extend, ThreeElement, ThreeElements } from '../src/index'
+import { ReconcilerRoot, createRoot, extend, ThreeElement, ThreeElements } from '../src/index'
 import { suspend } from 'suspend-react'
 
 extend(THREE as any)
@@ -42,17 +42,17 @@ describe('renderer', () => {
     root = createRoot(document.createElement('canvas'))
     Mock.instances = []
   })
-  afterEach(async () => act(async () => root.unmount()))
+  afterEach(async () => React.act(async () => root.unmount()))
 
   it('should render empty JSX', async () => {
-    const store = await act(async () => root.render(null))
+    const store = await React.act(async () => root.render(null))
     const { scene } = store.getState()
 
     expect(scene.children.length).toBe(0)
   })
 
   it('should render native elements', async () => {
-    const store = await act(async () => root.render(<group name="native" />))
+    const store = await React.act(async () => root.render(<group name="native" />))
     const { scene } = store.getState()
 
     expect(scene.children.length).toBe(1)
@@ -61,7 +61,7 @@ describe('renderer', () => {
   })
 
   it('should render extended elements', async () => {
-    const store = await act(async () => root.render(<mock name="mock" />))
+    const store = await React.act(async () => root.render(<mock name="mock" />))
     const { scene } = store.getState()
 
     expect(scene.children.length).toBe(1)
@@ -69,7 +69,7 @@ describe('renderer', () => {
     expect(scene.children[0].name).toBe('mock')
 
     const Component = extend(THREE.Mesh)
-    await act(async () => root.render(<Component />))
+    await React.act(async () => root.render(<Component />))
 
     expect(scene.children.length).toBe(1)
     expect(scene.children[0]).toBeInstanceOf(THREE.Mesh)
@@ -78,7 +78,7 @@ describe('renderer', () => {
   it('should render primitives', async () => {
     const object = new THREE.Object3D()
 
-    const store = await act(async () => root.render(<primitive name="primitive" object={object} />))
+    const store = await React.act(async () => root.render(<primitive name="primitive" object={object} />))
     const { scene } = store.getState()
 
     expect(scene.children.length).toBe(1)
@@ -102,14 +102,14 @@ describe('renderer', () => {
       )
     }
 
-    const store = await act(async () => root.render(<Component show={true} />))
+    const store = await React.act(async () => root.render(<Component show={true} />))
     const { scene } = store.getState()
 
     expect(scene.children.length).toBe(1)
     expect(scene.children[0]).toBe(object)
     expect(object.children.length).toBe(2)
 
-    await act(async () => root.render(<Component show={false} />))
+    await React.act(async () => root.render(<Component show={false} />))
 
     expect(scene.children.length).toBe(0)
     expect(object.children.length).toBe(0)
@@ -135,14 +135,14 @@ describe('renderer', () => {
       )
     }
 
-    const store = await act(async () => root.render(<Component primitiveKey="A" />))
+    const store = await React.act(async () => root.render(<Component primitiveKey="A" />))
     const { scene } = store.getState()
 
     expect(scene.children.length).toBe(1)
     expect(scene.children[0]).toBe(object)
     expect(object.children.length).toBe(2)
 
-    await act(async () => root.render(<Component primitiveKey="B" />))
+    await React.act(async () => root.render(<Component primitiveKey="B" />))
 
     expect(scene.children.length).toBe(1)
     expect(scene.children[0]).toBe(object)
@@ -163,7 +163,7 @@ describe('renderer', () => {
       lifecycle.push('render')
       return <group ref={() => void lifecycle.push('ref')} />
     }
-    await act(async () => root.render(<Test />))
+    await React.act(async () => root.render(<Test />))
 
     expect(lifecycle).toStrictEqual([
       'render',
@@ -195,7 +195,7 @@ describe('renderer', () => {
       )
     }
 
-    await act(async () => root.render(<RefTest />))
+    await React.act(async () => root.render(<RefTest />))
 
     expect(immutableRef.current).toBeInstanceOf(THREE.Mesh)
     expect(mutableRef.current).toBeInstanceOf(THREE.Mesh)
@@ -208,7 +208,7 @@ describe('renderer', () => {
         <mesh />
       </group>
     )
-    const store = await act(async () => root.render(<Test />))
+    const store = await React.act(async () => root.render(<Test />))
     const { scene } = store.getState()
 
     expect(scene.children.length).toBe(1)
@@ -233,7 +233,7 @@ describe('renderer', () => {
         </mesh>
       )
     }
-    const store = await act(async () => root.render(<Test />))
+    const store = await React.act(async () => root.render(<Test />))
     const { scene } = store.getState()
 
     expect(scene.children.length).toBe(1)
@@ -250,7 +250,7 @@ describe('renderer', () => {
   })
 
   it('should update props reactively', async () => {
-    const store = await act(async () => root.render(<group />))
+    const store = await React.act(async () => root.render(<group />))
     const { scene } = store.getState()
     const group = scene.children[0] as THREE.Group
 
@@ -258,20 +258,20 @@ describe('renderer', () => {
     expect(group.name).toBe(new THREE.Group().name)
 
     // Set
-    await act(async () => root.render(<group name="one" />))
+    await React.act(async () => root.render(<group name="one" />))
     expect(group.name).toBe('one')
 
     // Update
-    await act(async () => root.render(<group name="two" />))
+    await React.act(async () => root.render(<group name="two" />))
     expect(group.name).toBe('two')
 
     // Unset
-    await act(async () => root.render(<group />))
+    await React.act(async () => root.render(<group />))
     expect(group.name).toBe(new THREE.Group().name)
   })
 
   it('should handle event props reactively', async () => {
-    const store = await act(async () => root.render(<mesh />))
+    const store = await React.act(async () => root.render(<mesh />))
     const { scene, internal } = store.getState()
     const mesh = scene.children[0] as ComponentMesh
     mesh.name = 'current'
@@ -280,17 +280,17 @@ describe('renderer', () => {
     expect(internal.interaction.length).toBe(0)
 
     // Set
-    await act(async () => root.render(<mesh onClick={() => void 0} />))
+    await React.act(async () => root.render(<mesh onClick={() => void 0} />))
     expect(internal.interaction.length).toBe(1)
     expect(internal.interaction).toStrictEqual([mesh])
 
     // Update
-    await act(async () => root.render(<mesh onPointerOver={() => void 0} />))
+    await React.act(async () => root.render(<mesh onPointerOver={() => void 0} />))
     expect(internal.interaction.length).toBe(1)
     expect(internal.interaction).toStrictEqual([mesh])
 
     // Unset
-    await act(async () => root.render(<mesh />))
+    await React.act(async () => root.render(<mesh />))
     expect(internal.interaction.length).toBe(0)
   })
 
@@ -307,7 +307,7 @@ describe('renderer', () => {
     )
 
     // Initial
-    await act(async () => root.render(<Test />))
+    await React.act(async () => root.render(<Test />))
     expect(ref.current!.geometry).toBeInstanceOf(THREE.BufferGeometry)
     expect(ref.current!.geometry).not.toBeInstanceOf(THREE.BoxGeometry)
     expect(ref.current!.material).toBeInstanceOf(THREE.Material)
@@ -317,14 +317,14 @@ describe('renderer', () => {
 
     // Throw on non-array value
     await expectToThrow(
-      async () => await act(async () => root.render(<Test args={{} as any} />)),
+      async () => await React.act(async () => root.render(<Test args={{} as any} />)),
       'R3F: The args prop must be an array!',
     )
 
     // Set
     const geometry1 = new THREE.BoxGeometry()
     const material1 = new THREE.MeshStandardMaterial()
-    await act(async () => root.render(<Test args={[geometry1, material1]} />))
+    await React.act(async () => root.render(<Test args={[geometry1, material1]} />))
     expect(ref.current!.geometry).toBe(geometry1)
     expect(ref.current!.material).toBe(material1)
     expect(ref.current!.children[0]).toBe(child.current)
@@ -333,14 +333,14 @@ describe('renderer', () => {
     // Update
     const geometry2 = new THREE.BoxGeometry()
     const material2 = new THREE.MeshStandardMaterial()
-    await act(async () => root.render(<Test args={[geometry2, material2]} />))
+    await React.act(async () => root.render(<Test args={[geometry2, material2]} />))
     expect(ref.current!.geometry).toBe(geometry2)
     expect(ref.current!.material).toBe(material2)
     expect(ref.current!.children[0]).toBe(child.current)
     expect(ref.current!.userData.attach).toBe(attachedChild.current)
 
     // Unset
-    await act(async () => root.render(<Test />))
+    await React.act(async () => root.render(<Test />))
     expect(ref.current!.geometry).toBeInstanceOf(THREE.BufferGeometry)
     expect(ref.current!.geometry).not.toBeInstanceOf(THREE.BoxGeometry)
     expect(ref.current!.material).toBeInstanceOf(THREE.Material)
@@ -370,25 +370,25 @@ describe('renderer', () => {
     object2.add(child2)
 
     // Initial
-    await act(async () => root.render(<Test object={object1} />))
+    await React.act(async () => root.render(<Test object={object1} />))
     expect(ref.current).toBe(object1)
     expect(ref.current!.children).toStrictEqual([child1, child.current])
     expect(ref.current!.userData.attach).toBe(attachedChild.current)
 
     // Throw on undefined
     await expectToThrow(
-      async () => await act(async () => root.render(<Test object={undefined as any} />)),
+      async () => await React.act(async () => root.render(<Test object={undefined as any} />)),
       "R3F: Primitives without 'object' are invalid!",
     )
 
     // Update
-    await act(async () => root.render(<Test object={object2} />))
+    await React.act(async () => root.render(<Test object={object2} />))
     expect(ref.current).toBe(object2)
     expect(ref.current!.children).toStrictEqual([child2, child.current])
     expect(ref.current!.userData.attach).toBe(attachedChild.current)
 
     // Revert
-    await act(async () => root.render(<Test object={object1} />))
+    await React.act(async () => root.render(<Test object={object1} />))
     expect(ref.current).toBe(object1)
     expect(ref.current!.children).toStrictEqual([child1, child.current])
     expect(ref.current!.userData.attach).toBe(attachedChild.current)
@@ -448,8 +448,8 @@ describe('renderer', () => {
       </mesh>
     )
 
-    const store = await act(async () => root.render(<Test />))
-    await act(async () => root.render(null))
+    const store = await React.act(async () => root.render(<Test />))
+    await React.act(async () => root.render(null))
 
     const { scene, internal } = store.getState()
 
@@ -494,17 +494,17 @@ describe('renderer', () => {
     )
 
     const array = [a, b, c, d]
-    const store = await act(async () => root.render(<Test array={array} />))
+    const store = await React.act(async () => root.render(<Test array={array} />))
     const { scene } = store.getState()
 
     expect(scene.children.map((o) => o.name)).toStrictEqual(array.map((o) => o.name))
 
     const reversedArray = [d, c, b, a]
-    await act(async () => root.render(<Test array={reversedArray} />))
+    await React.act(async () => root.render(<Test array={reversedArray} />))
     expect(scene.children.map((o) => o.name)).toStrictEqual(reversedArray.map((o) => o.name))
 
     const mixedArray = [b, a, d, c]
-    await act(async () => root.render(<Test array={mixedArray} />))
+    await React.act(async () => root.render(<Test array={mixedArray} />))
     expect(scene.children.map((o) => o.name)).toStrictEqual(mixedArray.map((o) => o.name))
   })
 
@@ -529,33 +529,33 @@ describe('renderer', () => {
       </>
     )
 
-    const store = await act(async () => root.render(<Test array={array} />))
+    const store = await React.act(async () => root.render(<Test array={array} />))
     const { scene } = store.getState()
 
     expect(scene.children.length).toBe(0)
     expect(scene.userData.objects.map((o: THREE.Object3D) => o.name)).toStrictEqual(array.map((o) => o.name))
 
     const reversedArray = [d, c, b, a]
-    await act(async () => root.render(<Test array={reversedArray} />))
+    await React.act(async () => root.render(<Test array={reversedArray} />))
     expect(scene.children.length).toBe(0)
     expect(scene.userData.objects.map((o: THREE.Object3D) => o.name)).toStrictEqual(reversedArray.map((o) => o.name))
 
     const mixedArray = [b, a, d, c]
-    await act(async () => root.render(<Test array={mixedArray} />))
+    await React.act(async () => root.render(<Test array={mixedArray} />))
     expect(scene.children.length).toBe(0)
     expect(scene.userData.objects.map((o: THREE.Object3D) => o.name)).toStrictEqual(mixedArray.map((o) => o.name))
   })
 
   it('should gracefully handle text', async () => {
     // Mount
-    await act(async () => root.render(<>one</>))
+    await React.act(async () => root.render(<>one</>))
     // Update
-    await act(async () => root.render(<>two</>))
+    await React.act(async () => root.render(<>two</>))
     // Unmount
-    await act(async () => root.render(<></>))
+    await React.act(async () => root.render(<></>))
     // Suspense
     const Test = () => suspend(async () => <>four</>, [])
-    await act(async () => root.render(<Test />))
+    await React.act(async () => root.render(<Test />))
   })
 
   it('should gracefully interrupt when building up the tree', async () => {
@@ -591,14 +591,14 @@ describe('renderer', () => {
       )
     }
 
-    await act(async () => root.render(<Test />))
+    await React.act(async () => root.render(<Test />))
 
     // Should complete tree before layout-effects fire
     expect(calls).toStrictEqual(['attach', 'useLayoutEffect'])
     expect(lastAttached).toBe(lastMounted)
     expect(Mock.instances).toStrictEqual(['suspense', 'parent', 'child'])
 
-    await act(async () => root.render(<Test reconstruct />))
+    await React.act(async () => root.render(<Test reconstruct />))
 
     expect(calls).toStrictEqual(['attach', 'useLayoutEffect', 'detach', 'attach'])
     expect(lastAttached).toBe(lastMounted)
@@ -614,7 +614,7 @@ describe('renderer', () => {
     }
 
     for (let i = 0; i < 3; i++) {
-      await act(async () =>
+      await React.act(async () =>
         (
           await root.configure()
         ).render(
@@ -654,7 +654,7 @@ describe('renderer', () => {
 
     // Mount unresolved A promise.
     // Fallback should be mounted and nothing else.
-    const store = await act(async () =>
+    const store = await React.act(async () =>
       (
         await root.configure()
       ).render(
@@ -673,8 +673,8 @@ describe('renderer', () => {
 
     // Resolve A promise.
     // A should be mounted and visible and fallback should be unmounted.
-    await act(async () => resolveA())
-    await act(async () =>
+    await React.act(async () => resolveA())
+    await React.act(async () =>
       (
         await root.configure()
       ).render(
@@ -691,7 +691,7 @@ describe('renderer', () => {
 
     // Mount unresolved B promise.
     // A should remain mounted but be invisible, Fallback is mounted, B is unmounted.
-    await act(async () =>
+    await React.act(async () =>
       (
         await root.configure()
       ).render(
@@ -709,8 +709,8 @@ describe('renderer', () => {
 
     // Resolve B promise.
     // B should be mounted and visible, fallback should be unmounted, A also unmounted and unhidden.
-    await act(async () => resolveB())
-    await act(async () =>
+    await React.act(async () => resolveB())
+    await React.act(async () =>
       (
         await root.configure()
       ).render(
@@ -728,7 +728,7 @@ describe('renderer', () => {
 
     // Remount resolved A promise.
     // A should be mounted and visible, B should be unmounted and visible (not hidden), fallback should be unmounted.
-    await act(async () =>
+    await React.act(async () =>
       (
         await root.configure()
       ).render(
@@ -746,13 +746,13 @@ describe('renderer', () => {
   })
 
   it('preserves camera frustum props for perspective', async () => {
-    const store = await act(async () => (await root.configure({ camera: { aspect: 0 } })).render(null))
+    const store = await React.act(async () => (await root.configure({ camera: { aspect: 0 } })).render(null))
     const camera = store.getState().camera as THREE.PerspectiveCamera
     expect(camera.aspect).toBe(0)
   })
 
   it('preserves camera frustum props for orthographic', async () => {
-    const store = await act(async () =>
+    const store = await React.act(async () =>
       (await root.configure({ orthographic: true, camera: { left: 0, right: 0, top: 0, bottom: 0 } })).render(null),
     )
     const camera = store.getState().camera as THREE.OrthographicCamera
@@ -765,19 +765,19 @@ describe('renderer', () => {
   it('resolves conflicting and prefixed elements', async () => {
     extend({ ThreeRandom: THREE.Group })
 
-    const store = await act(async () => root.render(<line />))
+    const store = await React.act(async () => root.render(<line />))
     expect(store.getState().scene.children[0]).toBeInstanceOf(THREE.Line)
 
-    await act(async () => root.render(null))
+    await React.act(async () => root.render(null))
     expect(store.getState().scene.children.length).toBe(0)
 
-    await act(async () => root.render(<threeLine />))
+    await React.act(async () => root.render(<threeLine />))
     expect(store.getState().scene.children[0]).toBeInstanceOf(THREE.Line)
 
-    await act(async () => root.render(null))
+    await React.act(async () => root.render(null))
     expect(store.getState().scene.children.length).toBe(0)
 
-    await act(async () => root.render(<threeRandom />))
+    await React.act(async () => root.render(<threeRandom />))
     expect(store.getState().scene.children[0]).toBeInstanceOf(THREE.Group)
   })
 
@@ -798,7 +798,7 @@ describe('renderer', () => {
 
     // Initial render with 4 values
     const initialValues = [1, 2, 3, 4]
-    const store = await act(async () => root.render(<Test values={initialValues} />))
+    const store = await React.act(async () => root.render(<Test values={initialValues} />))
     const { scene } = store.getState()
 
     // Check initial state
@@ -808,7 +808,7 @@ describe('renderer', () => {
 
     // Update with one less value and different order
     const updatedValues = [3, 1, 4]
-    await act(async () => root.render(<Test values={updatedValues} />))
+    await React.act(async () => root.render(<Test values={updatedValues} />))
 
     // Check that the scene has exactly the meshes we expect
     expect(scene.children.length).toBe(3)
@@ -824,7 +824,7 @@ describe('renderer', () => {
 
     // Update with different order again
     const reorderedValues = [4, 1]
-    await act(async () => root.render(<Test values={reorderedValues} />))
+    await React.act(async () => root.render(<Test values={reorderedValues} />))
 
     // Check final state
     expect(scene.children.length).toBe(2)

--- a/packages/fiber/tests/utils.test.ts
+++ b/packages/fiber/tests/utils.test.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three'
-import { type RootStore, type Instance, act, createRoot } from '../src'
+import { act } from 'react'
+import { type RootStore, type Instance, createRoot } from '../src'
 import {
   is,
   dispose,

--- a/packages/test-renderer/src/__tests__/RTTR.core.test.tsx
+++ b/packages/test-renderer/src/__tests__/RTTR.core.test.tsx
@@ -195,7 +195,7 @@ describe('ReactThreeTestRenderer Core', () => {
 
     const instance = renderer.getInstance() as Instance
 
-    await ReactThreeTestRenderer.act(async () => {
+    await React.act(async () => {
       instance.handleStandard()
     })
 

--- a/packages/test-renderer/src/__tests__/RTTR.hooks.test.tsx
+++ b/packages/test-renderer/src/__tests__/RTTR.hooks.test.tsx
@@ -71,7 +71,7 @@ describe('ReactThreeTestRenderer Hooks', () => {
 
     expect(renderer.scene.children[0].instance.rotation.x).toEqual(0)
 
-    await ReactThreeTestRenderer.act(async () => {
+    await React.act(async () => {
       await renderer.advanceFrames(2, 1)
     })
 

--- a/packages/test-renderer/src/helpers/waitFor.ts
+++ b/packages/test-renderer/src/helpers/waitFor.ts
@@ -1,4 +1,4 @@
-import { act } from '@react-three/fiber'
+import { act } from 'react'
 
 export interface WaitOptions {
   interval?: number

--- a/packages/test-renderer/src/index.tsx
+++ b/packages/test-renderer/src/index.tsx
@@ -35,13 +35,13 @@ const create = async (element: React.ReactNode, options?: Partial<CreateOptions>
 
   const _store = mockRoots.get(canvas)!.store
 
-  await act(async () => _root.render(element))
+  await React.act(async () => _root.render(element))
   const _scene = (_store.getState().scene as Instance<THREE.Scene>['object']).__r3f!
 
   return {
     scene: wrapFiber(_scene),
     async unmount() {
-      await act(async () => {
+      await React.act(async () => {
         _root.unmount()
       })
     },
@@ -59,7 +59,7 @@ const create = async (element: React.ReactNode, options?: Partial<CreateOptions>
     async update(newElement: React.ReactNode) {
       if (!mockRoots.has(canvas)) return console.warn('RTTR: attempted to update an unmounted root!')
 
-      await act(async () => {
+      await React.act(async () => {
         _root.render(newElement)
       })
     },
@@ -69,7 +69,7 @@ const create = async (element: React.ReactNode, options?: Partial<CreateOptions>
     toGraph() {
       return toGraph(_scene)
     },
-    fireEvent: createEventFirer(act, _store),
+    fireEvent: createEventFirer(React.act, _store),
     async advanceFrames(frames: number, delta: number | number[] = 1) {
       const state = _store.getState()
       const storeSubscribers = state.internal.subscribers


### PR DESCRIPTION
Follow-up to #3513. Uses React's own `act` instead of our deprecated re-export for testing.