### PR TITLE
docs: replace deprecated miniplex with koota in AwesomeR3F

### DIFF
--- a/AwesomeR3F.md
+++ b/AwesomeR3F.md
@@ -89,7 +89,7 @@ Tools for creating custom shaders and materials.
 Helpful utility libraries for common tasks.
 
 - [`maath`](https://github.com/pmndrs/maath) - A kitchen sink for math helpers
-- [`miniplex`](https://github.com/hmans/miniplex) - ECS (entity management system)
+- [`koota`](https://github.com/pmndrs/koota) - ECS (entity management system)
 
 ## Editors & Dev Tools
 


### PR DESCRIPTION
## What

Replaces `miniplex` with `koota` in the Utilities section of AwesomeR3F.md.

`miniplex` has not been maintained for years (as noted by @krispya in https://github.com/pmndrs/react-three-fiber/issues/3642#issuecomment-3877099226). `koota` is the actively maintained pmndrs ECS library and the natural replacement.

## Changes

- `AwesomeR3F.md`: replace `miniplex` → `koota`, update GitHub link to `pmndrs/koota`

Closes #3642