### PR TITLE
docs: fix FBXLoader naming in loading-models

### DIFF
--- a/docs/tutorials/loading-models.mdx
+++ b/docs/tutorials/loading-models.mdx
@@ -126,7 +126,7 @@ import { useLoader } from '@react-three/fiber'
 import { FBXLoader } from 'three/addons/loaders/FBXLoader.js'
 ```
 
-To create our scene we can get the FBX as a return value of the useLoader by passing the `FBXloader` and the location of our file like so:
+To create our scene we can get the FBX as a return value of `useLoader` by passing `FBXLoader` and the location of our file like so:
 
 ```jsx
 function Scene() {


### PR DESCRIPTION
Fixes a docs typo in the “Loading FBX models” section by correcting the loader class name reference:

FBXloader -> FBXLoader
Also clarifies the same sentence by formatting useLoader as code.
This keeps the prose aligned with the actual import and usage shown in the code snippet.
