### PR TITLE
Change default shadow map type to `PCFShadowMap`

### DIFF
--- a/packages/fiber/src/core/renderer.tsx
+++ b/packages/fiber/src/core/renderer.tsx
@@ -363,7 +363,7 @@ export function createRoot<TCanvas extends HTMLCanvasElement | OffscreenCanvas>(
         gl.shadowMap.enabled = !!shadows
 
         if (is.boo(shadows)) {
-          gl.shadowMap.type = THREE.PCFSoftShadowMap
+          gl.shadowMap.type = THREE.PCFShadowMap
         } else if (is.str(shadows)) {
           const types = {
             basic: THREE.BasicShadowMap,
@@ -371,7 +371,7 @@ export function createRoot<TCanvas extends HTMLCanvasElement | OffscreenCanvas>(
             soft: THREE.PCFSoftShadowMap,
             variance: THREE.VSMShadowMap,
           }
-          gl.shadowMap.type = types[shadows] ?? THREE.PCFSoftShadowMap
+          gl.shadowMap.type = types[shadows] ?? THREE.PCFShadowMap
         } else if (is.obj(shadows)) {
           Object.assign(gl.shadowMap, shadows)
         }

--- a/packages/fiber/tests/index.test.tsx
+++ b/packages/fiber/tests/index.test.tsx
@@ -100,11 +100,11 @@ describe('createRoot', () => {
     expect(store.getState().viewport.dpr).toEqual(window.devicePixelRatio)
   })
 
-  it('should set PCFSoftShadowMap as the default shadow map', async () => {
+  it('should set PCFShadowMap as the default shadow map', async () => {
     const store = await act(async () => (await root.configure({ shadows: true })).render(<group />))
     const { gl } = store.getState()
 
-    expect(gl.shadowMap.type).toBe(THREE.PCFSoftShadowMap)
+    expect(gl.shadowMap.type).toBe(THREE.PCFShadowMap)
   })
 
   it('should set tonemapping to ACESFilmicToneMapping and outputColorSpace to SRGBColorSpace if linear is false', async () => {


### PR DESCRIPTION
The default shadow map should not be `PCFSoftShadowMap`, since it's deprecated, use `PCFShadowMap` instead.

This change prevents unintentional use of the deprecated shadow map and getting the warning:
`THREE.WebGLShadowMap: PCFSoftShadowMap has been deprecated. Using PCFShadowMap instead.`

If people want, they can still explicitly use the deprecated shadow map (if still available).

Note: Maybe remove the `soft` key from possible types as well? Or in the future?

Fixes #3749 