### PR TITLE
Fix extra rerenders of the GLView on updating  parent View pan getrur…

### DIFF
--- a/packages/fiber/src/native/Canvas.tsx
+++ b/packages/fiber/src/native/Canvas.tsx
@@ -45,6 +45,7 @@ function CanvasImpl({
   onPointerMissed,
   onCreated,
   ref,
+  pointerEvents,
   ...props
 }: CanvasProps) {
   // Create a known catalogue of Threejs-native elements
@@ -224,10 +225,11 @@ function CanvasImpl({
   }, [canvas])
 
   return (
-    <_View {...props} ref={viewRef} onLayout={onLayout} style={{ flex: 1, ...style }} {...bind}>
+    <_View {...props} ref={viewRef} onLayout={onLayout} style={{ flex: 1, ...style }}>
       {width > 0 && (
         <GLView msaaSamples={antialias ? 4 : 0} onContextCreate={onContextCreate} style={StyleSheet.absoluteFill} />
       )}
+      <_View style={StyleSheet.absoluteFill} pointerEvents={pointerEvents} {...bind} />
     </_View>
   )
 }


### PR DESCRIPTION
Env: 
new arch enabled: +
platform: iOS - always, Android - maybe in some cases.
react: 19.0.0
react-dom: 19.0.0
react-native: 0.79.2
threejs: tested on 0.150.1, 0.176.0, 0.177.0
react-three/fiber: 9.1.2

When assigning a gesture binding, the parent component is redrawn. This causes the canvas to be redrawn and additional reinitialization of the gl context occurs, which in turn interrupts the correct execution of the gl program.
This causes errors in the following places in the threejs library file node_modules/three/build/three.cjs:

```JS
	function onFirstUse( self ) {

		// check for link errors
		if ( renderer.debug.checkShaderErrors ) {

			const programLog = gl.getProgramInfoLog( program ).trim(); // <<<<<<<<<<<<<
			// ...
	}
```

```JS
	function drawBuffers( renderTarget, framebuffer ) {

		let drawBuffers = defaultDrawbuffers;

		let needsUpdate = false;

		if ( renderTarget ) {

			drawBuffers = currentDrawbuffers.get( framebuffer );

			if ( drawBuffers === undefined ) {

				drawBuffers = [];
				currentDrawbuffers.set( framebuffer, drawBuffers ); // <<<<<<<<<<<<<

			}
			// ...
    }
```




Same issue:  https://github.com/expo/expo/issues/33117
Linked issue: #3333