### PR TITLE
docs: correct outdated JSX namespace link (fixes #3582)

### DIFF
--- a/docs/API/objects.mdx
+++ b/docs/API/objects.mdx
@@ -191,7 +191,7 @@ return (
     <transformControls />
 ```
 
-If you're using TypeScript, you'll also need to [extend the JSX namespace](/tutorials/typescript#extending-jsx-intrinsic-elements).
+If you're using TypeScript, you'll also need to [extend the JSX namespace](/tutorials/v9-migration-guide#threeelements).
 
 ## Disposal
 


### PR DESCRIPTION
The link for extending the JSX namespace in objects.mdx was pointing to a non-existent tutorial page.

This change updates the link to point to the #threeelements anchor in the v9 migration guide. This page speaks on Three's interface and contains a direct link to the relevant tutorial for extening the JSX namespace.