### PR TITLE
experiment(types): declare global JSX for IntelliSense

### DIFF
--- a/packages/fiber/src/three-types.ts
+++ b/packages/fiber/src/three-types.ts
@@ -68,6 +68,12 @@ export interface ThreeElements extends Omit<ThreeElementsImpl, 'audio' | 'source
   threePath: ThreeElementsImpl['path']
 }
 
+declare global {
+  namespace JSX {
+    interface IntrinsicElements extends ThreeElements {}
+  }
+}
+
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements extends ThreeElements {}


### PR DESCRIPTION
Experimenting with restoring global `JSX` for an IntelliSense problem on native.