### PR TITLE
chore: export flushSync

### DIFF
--- a/packages/fiber/src/core/index.tsx
+++ b/packages/fiber/src/core/index.tsx
@@ -23,7 +23,7 @@ export type {
 } from './reconciler'
 export { extend, reconciler } from './reconciler'
 export type { ReconcilerRoot, GLProps, CameraProps, RenderProps, InjectState } from './renderer'
-export { _roots, createRoot, unmountComponentAtNode, createPortal } from './renderer'
+export { _roots, createRoot, unmountComponentAtNode, createPortal, flushSync } from './renderer'
 export type {
   Subscription,
   Dpr,

--- a/packages/fiber/tests/__snapshots__/canvas.native.test.tsx.snap
+++ b/packages/fiber/tests/__snapshots__/canvas.native.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`native Canvas should correctly mount 1`] = `"{\\"type\\":\\"view\\",\\"props\\":{\\"style\\":{\\"flex\\":1}},\\"children\\":[{\\"type\\":\\"glview\\",\\"props\\":{\\"msaaSamples\\":4,\\"style\\":{\\"position\\":\\"absolute\\",\\"left\\":0,\\"right\\":0,\\"top\\":0,\\"bottom\\":0}},\\"children\\":[]}]}"`;
+exports[`native Canvas should correctly mount 1`] = `"{\\"type\\":\\"view\\",\\"props\\":{\\"style\\":{\\"flex\\":1}},\\"children\\":[{\\"type\\":\\"glview\\",\\"props\\":{\\"msaaSamples\\":4,\\"style\\":{\\"position\\":\\"absolute\\",\\"left\\":0,\\"right\\":0,\\"top\\":0,\\"bottom\\":0}},\\"children\\":[]},{\\"type\\":\\"view\\",\\"props\\":{\\"style\\":{\\"position\\":\\"absolute\\",\\"left\\":0,\\"right\\":0,\\"top\\":0,\\"bottom\\":0}},\\"children\\":[]}]}"`;

--- a/packages/fiber/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/fiber/tests/__snapshots__/index.test.tsx.snap
@@ -81,6 +81,7 @@ Array [
   "events",
   "extend",
   "flushGlobalEffects",
+  "flushSync",
   "getRootState",
   "invalidate",
   "reconciler",


### PR DESCRIPTION
The export got removed from v9, presumably by accident. This adds it back.