### PR TITLE
Improve Attribute Resolution Logic for Non-Three.js Properties

### DIFF
--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -258,9 +258,16 @@ export function resolve(root: any, key: string): { root: any; key: string; targe
   let target: unknown = root[key]
   if (!key.includes('-')) return { root, key, target }
 
+  const chain = key.split('-')
+
+  // If the first part of the chain is not a property of the root, there is no need to continue processing the remaining chained queries.
+  if (!root.hasOwnProperty(chain[0])) {
+    return { root, key, target }
+  }
+
   // Resolve pierced target
   target = root
-  for (const part of key.split('-')) {
+  for (const part of chain) {
     key = part
     root = target
     target = (target as any)?.[key]

--- a/packages/fiber/tests/utils.test.ts
+++ b/packages/fiber/tests/utils.test.ts
@@ -205,6 +205,15 @@ describe('resolve', () => {
     expect(key).toBe('bar')
     expect(target).toBe(root[key])
   })
+
+  it ('should return the original root and key when the first part of the chain is not a property of the root', () => {
+    const object = { foo: { bar: 1 } }
+    const { root, key, target } = resolve(object, 'foo2-bar')
+
+    expect(root).toBe(object)
+    expect(key).toBe('foo2-bar')
+    expect(target).toBe(undefined)
+  })
 })
 
 describe('attach / detach', () => {


### PR DESCRIPTION
I noticed that there was a previous commit which left a TODO regarding this issue:
https://github.com/pmndrs/react-three-fiber/pull/3485/commits/645410ef2ceea38c1a45054227eafc9cac692857#diff-861bbdd4c9edaf2af00e9759390a2c40190a4a5c9342272be56751a6533ef323R266

Currently, when using attributes in the `aaa-bbb` format on a node, the `resolve` function parses them as `root['aaa']['bbb']`. This works well for nested properties on Three.js objects. However, in certain scenarios, if the attribute provided by the user is not a nested property on a Three.js object, it can lead to exceptions.

For example, some libraries that provide React inspector functionality (such as [react-dev-inspector](https://github.com/zthxxx/react-dev-inspector)) add attributes like `data-inspector-line` or `data-inspector-relative-path` to all nodes at compile time to indicate which source file the element originates from. Although nodes within a Canvas are not actually rendered to the DOM, this can still cause conflicts at runtime.

Would a better approach be: for attributes in the `aaa-bbb` format, if `aaa` is indeed a property of `root`, we proceed with the original logic. If `aaa` is not a property of `root`, we simply preserve the original attribute name as is?
