### PR TITLE
Fix broken link on "Performance pitfalls" documentation page

### DIFF
--- a/docs/advanced/scaling-performance.mdx
+++ b/docs/advanced/scaling-performance.mdx
@@ -363,4 +363,4 @@ It simulates heavy load by creating hundreds of THREE.TextGeometry instances (51
   />
 </p>
 
-For more on how to use this API, see [use startTransition for expensive ops](/docs/advanced/pitfalls#use-starttransition-for-expensive-ops).
+For more on how to use this API, see [use startTransition for expensive ops](/advanced/pitfalls#✅-use-starttransition-for-expensive-ops).


### PR DESCRIPTION
This tiny PR fixes the broken link I discovered on the "[Performance pitfalls](https://r3f.docs.pmnd.rs/advanced/pitfalls#use-starttransition-for-expensive-ops)" page.