### PR TITLE
fix: Seamlessly transfer interactivity state when swapping instances (#3743)

### DIFF
--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -121,6 +121,39 @@ function releaseInternalPointerCapture(
   }
 }
 
+/** This function transfers all interactivity state from one object instance to another. Used when swapping instances due to reconstruction. */
+export function swapInteractivity(store: RootStore, object: THREE.Object3D, newObject: THREE.Object3D) {
+  const { internal } = store.getState()
+
+  for (let i = 0; i < internal.interaction.length; i++) {
+    if (internal.interaction[i] === object) internal.interaction[i] = newObject
+  }
+
+  for (let i = 0; i < internal.initialHits.length; i++) {
+    if (internal.initialHits[i] === object) internal.initialHits[i] = newObject
+  }
+
+  internal.hovered.forEach((value, key) => {
+    if (value.eventObject === object || value.object === object) {
+      internal.hovered.delete(key)
+      const next = {
+        ...value,
+        eventObject: value.eventObject === object ? newObject : value.eventObject,
+        object: value.object === object ? newObject : value.object,
+      }
+      internal.hovered.set(makeId(next), next)
+    }
+  })
+
+  internal.capturedMap.forEach((captures) => {
+    const captureData = captures.get(object)
+    if (captureData) {
+      captures.delete(object)
+      captures.set(newObject, captureData)
+    }
+  })
+}
+
 export function removeInteractivity(store: RootStore, object: THREE.Object3D) {
   const { internal } = store.getState()
   // Removes every trace of an object from the data store

--- a/packages/fiber/src/core/reconciler.tsx
+++ b/packages/fiber/src/core/reconciler.tsx
@@ -20,7 +20,7 @@ import {
   IsAllOptional,
 } from './utils'
 import type { RootStore } from './store'
-import { removeInteractivity, type EventHandlers } from './events'
+import { swapInteractivity, removeInteractivity, type EventHandlers } from './events'
 import type { ThreeElement } from '../three-types'
 
 type Fiber = Omit<Reconciler.Fiber, 'alternate'> & { refCleanup: null | (() => void); alternate: Fiber | null }
@@ -416,11 +416,13 @@ function swapInstances(): void {
       const target = catalogue[toPascalCase(instance.type)]
 
       // Create object
+      const prevObject = instance.object
       instance.object = instance.props.object ?? new target(...(instance.props.args ?? []))
       instance.object.__r3f = instance
       setFiberRef(fiber, instance.object)
 
-      // Set initial props
+      swapInteractivity(findInitialRoot(instance), prevObject, instance.object)
+
       applyProps(instance.object, instance.props)
 
       if (instance.props.attach) {

--- a/packages/fiber/tests/events.test.tsx
+++ b/packages/fiber/tests/events.test.tsx
@@ -269,6 +269,154 @@ describe('events', () => {
     expect(handleClickRear).not.toHaveBeenCalled()
   })
 
+  describe('swapping instances', () => {
+    it('re-registers events when a primitive object prop is swapped', async () => {
+      const handleClick = jest.fn()
+
+      const meshA = new THREE.Mesh(new THREE.BoxGeometry(2, 2), new THREE.MeshBasicMaterial())
+      const meshB = new THREE.Mesh(new THREE.BoxGeometry(2, 2), new THREE.MeshBasicMaterial())
+
+      function App({ object }: { object: THREE.Object3D }) {
+        return (
+          <Canvas>
+            <primitive object={object} onClick={handleClick} />
+          </Canvas>
+        )
+      }
+
+      let result: RenderResult = null!
+      await act(async () => {
+        result = render(<App object={meshA} />)
+      })
+
+      // Swap the underlying THREE object — this triggers reconciler reconstruction.
+      await act(async () => {
+        result.rerender(<App object={meshB} />)
+      })
+
+      const down = new PointerEvent('pointerdown')
+      Object.defineProperty(down, 'offsetX', { get: () => 577 })
+      Object.defineProperty(down, 'offsetY', { get: () => 480 })
+      fireEvent(getContainer(), down)
+
+      const up = new PointerEvent('pointerup')
+      Object.defineProperty(up, 'offsetX', { get: () => 577 })
+      Object.defineProperty(up, 'offsetY', { get: () => 480 })
+      fireEvent(getContainer(), up)
+
+      const evt = new MouseEvent('click')
+      Object.defineProperty(evt, 'offsetX', { get: () => 577 })
+      Object.defineProperty(evt, 'offsetY', { get: () => 480 })
+      fireEvent(getContainer(), evt)
+
+      expect(handleClick).toHaveBeenCalledTimes(1)
+      expect(handleClick.mock.calls[0][0].eventObject).toBe(meshB)
+    })
+
+    it('re-registers events when an args change reconstructs the instance', async () => {
+      const handleClick = jest.fn()
+
+      const geometry = new THREE.BoxGeometry(2, 2)
+      const materialA = new THREE.MeshBasicMaterial()
+      const materialB = new THREE.MeshBasicMaterial()
+
+      function App({ material }: { material: THREE.Material }) {
+        return (
+          <Canvas>
+            <mesh args={[geometry, material]} onClick={handleClick} />
+          </Canvas>
+        )
+      }
+
+      let result: RenderResult = null!
+      await act(async () => {
+        result = render(<App material={materialA} />)
+      })
+
+      // Reconstruct the mesh via args change while keeping onClick attached.
+      await act(async () => {
+        result.rerender(<App material={materialB} />)
+      })
+
+      const down = new PointerEvent('pointerdown')
+      Object.defineProperty(down, 'offsetX', { get: () => 577 })
+      Object.defineProperty(down, 'offsetY', { get: () => 480 })
+      fireEvent(getContainer(), down)
+
+      const up = new PointerEvent('pointerup')
+      Object.defineProperty(up, 'offsetX', { get: () => 577 })
+      Object.defineProperty(up, 'offsetY', { get: () => 480 })
+      fireEvent(getContainer(), up)
+
+      const evt = new MouseEvent('click')
+      Object.defineProperty(evt, 'offsetX', { get: () => 577 })
+      Object.defineProperty(evt, 'offsetY', { get: () => 480 })
+      fireEvent(getContainer(), evt)
+
+      expect(handleClick).toHaveBeenCalledTimes(1)
+      expect((handleClick.mock.calls[0][0].eventObject as THREE.Mesh).material).toBe(materialB)
+    })
+
+    it('keeps previous event state when an instance is swapped', async () => {
+      const handlePointerEnter = jest.fn()
+      const handlePointerLeave = jest.fn()
+      const handlePointerMove = jest.fn()
+
+      const geometry = new THREE.BoxGeometry(2, 2)
+      const materialA = new THREE.MeshBasicMaterial()
+      const materialB = new THREE.MeshBasicMaterial()
+
+      function App({ material }: { material: THREE.Material }) {
+        return (
+          <Canvas>
+            <mesh
+              args={[geometry, material]}
+              onPointerEnter={handlePointerEnter}
+              onPointerLeave={handlePointerLeave}
+              onPointerMove={handlePointerMove}
+            />
+          </Canvas>
+        )
+      }
+
+      let result: RenderResult = null!
+      await act(async () => {
+        result = render(<App material={materialA} />)
+      })
+
+      const canvas = getContainer()
+
+      // Move pointer over the mesh to establish hovered state
+      const moveIn = new PointerEvent('pointermove')
+      Object.defineProperty(moveIn, 'offsetX', { get: () => 577 })
+      Object.defineProperty(moveIn, 'offsetY', { get: () => 480 })
+
+      await act(async () => canvas.dispatchEvent(moveIn))
+
+      expect(handlePointerEnter).toHaveBeenCalledTimes(1)
+      expect(handlePointerMove).toHaveBeenCalledTimes(1)
+
+      // Swap instance via args change — should NOT trigger leave/enter
+      await act(async () => {
+        result.rerender(<App material={materialB} />)
+      })
+
+      expect(handlePointerLeave).not.toHaveBeenCalled()
+      expect(handlePointerEnter).toHaveBeenCalledTimes(1)
+
+      // Moving again over the same spot should still fire move, not a new enter
+      const moveAgain = new PointerEvent('pointermove')
+      Object.defineProperty(moveAgain, 'offsetX', { get: () => 577 })
+      Object.defineProperty(moveAgain, 'offsetY', { get: () => 480 })
+
+      await act(async () => canvas.dispatchEvent(moveAgain))
+
+      expect(handlePointerMove).toHaveBeenCalledTimes(2)
+      expect(handlePointerEnter).toHaveBeenCalledTimes(1)
+      expect(handlePointerLeave).not.toHaveBeenCalled()
+    })
+  })
+
   describe('web pointer capture', () => {
     const handlePointerMove = jest.fn()
     const handlePointerDown = jest.fn((ev) => (ev.target as any).setPointerCapture(ev.pointerId))


### PR DESCRIPTION
Currently, the interactivity state seems to be not accounted for when the instance is swapped at all. This causes events to break for example when updating the `object` prop of a primitive (#3743), or also when an update to the `args` of a built-in tag triggers a full reconstruction of the object.

This PR proposes a fix, where the interactivity state is seamlessly transferred in this situation from one object to another.
So that for example an instance swap during an interaction, e.g. after pointer down, but before pointer up, doesn't cause all enter/exit events, but instead is treated like one continuous interaction.