### PR TITLE
[v10] Prevent elapsedTime from being reset unescessarily

### DIFF
--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -253,12 +253,13 @@ export const createStore = (
         const clock = get().clock
 
         // if frameloop === "never" clock.elapsedTime is updated using advance(timestamp)
-        clock.stop()
-        clock.elapsedTime = 0
-
-        if (frameloop !== 'never') {
-          clock.start()
+        if (frameloop === 'never') {
+          clock.stop()
           clock.elapsedTime = 0
+        }
+
+        if (frameloop !== 'never' && !clock.running) {
+          clock.start()
         }
         set(() => ({ frameloop }))
       },


### PR DESCRIPTION
I don't think that setFrameLoop should affect elapsedTime.

In my use case, I temporarily set frameloop to `always` before reverting back to `demand`, with the current version it mess the elapsedTime.

This PR only reset elapsedTime when using never, which seem to be the initial intended use case.