### PR TITLE
fix: improve resolution of dashed prop names

### DIFF
--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -424,6 +424,11 @@ export function applyProps<T = any>(object: Instance<T>['object'], props: Instan
 
     let { root, key, target } = resolve(object, prop)
 
+    // Throw an error if we attempted to set a pierced prop to a non-object
+    if (target === undefined && (typeof root !== 'object' || root === null)) {
+      throw Error(`R3F: Cannot set "${prop}". Ensure it is an object before setting "${key}".`)
+    }
+
     // Layers must be written to the mask property
     if (target instanceof THREE.Layers && value instanceof THREE.Layers) {
       target.mask = value.mask

--- a/packages/fiber/tests/utils.test.ts
+++ b/packages/fiber/tests/utils.test.ts
@@ -372,6 +372,7 @@ describe('applyProps', () => {
     const target = new THREE.Object3D()
     applyProps(target, {})
     expect(() => applyProps(target, { ['foo-bar']: 1 })).not.toThrow()
+    expect((target as any)['foo-bar']).toBe(undefined)
   })
 
   it('should throw when applying unknown props due to non-object intermediate', () => {


### PR DESCRIPTION
Fixes an issue with unknown props causing errors when applied to Three.js objects.
