### PR TITLE
fix(fiber): guard null pointer event targets

### DIFF
--- a/packages/fiber/src/web/events.ts
+++ b/packages/fiber/src/web/events.ts
@@ -37,9 +37,10 @@ export function createPointerEvents(store: RootStore): EventManager<HTMLElement>
       const { events, internal } = store.getState()
       if (internal.lastEvent?.current && events.handlers) events.handlers.onPointerMove(internal.lastEvent.current)
     },
-    connect: (target: HTMLElement) => {
+    connect: (target: HTMLElement | null) => {
       const { set, events } = store.getState()
       events.disconnect?.()
+      if (!target) return
       set((state) => ({ events: { ...state.events, connected: target } }))
       if (events.handlers) {
         for (const name in events.handlers) {

--- a/packages/fiber/tests/events.test.tsx
+++ b/packages/fiber/tests/events.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { render, fireEvent, RenderResult } from '@testing-library/react'
-import { Canvas, act, extend } from '../src'
+import { Canvas, act, extend, events as createPointerEvents, type RootStore } from '../src'
 import THREE from 'three'
 
 extend(THREE as any)
@@ -8,6 +8,30 @@ extend(THREE as any)
 const getContainer = () => document.querySelector('canvas')?.parentNode?.parentNode as HTMLDivElement
 
 describe('events', () => {
+  it('disconnects without throwing when connecting to a null target', () => {
+    let state: any
+    const store = {
+      getState: () => state,
+    } as RootStore
+
+    state = {
+      set: (fn: (_state: any) => any) => {
+        state = { ...state, ...fn(state) }
+      },
+      events: createPointerEvents(store),
+    }
+
+    const target = document.createElement('div')
+    const removeEventListener = jest.spyOn(target, 'removeEventListener')
+
+    state.events.connect(target)
+
+    expect(state.events.connected).toBe(target)
+    expect(() => state.events.connect(null)).not.toThrow()
+    expect(removeEventListener).toHaveBeenCalled()
+    expect(state.events.connected).toBeUndefined()
+  })
+
   it('can handle onPointerDown', async () => {
     const handlePointerDown = jest.fn()
 


### PR DESCRIPTION
Fixes #3754.

## Summary
- Treat a null web pointer-event target as a disconnect/no-op before adding DOM listeners.
- Add a regression test for reconnecting `events.connect(null)` after a previous target was connected.

## Test plan
- `yarn jest packages/fiber/tests/events.test.tsx --runInBand`
- `./node_modules/.bin/eslint packages/fiber/src/web/events.ts packages/fiber/tests/events.test.tsx`
- `yarn typecheck`
- `git diff --check`
