### PR TITLE
feat: Add GLTFLoader integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "jest": "^29.3.1",
     "jest-cli": "^27.5.1",
     "lint-staged": "^12.3.7",
+    "node-fetch": "2",
     "prettier": "^2.6.1",
     "pretty-quick": "^3.1.3",
     "react": "^18.0.0",

--- a/packages/shared/setupTests.ts
+++ b/packages/shared/setupTests.ts
@@ -19,3 +19,8 @@ global.console.error = (...args: any[]) => {
   if (args.join('').startsWith('Warning')) return
   return logError(...args)
 }
+
+const { default: fetch, Request, Response } = require('node-fetch')
+global.fetch = fetch
+global.Request = Request
+global.Response = Response

--- a/yarn.lock
+++ b/yarn.lock
@@ -8074,6 +8074,13 @@ node-dir@^0.1.17:
   dependencies:
     minimatch "^3.0.2"
 
+node-fetch@2:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-fetch@^2.2.0, node-fetch@^2.6.0:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"


### PR DESCRIPTION
This PR is made in attempt to remove the following blocker. #3085 
There is an existing PR #3086 and this is to solve the blocker on that pr.

This commit adds an integration test for `useLoader` with `GLTFLoader`.

The test verifies that the loader can correctly parse a binary GLB file. To achieve this in a Node.js test environment, the following changes were made:

- `node-fetch` is added as a dev dependency to provide `fetch`, `Request`, and `Response` objects.
- These are polyfilled globally in the Jest setup file for all tests to use.
- The test mocks the `fetch` call to return a minimal, valid GLB file as an `ArrayBuffer`.

This approach was chosen after discovering that the native test environment does not support the features required for a full native integration test.