### PR TITLE
fix(fiber): normalize viewport event prefixes

### DIFF
--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -113,8 +113,14 @@ function CanvasImpl({
             if (eventPrefix) {
               state.setEvents({
                 compute: (event, state) => {
-                  const x = event[(eventPrefix + 'X') as keyof DomEvent] as number
-                  const y = event[(eventPrefix + 'Y') as keyof DomEvent] as number
+                  const eventX = event[(eventPrefix + 'X') as keyof DomEvent] as number
+                  const eventY = event[(eventPrefix + 'Y') as keyof DomEvent] as number
+                  const scrollX = eventPrefix === 'page' ? window.scrollX : 0
+                  const scrollY = eventPrefix === 'page' ? window.scrollY : 0
+                  const offsetX = eventPrefix === 'client' || eventPrefix === 'page' ? state.size.left + scrollX : 0
+                  const offsetY = eventPrefix === 'client' || eventPrefix === 'page' ? state.size.top + scrollY : 0
+                  const x = eventX - offsetX
+                  const y = eventY - offsetY
                   state.pointer.set((x / state.size.width) * 2 - 1, -(y / state.size.height) * 2 + 1)
                   state.raycaster.setFromCamera(state.pointer, state.camera)
                 },

--- a/packages/fiber/tests/events.test.tsx
+++ b/packages/fiber/tests/events.test.tsx
@@ -594,5 +594,54 @@ describe('events', () => {
     expect(handlePointerDown).toHaveBeenCalled()
   })
 
-  it.todo('can handle different event prefixes')
+  it.each([
+    ['client', 0, 0],
+    ['page', 20, 40],
+  ] as const)('can handle different event prefixes (%s)', async (eventPrefix, scrollX, scrollY) => {
+    const scrollXDescriptor = Object.getOwnPropertyDescriptor(window, 'scrollX')
+    const scrollYDescriptor = Object.getOwnPropertyDescriptor(window, 'scrollY')
+    Object.defineProperty(window, 'scrollX', { configurable: true, value: scrollX })
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: scrollY })
+
+    try {
+      const handlePointerDown = jest.fn()
+      let eventCoordinates: { width: number; height: number; left: number; top: number } | null = null
+
+      await act(async () => {
+        render(
+          <Canvas
+            eventPrefix={eventPrefix}
+            onCreated={(state) => {
+              state.size.left = 300
+              state.size.top = 180
+              eventCoordinates = state.size
+            }}>
+            <mesh onPointerDown={handlePointerDown}>
+              <boxGeometry args={[1000, 1000, 1]} />
+              <meshBasicMaterial />
+            </mesh>
+          </Canvas>,
+        )
+      })
+
+      expect(eventCoordinates).not.toBeNull()
+      const { width, height, left, top } = eventCoordinates!
+      const x = left + scrollX + width / 2
+      const y = top + scrollY + height / 2
+
+      const evt = new PointerEvent('pointerdown')
+      Object.defineProperty(evt, `${eventPrefix}X`, { get: () => x })
+      Object.defineProperty(evt, `${eventPrefix}Y`, { get: () => y })
+
+      fireEvent(getContainer(), evt)
+
+      const threeEvent = handlePointerDown.mock.calls[0]?.[0]
+      expect(threeEvent).toBeDefined()
+      expect(threeEvent.pointer.x).toBeCloseTo(0, 5)
+      expect(threeEvent.pointer.y).toBeCloseTo(0, 5)
+    } finally {
+      if (scrollXDescriptor) Object.defineProperty(window, 'scrollX', scrollXDescriptor)
+      if (scrollYDescriptor) Object.defineProperty(window, 'scrollY', scrollYDescriptor)
+    }
+  })
 })


### PR DESCRIPTION
## Summary

`Canvas` supports overriding pointer coordinate extraction via `eventPrefix`, but prefixes like `client` and `page` produce viewport/document coordinates instead of coordinates local to the canvas bounds. Those values were normalized directly against the canvas size, so an offset canvas produced shifted pointer coordinates and raycasts.

This normalizes `clientX/clientY` by the canvas bounds and `pageX/pageY` by the bounds plus window scroll. Offset-like prefixes keep their existing behavior.

## Test Plan

- `npx jest packages/fiber/tests/events.test.tsx --runInBand`
- `npx eslint packages/fiber/src/web/Canvas.tsx packages/fiber/tests/events.test.tsx`
- `npx prettier --check packages/fiber/src/web/Canvas.tsx packages/fiber/tests/events.test.tsx`
- `npm run -s typecheck`
- `npm run -s build`