### PR TITLE
Fix memory leak (not releasing things on unmount)

### DIFF
--- a/packages/fiber/src/core/loop.ts
+++ b/packages/fiber/src/core/loop.ts
@@ -123,6 +123,10 @@ export function loop(timestamp: number): void {
 
     // Flag end of operation
     running = false
+    // Release references to prevent leaking the last root's state after all roots unmount
+    state = undefined!
+    subscribers = undefined!
+    subscription = undefined!
     return cancelAnimationFrame(frame)
   }
 }


### PR DESCRIPTION
## Problem

After all `<Canvas>` components unmount and `_roots` is empty, the module-scoped `state`, `subscribers`, and `subscription` variables in `packages/fiber/src/core/loop.ts` still reference the last rendered root's store state. This prevents GC of the entire R3F fiber tree, Three.js scene, and any context values bridged via `its-fine`.

## Reproduction

Minimal repro: https://github.com/xpl/r3f-leak (`npm i && npm run dev`)

1. Click "Mount/Unmount x16"
2. Wait for the cycle to complete, then force GC in DevTools (in Performance tab there is a button)
3. The last value remains "alive" indefinitely — never garbage collected

<img width="1481" height="632" alt="Screenshot 2026-04-30 at 4 28 35 PM" src="https://github.com/user-attachments/assets/ba25831a-c1bb-45ba-a81b-2787f5d49f18" />

## Root cause

In `loop.ts`, three variables are declared at module scope for performance (avoiding per-frame allocations):

```ts
let subscribers: Subscription[]
let subscription: Subscription
let state: RootState
```

They are written inside the `for (const root of _roots.values())` loop body and inside `update()`. When the loop stops (`repeat === 0`), these variables are never cleared — they retain the last root's store state forever.

## Fix

Null out the variables when the loop terminates:

```diff
  if (repeat === 0) {
    flushGlobalEffects('tail', timestamp)

    running = false
+   state = undefined!
+   subscribers = undefined!
+   subscription = undefined!
    return cancelAnimationFrame(frame)
  }
```

This is safe because every code path that **reads** these variables first **writes** to them from fresh data within the same frame tick (inside the `_roots` for-loop or `update()`). When `_roots` is empty, the loop body doesn't execute, so the undefined values can never be observed at runtime.

## Impact

Any app that mounts and unmounts `<Canvas>` (e.g. route transitions, conditional rendering, modals) leaks ~the entire R3F state of the last mounted canvas until a new canvas is mounted. This includes the Three.js scene graph, WebGL renderer reference, all `useFrame` subscriptions, and any React context values bridged through `its-fine`.