### PR TITLE
chore: move eslint rules from parserOptions to top-level rules (#3706)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,27 +18,7 @@
       "jsx": true
     },
     "ecmaVersion": 2018,
-    "sourceType": "module",
-    "rules": {
-      "curly": ["warn", "multi-line", "consistent"],
-      "no-console": "off",
-      "no-empty-pattern": "warn",
-      "no-duplicate-imports": "error",
-      "import/no-unresolved": "off",
-      "import/export": "error",
-      // https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md#eslint-plugin-import
-      // We recommend you do not use the following import/* rules, as TypeScript provides the same checks as part of standard type checking:
-      "import/named": "off",
-      "import/namespace": "off",
-      "import/default": "off",
-      "no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
-      "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
-      "@typescript-eslint/no-use-before-define": "off",
-      "@typescript-eslint/no-empty-function": "off",
-      "@typescript-eslint/no-empty-interface": "off",
-      "@typescript-eslint/no-explicit-any": "off",
-      "jest/consistent-test-it": ["error", { "fn": "it", "withinDescribe": "it" }]
-    }
+    "sourceType": "module"
   },
   "settings": {
     "react": {
@@ -68,9 +48,22 @@
     }
   ],
   "rules": {
+    "curly": ["warn", "multi-line", "consistent"],
+    "no-console": "off",
+    "no-empty-pattern": "warn",
+    "no-duplicate-imports": "error",
     "import/no-unresolved": "off",
+    "import/export": "error",
     "import/named": "off",
     "import/namespace": "off",
-    "import/no-named-as-default-member": "off"
+    "import/default": "off",
+    "import/no-named-as-default-member": "off",
+    "no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
+    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
+    "@typescript-eslint/no-use-before-define": "off",
+    "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-empty-interface": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "jest/consistent-test-it": ["error", { "fn": "it", "withinDescribe": "it" }]
   }
 }

--- a/packages/test-renderer/src/__tests__/RTTR.events.test.tsx
+++ b/packages/test-renderer/src/__tests__/RTTR.events.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 
-import ReactThreeTestRenderer from '../index'
-import type { ReactThreeTest } from '../index'
+import ReactThreeTestRenderer, { type ReactThreeTest } from '../index'
 
 describe('ReactThreeTestRenderer Events', () => {
   it('should fire an event', async () => {


### PR DESCRIPTION
Fixes #3706