### PR TITLE
fix: uniforms have stable refs for ShaderMaterial

### DIFF
--- a/docs/advanced/pitfalls.mdx
+++ b/docs/advanced/pitfalls.mdx
@@ -213,6 +213,50 @@ function Foo(props)
   })
 ```
 
+## Shader material uniforms
+
+`ShaderMaterial`, `RawShaderMaterial` and subclasses keep the material's [`uniforms` object](https://threejs.org/docs/#ShaderMaterial.uniforms) stable. When you pass a new `uniforms` object, React Three Fiber merges the incoming uniforms into the existing target instead of replacing it.
+
+This preserves three.js internal uniform caching, even if your component creates a fresh `uniforms` object on each render. Existing uniform entries are updated in place and new entries are added as needed.
+
+```jsx
+<shaderMaterial
+  uniforms={{
+    time: { value: time },
+    color: { value: color },
+  }}
+/>
+```
+
+To get a stable reference to the material's `uniforms`, use the React ref.
+
+```jsx
+function Component() {
+  const ref = useRef()
+
+  // This object is merged into the material, so mutating this reference
+  // later will not update the shader.
+  const uniforms = useMemo(
+    () => ({
+      time: { value: 0 },
+      color: { value: color },
+    }),
+    [color],
+  )
+
+  useFrame(({ clock }) => {
+    // The material ref's uniforms object is stable and should be mutated instead.
+    ref.current.uniforms.time.value = clock.elapsedTime
+  })
+
+  return (
+    <mesh>
+      <shaderMaterial ref={ref} uniforms={uniforms} />
+    </mesh>
+  )
+}
+```
+
 ## `useLoader` instead of plain loaders
 
 Threejs loaders give you the ability to load async assets (models, textures, etc), but if you do not re-use assets it can quickly become problematic.

--- a/example/src/demos/ShaderMaterial.tsx
+++ b/example/src/demos/ShaderMaterial.tsx
@@ -1,0 +1,51 @@
+import { Canvas, useFrame } from '@react-three/fiber'
+import { useMemo, useRef } from 'react'
+import * as THREE from 'three'
+
+const vertexShader = `
+uniform float uTime;
+varying vec2 vUv;
+
+void main() {
+  vUv = uv;
+
+  vec3 transformed = position;
+  transformed.z += sin((position.x + uTime) * 4.0) * 0.1;
+
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(transformed, 1.0);
+}
+`
+
+const fragmentShader = `
+uniform float uTime;
+varying vec2 vUv;
+
+void main() {
+  vec3 color = 0.5 + 0.5 * cos(uTime + vUv.xyx + vec3(0.0, 2.0, 4.0));
+  gl_FragColor = vec4(color, 1.0);
+}
+`
+
+function Plane() {
+  const material = useRef<THREE.ShaderMaterial>(null!)
+  const uniforms = useMemo(() => ({ uTime: { value: 0 } }), [])
+
+  useFrame(({ clock }) => {
+    material.current.uniforms.uTime.value = clock.elapsedTime
+  })
+
+  return (
+    <mesh>
+      <planeGeometry args={[2, 2, 64, 64]} />
+      <shaderMaterial ref={material} uniforms={uniforms} vertexShader={vertexShader} fragmentShader={fragmentShader} />
+    </mesh>
+  )
+}
+
+export default function App() {
+  return (
+    <Canvas camera={{ position: [0, 0, 2.5] }}>
+      <Plane />
+    </Canvas>
+  )
+}

--- a/example/src/demos/index.tsx
+++ b/example/src/demos/index.tsx
@@ -16,6 +16,7 @@ const Pointcloud = { Component: lazy(() => import('./Pointcloud')) }
 const Reparenting = { Component: lazy(() => import('./Reparenting')) }
 const ResetProps = { Component: lazy(() => import('./ResetProps')) }
 const Selection = { Component: lazy(() => import('./Selection')) }
+const ShaderMaterial = { Component: lazy(() => import('./ShaderMaterial')) }
 const StopPropagation = { Component: lazy(() => import('./StopPropagation')) }
 const SuspenseAndErrors = { Component: lazy(() => import('./SuspenseAndErrors')) }
 const SuspenseMaterial = { Component: lazy(() => import('./SuspenseMaterial')) }
@@ -44,6 +45,7 @@ export {
   Reparenting,
   ResetProps,
   Selection,
+  ShaderMaterial,
   StopPropagation,
   SuspenseAndErrors,
   SuspenseMaterial,

--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -469,6 +469,20 @@ export function applyProps<T = any>(object: Instance<T>['object'], props: Instan
       // Otherwise just set single value
       else target.set(value)
     }
+    // ShaderMaterial uniforms must keep a stable target reference
+    else if (root instanceof THREE.ShaderMaterial && key === 'uniforms' && is.obj(value)) {
+      if (!is.obj(root.uniforms)) root.uniforms = {}
+      const uniforms = root.uniforms as Record<string, THREE.IUniform>
+      const nextUniforms = value as Record<string, THREE.IUniform>
+
+      for (const name in nextUniforms) {
+        const uniform = nextUniforms[name]
+        const targetUniform = uniforms[name]
+
+        if (targetUniform) Object.assign(targetUniform, uniform)
+        else uniforms[name] = { ...uniform }
+      }
+    }
     // Else, just overwrite the value
     else {
       root[key] = value

--- a/packages/fiber/tests/utils.test.ts
+++ b/packages/fiber/tests/utils.test.ts
@@ -406,6 +406,30 @@ describe('applyProps', () => {
     expect(target.foo.value).toBe(false)
   })
 
+  it('should merge shader material uniforms into a stable target', () => {
+    const material = new THREE.ShaderMaterial({ uniforms: { time: { value: 1 } } })
+    const uniforms = material.uniforms
+    const time = material.uniforms.time
+
+    const nextUniforms = {
+      time: { value: 2 },
+      resolution: { value: new THREE.Vector2(4, 8) },
+    }
+
+    applyProps(material, { uniforms: nextUniforms })
+
+    // The uniforms object is copied in leaviung a stable ref
+    expect(material.uniforms).toBe(uniforms)
+    expect(material.uniforms).not.toBe(nextUniforms)
+    // Individual uniforms are also copied into if present
+    expect(material.uniforms.time).toBe(time)
+    expect(material.uniforms.time).not.toBe(nextUniforms.time)
+    expect(material.uniforms.time.value).toBe(2)
+    // When it is a new uniform it gets cloned isntead of assigning by ref
+    expect(material.uniforms.resolution).not.toBe(nextUniforms.resolution)
+    expect(material.uniforms.resolution.value.toArray()).toStrictEqual([4, 8])
+  })
+
   it('should prefer to copy potentially read-only math classes', () => {
     const one = new THREE.Vector3(1, 1, 1)
     const two = new THREE.Vector3(2, 2, 2)


### PR DESCRIPTION
Currently, if a uniform is recreated due to a rerender or simply an HMR and the uniform is passed in as a prop, then it overwrites the uniforms object.

```js
// This will still regenerate on HMR
const uniforms = useMemo(() => {}, [])

// Overwrites the original reference
return <shaderMaterial uniforms={uniforms} />
```

This is catastrophic for Three which assumes this object never changes in its program caching. This leads people to do silly things like put `Math.random()` in the key prop forcing the material itself to regenerate every rerender. 

This change makes the uniforms objects on `ShaderMaterial` and its derivatives have a stable reference. Anything passed into `uniforms` will instead copy into it. This is the same as behavior for math structures that have copy such as position, rotation, quaternion, etc.

The user would then get the uniforms ref from the material ref itself.