### PR TITLE
fix(fiber): ignore null pointer event targets

### DIFF
--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -82,7 +82,7 @@ export interface EventManager<TTarget> {
   /** All the pointer event handlers through which the host forwards native events */
   handlers?: Events
   /** Allows re-connecting to another target */
-  connect?: (target: TTarget) => void
+  connect?: (target: TTarget | null) => void
   /** Removes all existing events handlers from the target */
   disconnect?: () => void
   /** Triggers a onPointerMove with the last known event. This can be useful to enable raycasting without

--- a/packages/fiber/src/web/events.ts
+++ b/packages/fiber/src/web/events.ts
@@ -37,7 +37,9 @@ export function createPointerEvents(store: RootStore): EventManager<HTMLElement>
       const { events, internal } = store.getState()
       if (internal.lastEvent?.current && events.handlers) events.handlers.onPointerMove(internal.lastEvent.current)
     },
-    connect: (target: HTMLElement) => {
+    connect: (target: HTMLElement | null) => {
+      if (!target) return
+
       const { set, events } = store.getState()
       events.disconnect?.()
       set((state) => ({ events: { ...state.events, connected: target } }))

--- a/packages/fiber/tests/events.test.tsx
+++ b/packages/fiber/tests/events.test.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import { render, fireEvent, RenderResult } from '@testing-library/react'
 import { Canvas, act, extend } from '../src'
+import { createStore } from '../src/core/store'
+import { createPointerEvents } from '../src/web/events'
 import THREE from 'three'
 
 extend(THREE as any)
@@ -8,6 +10,16 @@ extend(THREE as any)
 const getContainer = () => document.querySelector('canvas')?.parentNode?.parentNode as HTMLDivElement
 
 describe('events', () => {
+  it('ignores null pointer event targets', () => {
+    const store = createStore(jest.fn(), jest.fn())
+    const events = createPointerEvents(store)
+
+    store.getState().setEvents(events)
+
+    expect(() => store.getState().events.connect?.(null)).not.toThrow()
+    expect(store.getState().events.connected).toBeUndefined()
+  })
+
   it('can handle onPointerDown', async () => {
     const handlePointerDown = jest.fn()
 


### PR DESCRIPTION
Fixes #3754.

`createPointerEvents.connect` could receive a transient `null` target while a canvas subtree is being reparented or remounted. The matching `disconnect` path is already defensive around missing targets, but `connect` called `addEventListener` unconditionally.

This change allows the event manager `connect` contract to receive `null` and makes the web pointer event manager return before touching DOM APIs when no target is available. Existing connected handlers are left intact, and the next non-null target still goes through the normal disconnect/reconnect path.

Validation:
- `corepack yarn prettier --write packages/fiber/src/core/events.ts packages/fiber/src/web/events.ts packages/fiber/tests/events.test.tsx`
- `corepack yarn patch-react-reconciler`
- `corepack yarn jest packages/fiber/tests/events.test.tsx --runInBand`
- `.\node_modules\.bin\tsc.cmd --noEmit --emitDeclarationOnly false --strict --pretty false`
- `.\node_modules\.bin\eslint.cmd packages/fiber/src/core/events.ts packages/fiber/src/web/events.ts packages/fiber/tests/events.test.tsx --quiet`

Note: `corepack yarn install --frozen-lockfile` fetched and linked dependencies, but the repo postinstall failed on Windows while Preconstruct tried to create a symlink in `packages/test-renderer/dist` (`EPERM`). I ran the generated `patch-react-reconciler` step directly and used source-level checks afterward.