### PR TITLE
Fix-portal-container-updates

### DIFF
--- a/example/src/demos/default/PortalTest.tsx
+++ b/example/src/demos/default/PortalTest.tsx
@@ -1,0 +1,54 @@
+import { Canvas, createPortal, useThree } from '@react-three/fiber'
+import { Suspense, useRef } from 'react'
+import { OrbitControls, PerspectiveCamera } from '@react-three/drei'
+import * as THREE from 'three'
+import { Mesh, Group } from 'three'
+
+export default function App() {
+  return (
+    <Canvas renderer>
+      <ambientLight intensity={Math.PI} />
+      <Suspense fallback={null}>
+        <PortalTestScene />
+      </Suspense>
+    </Canvas>
+  )
+}
+
+function PortalTestScene() {
+  const { camera } = useThree()
+  // console.log('original camera', camera)
+  const cubeRef = useRef<Mesh>(null)
+  // console.log('cubeRef', cubeRef.current)
+  const groupRef = useRef<Group>(null)
+  // console.log('groupRef', groupRef.current)
+  const cameraRef = useRef<THREE.PerspectiveCamera>(null)
+  // console.log('portal camera', cameraRef.current)
+
+  return (
+    <>
+      {/* Main scene content */}
+      <color attach="background" args={['#1e1e1e']} />
+      <ambientLight intensity={0.5} />
+      <directionalLight position={[5, 5, 5]} intensity={1} />
+      <mesh position={[0, 0, -5]}>
+        <boxGeometry args={[1, 1, 1]} />
+        <meshStandardMaterial color="orange" />
+      </mesh>
+
+      {/* Camera setup */}
+      <PerspectiveCamera ref={cameraRef} makeDefault position={[0, 0, 2]} fov={75} />
+
+      <OrbitControls />
+
+      {/* Cube bound to camera - createPortal now accepts refs directly! */}
+      {createPortal(
+        <mesh position={[0, 0, -2]} scale={0.2} ref={cubeRef}>
+          <boxGeometry />
+          <meshStandardMaterial color="hotpink" side={THREE.DoubleSide} />
+        </mesh>,
+        camera,
+      )}
+    </>
+  )
+}

--- a/example/src/demos/index.tsx
+++ b/example/src/demos/index.tsx
@@ -14,6 +14,7 @@ const Inject = { Component: lazy(() => import('./default/Inject')) }
 const Layers = { Component: lazy(() => import('./default/Layers')) }
 const MultiMaterial = { Component: lazy(() => import('./default/MultiMaterial')) }
 const MultiRender = { Component: lazy(() => import('./default/MultiRender')) }
+const PortalTest = { Component: lazy(() => import('./default/PortalTest')) }
 const ResetProps = { Component: lazy(() => import('./default/ResetProps')) }
 const Selection = { Component: lazy(() => import('./default/Selection')) }
 const StopPropagation = { Component: lazy(() => import('./default/StopPropagation')) }
@@ -68,6 +69,7 @@ export {
   Test,
   Viewcube,
   ViewTracking,
+  PortalTest,
   // Legacy
   EventPriority,
   Lines,

--- a/example/src/demos/webgpu/WebGPU.tsx
+++ b/example/src/demos/webgpu/WebGPU.tsx
@@ -1,7 +1,7 @@
 import { Canvas, extend, type ThreeToJSXElements, useFrame, type ThreeElements } from '@react-three/fiber'
-import { useNodes } from '@react-three/fiber/webgpu'
 import { easing } from 'maath'
-import { useMemo, useState } from 'react'
+import * as React from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { color, mix, positionLocal, sin, time, uniform, vec3 } from 'three/tsl'
 
 function Plane(props: ThreeElements['mesh']) {
@@ -30,6 +30,7 @@ function Plane(props: ThreeElements['mesh']) {
 }
 
 export default function App() {
+  const meshRef = useRef<React.ComponentRef<'mesh'>>(null)
   return (
     <Canvas renderer>
       <ambientLight intensity={Math.PI} />


### PR DESCRIPTION
closes react 19 (v9) createPortal bug
Fixes #3486

Also added the ability to pass a ref to createPoral with a watch if the object doest exist yet (groups, scenes, etc)

Added test and example based on the issue