### PR TITLE
docs: fix typos and documentation consistency

### DIFF
--- a/docs/getting-started/community-r3f-components.mdx
+++ b/docs/getting-started/community-r3f-components.mdx
@@ -4,7 +4,7 @@ description: This page showcases some React Three Fiber/r3f community components
 nav: 4
 ---
 
-If you'd like to list new community components, please make a PR to [this doc](https://github.com/pmndrs/react-three-fiber/tree/master/docs/getting-started/community-r3f-components.mdx) file. It showcases some r3f community components that have not been merged to to the [drei](http://drei.docs.pmnd.rs) components collection or to another [pmndrs](https://github.com/pmndrs) project.
+If you'd like to list new community components, please make a PR to [this doc](https://github.com/pmndrs/react-three-fiber/tree/master/docs/getting-started/community-r3f-components.mdx) file. It showcases some r3f community components that have not been merged to the [drei](http://drei.docs.pmnd.rs) components collection or to another [pmndrs](https://github.com/pmndrs) project.
 
 ## R3F community components 
 

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -167,11 +167,11 @@ Some helpful material:
   <img src="../banner-journey.jpg" />
 </a>
 
-## Eco system
+## Ecosystem
 
-There is a vibrant and extensive eco system around three-fiber, full of libraries, helpers and abstractions.
+There is a vibrant and extensive ecosystem around three-fiber, full of libraries, helpers and abstractions.
 
-- [`@react-three/drei`](https://github.com/pmndrs/drei) &ndash; useful helpers, this is an eco system in itself
+- [`@react-three/drei`](https://github.com/pmndrs/drei) &ndash; useful helpers, this is an ecosystem in itself
 - [`@react-three/gltfjsx`](https://github.com/pmndrs/gltfjsx) &ndash; turns GLTFs into JSX components
 - [`@react-three/postprocessing`](https://github.com/pmndrs/react-postprocessing) &ndash; post-processing effects
 - [`@react-three/test-renderer`](https://github.com/pmndrs/react-three-fiber/tree/master/packages/test-renderer) &ndash; for unit tests in node

--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -353,7 +353,7 @@ export function createEvents(store: RootStore) {
   function cancelPointer(intersections: Intersection[]) {
     const { internal } = store.getState()
     for (const hoveredObj of internal.hovered.values()) {
-      // When no objects were hit or the the hovered object wasn't found underneath the cursor
+      // When no objects were hit or the hovered object wasn't found underneath the cursor
       // we call onPointerOut and delete the object from the hovered-elements map
       if (
         !intersections.length ||

--- a/packages/fiber/src/core/loop.ts
+++ b/packages/fiber/src/core/loop.ts
@@ -144,7 +144,7 @@ export function invalidate(state?: RootState, frames = 1): void {
       //called from within a useFrame, it means the user wants an additional frame
       state.internal.frames = 2
     } else {
-      //the user need a new frame, no need to increment further than 1
+      //the user needs a new frame, no need to increment further than 1
       state.internal.frames = 1
     }
   }

--- a/readme.md
+++ b/readme.md
@@ -226,9 +226,9 @@ Some helpful material:
 
 # Ecosystem
 
-There is a vibrant and extensive eco system around three-fiber, full of libraries, helpers and abstractions.
+There is a vibrant and extensive ecosystem around three-fiber, full of libraries, helpers and abstractions.
 
-- [`@react-three/drei`](https://github.com/pmndrs/drei) &ndash; useful helpers, this is an eco system in itself
+- [`@react-three/drei`](https://github.com/pmndrs/drei) &ndash; useful helpers, this is an ecosystem in itself
 - [`@react-three/gltfjsx`](https://github.com/pmndrs/gltfjsx) &ndash; turns GLTFs into JSX components
 - [`@react-three/postprocessing`](https://github.com/pmndrs/react-postprocessing) &ndash; post-processing effects
 - [`@react-three/uikit`](https://github.com/pmndrs/uikit) &ndash; WebGL rendered UI components for three-fiber


### PR DESCRIPTION
# docs: fix typos and documentation consistency

## Summary
This PR addresses several small typos in code comments and unifies the usage of terms like "ecosystem" across the documentation for better consistency and professionalism.

## Changes:
- **`packages/fiber/src/core/events.ts`**: Fixed `the the` typo in a comment.
- **`packages/fiber/src/core/loop.ts`**: Fixed `need` to `needs` typo in a comment.
- **`readme.md`**: Standardized all occurrences of `eco system` to `ecosystem`.
- **`docs/getting-started/introduction.mdx`**: Standardized the `Eco system` header and body text to `Ecosystem`.
- **`docs/getting-started/community-r3f-components.mdx`**: Fixed a `to to` typo in the introductory sentence.

## Checklist:
- [x] Fixed typos.
- [x] Unified term usage.
- [x] All changes are non-breaking and documentation-focused.
