### PR TITLE
feat(useLoader): support custom cache keys

### DIFF
--- a/docs/API/hooks.mdx
+++ b/docs/API/hooks.mdx
@@ -194,6 +194,12 @@ function App() {
 > [!NOTE]
 > Assets loaded with useLoader are cached by default. The urls given serve as cache-keys. This allows you to re-use loaded data everywhere in the component tree.
 
+You can also provide an explicit cache key as the fifth argument when the request URL changes (for example signed URLs or auth tokens):
+
+```jsx
+const model = useLoader(GLTFLoader, signedUrl, undefined, undefined, '/model.glb')
+```
+
 > [!WARNING]
 > Be very careful with mutating or disposing of loaded assets, especially when you plan to re-use them. Refer to the automatic disposal section in the API.
 
@@ -243,6 +249,13 @@ You can pre-load assets in global space so that models can be loaded in anticipa
 
 ```jsx
 useLoader.preload(GLTFLoader, '/model.glb' /* extensions */)
+```
+
+You can pass the same cache key to `preload` and `clear`:
+
+```jsx
+useLoader.preload(GLTFLoader, signedUrl, undefined, '/model.glb')
+useLoader.clear(GLTFLoader, signedUrl, '/model.glb')
 ```
 
 ## `useGraph`

--- a/packages/fiber/src/core/hooks.tsx
+++ b/packages/fiber/src/core/hooks.tsx
@@ -64,6 +64,7 @@ export function useGraph(object: THREE.Object3D): ObjectMap {
 type InputLike = string | string[] | string[][] | Readonly<string | string[] | string[][]>
 type LoaderLike = THREE.Loader<any, InputLike>
 type GLTFLike = { scene: THREE.Object3D }
+type CacheKeyLike = InputLike
 
 type LoaderInstance<T extends LoaderLike | ConstructorRepresentation<LoaderLike>> =
   T extends ConstructorRepresentation<LoaderLike> ? InstanceType<T> : T
@@ -139,10 +140,12 @@ export function useLoader<I extends InputLike, L extends LoaderLike | Constructo
   input: I,
   extensions?: Extensions<L>,
   onProgress?: (event: ProgressEvent<EventTarget>) => void,
+  cacheKey?: CacheKeyLike,
 ) {
   // Use suspense to load async assets
-  const keys = (Array.isArray(input) ? input : [input]) as string[]
-  const results = suspend(loadingFn(extensions, onProgress), [loader, ...keys], { equal: is.equ })
+  const inputs = (Array.isArray(input) ? input : [input]) as string[]
+  const keys = (Array.isArray(cacheKey ?? input) ? (cacheKey ?? input) : [cacheKey ?? input]) as string[]
+  const results = suspend(() => loadingFn(extensions, onProgress)(loader, ...inputs), [loader, ...keys], { equal: is.equ })
   // Return the object(s)
   return (Array.isArray(input) ? results : results[0]) as I extends any[] ? LoaderResult<L>[] : LoaderResult<L>
 }
@@ -154,9 +157,11 @@ useLoader.preload = function <I extends InputLike, L extends LoaderLike | Constr
   loader: L,
   input: I,
   extensions?: Extensions<L>,
+  cacheKey?: CacheKeyLike,
 ): void {
-  const keys = (Array.isArray(input) ? input : [input]) as string[]
-  return preload(loadingFn(extensions), [loader, ...keys])
+  const inputs = (Array.isArray(input) ? input : [input]) as string[]
+  const keys = (Array.isArray(cacheKey ?? input) ? (cacheKey ?? input) : [cacheKey ?? input]) as string[]
+  return preload(() => loadingFn(extensions)(loader, ...inputs), [loader, ...keys])
 }
 
 /**
@@ -165,7 +170,8 @@ useLoader.preload = function <I extends InputLike, L extends LoaderLike | Constr
 useLoader.clear = function <I extends InputLike, L extends LoaderLike | ConstructorRepresentation<LoaderLike>>(
   loader: L,
   input: I,
+  cacheKey?: CacheKeyLike,
 ): void {
-  const keys = (Array.isArray(input) ? input : [input]) as string[]
+  const keys = (Array.isArray(cacheKey ?? input) ? (cacheKey ?? input) : [cacheKey ?? input]) as string[]
   return clear([loader, ...keys])
 }

--- a/packages/fiber/tests/hooks.test.tsx
+++ b/packages/fiber/tests/hooks.test.tsx
@@ -194,6 +194,57 @@ describe('hooks', () => {
     expect(proto).toBeInstanceOf(Loader)
   })
 
+  it('can use a custom cache key with useLoader', async () => {
+    const loadedObjects: THREE.Object3D[] = []
+    const loadMock = jest.fn((url: string, onLoad: (result: THREE.Object3D) => void) => {
+      const object = new THREE.Group()
+      object.name = url
+      loadedObjects.push(object)
+      onLoad(object)
+    })
+
+    class Loader extends THREE.Loader<THREE.Object3D, string> {
+      load = loadMock
+    }
+
+    function Test({ url, cacheKey }: { url: string; cacheKey: string }) {
+      const object = useLoader(Loader, url, undefined, undefined, cacheKey)
+      return <primitive object={object} />
+    }
+
+    await act(async () => root.render(<Test url="/model.glb?token=abc" cacheKey="model-1" />))
+    await act(async () => root.render(<Test url="/model.glb?token=def" cacheKey="model-1" />))
+
+    expect(loadMock).toHaveBeenCalledTimes(1)
+    expect(loadedObjects).toHaveLength(1)
+  })
+
+  it('can clear useLoader cache by custom cache key', async () => {
+    const loadedObjects: THREE.Object3D[] = []
+    const loadMock = jest.fn((url: string, onLoad: (result: THREE.Object3D) => void) => {
+      const object = new THREE.Group()
+      object.name = url
+      loadedObjects.push(object)
+      onLoad(object)
+    })
+
+    class Loader extends THREE.Loader<THREE.Object3D, string> {
+      load = loadMock
+    }
+
+    function Test({ url, cacheKey }: { url: string; cacheKey: string }) {
+      const object = useLoader(Loader, url, undefined, undefined, cacheKey)
+      return <primitive object={object} />
+    }
+
+    await act(async () => root.render(<Test url="/model.glb?token=abc" cacheKey="model-1" />))
+    useLoader.clear(Loader, '/model.glb?token=def', 'model-1')
+    await act(async () => root.render(<Test url="/model.glb?token=def" cacheKey="model-1" />))
+
+    expect(loadMock).toHaveBeenCalledTimes(2)
+    expect(loadedObjects).toHaveLength(2)
+  })
+
   it('can handle useGraph hook', async () => {
     const group = new THREE.Group()
     const mat1 = new THREE.MeshBasicMaterial()


### PR DESCRIPTION
Implements optional cacheKey support for useLoader/useLoader.preload/useLoader.clear to support signed/auth URLs while reusing cached assets. Adds tests and docs. Related: #3634, #3149