### PR TITLE
fix: pass DevTools config through createReconciler to fix React DevTools

### DIFF
--- a/packages/fiber/src/core/reconciler.tsx
+++ b/packages/fiber/src/core/reconciler.tsx
@@ -56,6 +56,7 @@ function createReconciler<
 ): Reconciler.Reconciler<Container, Instance, TextInstance, SuspenseInstance, FormInstance, PublicInstance> {
   const reconciler = Reconciler(config as any)
 
+  // @ts-ignore DefinitelyTyped is not up to date
   reconciler.injectIntoDevTools()
 
   return reconciler as any
@@ -467,8 +468,6 @@ export const reconciler = /* @__PURE__ */ createReconciler<
   HostConfig['noTimeout'],
   HostConfig['TransitionStatus']
 >({
-  rendererPackageName: '@react-three/fiber',
-  rendererVersion: packageData.version,
   isPrimaryRenderer: false,
   warnsIfNotActing: false,
   supportsMutation: true,
@@ -600,4 +599,7 @@ export const reconciler = /* @__PURE__ */ createReconciler<
     }
   },
   resetFormInstance() {},
+  // @ts-ignore DefinitelyTyped is not up to date
+  rendererPackageName: '@react-three/fiber',
+  rendererVersion: packageData.version,
 })


### PR DESCRIPTION
Fix: #3593 

Since react 19 and our v9, the React DevTools didn't work in the context of r3f.
We'd get things like
 
<img width="auto" height="400" alt="noProfilingRecorded" src="https://github.com/user-attachments/assets/6438caeb-9c44-42ce-b7fd-a1e593f136ee" />

And this error
<img width="424" height="59" alt="504814709-f09fc062-319a-43ef-98ec-08121c594904" src="https://github.com/user-attachments/assets/a2385083-25a5-4054-b105-69350a9b9f31" />

After some digging, turns out injectIntoDevTools is not the correct way to pass the DevTools config anymore. It changed in that PR https://github.com/facebook/react/pull/30522/files

bundleType is handled automatically for us so we just have to move `rendererPackageName` and `rendererVersion` to the config passed to `createReconciler`.

I believe that DefinitelyTyped is not up to date yet so my PR won't pass ts check I guess https://github.com/search?q=repo%3ADefinitelyTyped%2FDefinitelyTyped%20rendererPackageName&type=code
I'll check how can this be updated.

After this change I can use the DevTools again
<img width="2243" height="1340" alt="soda" src="https://github.com/user-attachments/assets/80875ae4-228d-4338-879f-0c8f6d3d2758" />

