### PR TITLE
fix(fiber): ignore null event targets

### DIFF
--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -82,7 +82,7 @@ export interface EventManager<TTarget> {
   /** All the pointer event handlers through which the host forwards native events */
   handlers?: Events
   /** Allows re-connecting to another target */
-  connect?: (target: TTarget) => void
+  connect?: (target: TTarget | null) => void
   /** Removes all existing events handlers from the target */
   disconnect?: () => void
   /** Triggers a onPointerMove with the last known event. This can be useful to enable raycasting without

--- a/packages/fiber/src/web/events.ts
+++ b/packages/fiber/src/web/events.ts
@@ -37,7 +37,9 @@ export function createPointerEvents(store: RootStore): EventManager<HTMLElement>
       const { events, internal } = store.getState()
       if (internal.lastEvent?.current && events.handlers) events.handlers.onPointerMove(internal.lastEvent.current)
     },
-    connect: (target: HTMLElement) => {
+    connect: (target: HTMLElement | null) => {
+      if (!target) return
+
       const { set, events } = store.getState()
       events.disconnect?.()
       set((state) => ({ events: { ...state.events, connected: target } }))

--- a/packages/fiber/tests/events.test.tsx
+++ b/packages/fiber/tests/events.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { render, fireEvent, RenderResult } from '@testing-library/react'
 import { Canvas, act, extend } from '../src'
+import { createPointerEvents } from '../src/web/events'
 import THREE from 'three'
 
 extend(THREE as any)
@@ -8,6 +9,17 @@ extend(THREE as any)
 const getContainer = () => document.querySelector('canvas')?.parentNode?.parentNode as HTMLDivElement
 
 describe('events', () => {
+  it('ignores null pointer event connection targets', () => {
+    const set = jest.fn()
+    const store = {
+      getState: () => ({ set, events: {} }),
+    } as any
+    const events = createPointerEvents(store)
+
+    expect(() => events.connect?.(null)).not.toThrow()
+    expect(set).not.toHaveBeenCalled()
+  })
+
   it('can handle onPointerDown', async () => {
     const handlePointerDown = jest.fn()
 


### PR DESCRIPTION
## Summary

`createPointerEvents.connect()` currently assumes React always passes a non-null DOM event target. During mount/reparent windows, React can briefly call the ref callback with `null`, which causes the event layer to call DOM listener APIs on a null target.

This updates the event manager contract to allow `null` connection targets and makes the web pointer event connector treat them as a no-op. The next non-null target still disconnects/reconnects as before.

Fixes #3754.

## Validation

- `npx prettier --check packages/fiber/src/core/events.ts packages/fiber/src/web/events.ts packages/fiber/tests/events.test.tsx`
- `npx eslint packages/fiber/src/core/events.ts packages/fiber/src/web/events.ts packages/fiber/tests/events.test.tsx` (passes with existing warning-level lint noise)
- `npx jest packages/fiber/tests/events.test.tsx --runInBand`
- `npm run -s typecheck`
- `npm run -s build`