### PR TITLE
fix(fiber): warn in dev when priority > 0 useFrame disables auto-render

### DIFF
--- a/packages/fiber/src/core/hooks.tsx
+++ b/packages/fiber/src/core/hooks.tsx
@@ -39,8 +39,37 @@ export function useThree<T = RootState>(
 }
 
 /**
- * Executes a callback before render in a shared frame loop.
- * Can order effects with render priority or manually render with a positive priority.
+ * Executes a callback in a shared frame loop.
+ *
+ * @param callback - Function called every frame with `(state, delta, xrFrame)`.
+ * @param renderPriority - Execution order and render ownership (default: `0`).
+ *
+ * **Priority behaviour:**
+ * - `priority = 0` (default): callback runs before R3F's automatic `gl.render()`.
+ *   The scene is rendered automatically after all priority-0 callbacks complete.
+ * - `priority > 0`: callback runs **after** all priority-0 callbacks.
+ *   **Automatic rendering is disabled** — you must call `gl.render(scene, camera)`
+ *   manually inside your callback. This is required for multi-camera setups
+ *   (e.g. minimaps, portals, reflections).
+ *
+ * @example
+ * ```tsx
+ * // Priority 0 — scene updates only, auto-render handles the rest
+ * useFrame(({ clock }) => {
+ *   meshRef.current.rotation.y = clock.elapsedTime
+ * })
+ *
+ * // Priority > 0 — manual render required (e.g. minimap)
+ * useFrame(({ gl, scene, camera }) => {
+ *   gl.render(scene, camera)          // ← main render (required!)
+ *   gl.autoClear = false
+ *   gl.setScissorTest(true)
+ *   gl.render(scene, minimapCamera)   // ← extra pass
+ *   gl.setScissorTest(false)
+ *   gl.autoClear = true
+ * }, 1)
+ * ```
+ *
  * @see https://docs.pmnd.rs/react-three-fiber/api/hooks#useframe
  */
 export function useFrame(callback: RenderCallback, renderPriority: number = 0): null {

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -67,6 +67,7 @@ export interface InternalState {
   active: boolean
   priority: number
   frames: number
+  warnedUseFramePriority: boolean
   subscribe: (callback: React.RefObject<RenderCallback>, priority: number, store: RootStore) => () => void
 }
 
@@ -277,6 +278,7 @@ export const createStore = (
         active: false,
         frames: 0,
         priority: 0,
+        warnedUseFramePriority: false,
         subscribe: (ref: React.RefObject<RenderCallback>, priority: number, store: RootStore) => {
           const internal = get().internal
           // If this subscription was given a priority, it takes rendering into its own hands
@@ -287,12 +289,13 @@ export const createStore = (
           // Warn in development when a positive-priority subscriber is registered.
           // These subscribers disable R3F's automatic gl.render(scene, camera) call,
           // so the user must call it manually inside their useFrame callback.
-          if (process.env.NODE_ENV !== 'production' && priority > 0) {
+          if (process.env.NODE_ENV !== 'production' && priority > 0 && !internal.warnedUseFramePriority) {
             console.warn(
               `R3F: useFrame with priority=${priority} disables automatic rendering.\n` +
                 `You must call gl.render(scene, camera) manually inside your useFrame callback.\n` +
-                `See: https://docs.pmnd.rs/react-three-fiber/api/hooks#useFame`,
+                `See: https://docs.pmnd.rs/react-three-fiber/api/hooks#useFrame`,
             )
+            internal.warnedUseFramePriority = true
           }
           internal.subscribers.push({ ref, priority, store })
           // Register subscriber and sort layers from lowest to highest, meaning,

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -284,6 +284,16 @@ export const createStore = (
           // As long as this flag is positive there can be no internal rendering at all
           // because there could be multiple render subscriptions
           internal.priority = internal.priority + (priority > 0 ? 1 : 0)
+          // Warn in development when a positive-priority subscriber is registered.
+          // These subscribers disable R3F's automatic gl.render(scene, camera) call,
+          // so the user must call it manually inside their useFrame callback.
+          if (process.env.NODE_ENV !== 'production' && priority > 0) {
+            console.warn(
+              `R3F: useFrame with priority=${priority} disables automatic rendering.\n` +
+                `You must call gl.render(scene, camera) manually inside your useFrame callback.\n` +
+                `See: https://docs.pmnd.rs/react-three-fiber/api/hooks#useFame`,
+            )
+          }
           internal.subscribers.push({ ref, priority, store })
           // Register subscriber and sort layers from lowest to highest, meaning,
           // highest priority renders last (on top of the other frames)


### PR DESCRIPTION
## Problem

When `useFrame(callback, priority)` is called with `priority > 0`, R3F silently disables its automatic `gl.render(scene, camera)` call. The user must call it manually inside their callback — but this contract is not communicated anywhere.

**Result:** completely blank canvas, no error, no warning in console.

The existing source comment already describes the intent:
```
// If this subscription was given a priority, it takes rendering into its own hands
// For that reason we switch off automatic rendering and increase the manual flag
```

But the *developer* never sees this comment.

Related issue: #3692

## Changes

### `store.ts` — dev warning on subscription

```ts
if (process.env.NODE_ENV !== 'production' && priority > 0) {
  console.warn(
    `R3F: useFrame with priority=${priority} disables automatic rendering.\n` +
    `You must call gl.render(scene, camera) manually inside your useFrame callback.\n` +
    `See: https://docs.pmnd.rs/react-three-fiber/api/hooks#useFrame`
  )
}
```

The warning fires once per subscription (at mount), not every frame. It is stripped in production builds.

### `hooks.tsx` — expanded JSDoc for `useFrame`

Documents the priority behaviour and provides a working multi-camera example (minimap pattern) directly in the type signature so IDEs surface it on hover.

## Behaviour

**Before:**
```tsx
useFrame(({ gl, scene }) => {
  gl.render(scene, minimapCam) // main view silently gone — no indication why
}, 1)
```

**After (dev console):**
```
⚠ R3F: useFrame with priority=1 disables automatic rendering.
  You must call gl.render(scene, camera) manually inside your useFrame callback.
  See: https://docs.pmnd.rs/react-three-fiber/api/hooks#useFrame
```

## Alternatives considered

| Option | Verdict |
|--------|---------|
| New `useAfterRender` hook | Better DX but breaking API addition |
| TypeScript `manualRender: true` opt-in | Breaking API change |
| Docs update only | Doesn't help users who never read docs |
| **Dev warning (this PR)** | **Non-breaking, zero runtime cost in prod, actionable** |

## Testing

No existing tests cover this behaviour. The change is a dev-only `console.warn` with no effect on render logic.