### PR TITLE
docs: update installation guide with iOS simulator note

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -171,6 +171,9 @@ R3F's API is completely x-platform, so you can use [events](/api/events) and [ho
 > [!NOTE]
 > Make sure to import from `@react-three/fiber/native` or `@react-three/drei/native` for correct IntelliSense and platform-specific abstractions.
 
+> [!NOTE]
+> iOS simulators often have incomplete or unreliable OpenGL ES support, which can cause EXC_BAD_ACCESS crashes when rendering 3D content. Always test on a physical iOS device (iPhone/iPad running iOS 16 or later) to ensure stable WebGL rendering.
+
 ```jsx
 import { Suspense } from 'react'
 import { Canvas } from '@react-three/fiber/native'


### PR DESCRIPTION
I was unable to get this to render on the iOS Simulator. I kept encountering `EXC_BAD_ACCESS` crashes.
After investigating, I discovered that iOS Simulators provide incomplete/unreliable support for OpenGL ES, which causes issues with WebGL rendering. So, I suggest adding a note to recommend testing on a physical iOS device.