### PR TITLE
fix(fiber): avoid retaining stale portal state in setEvents

### DIFF
--- a/.changeset/quiet-portal-events.md
+++ b/.changeset/quiet-portal-events.md
@@ -1,0 +1,5 @@
+---
+'@react-three/fiber': patch
+---
+
+Avoid retaining stale portal state objects in `setEvents`.

--- a/packages/fiber/src/core/renderer.tsx
+++ b/packages/fiber/src/core/renderer.tsx
@@ -525,6 +525,8 @@ function Portal({ state = {}, children, container }: PortalProps): React.JSX.Ele
       if (camera !== rootState.camera) updateCamera(camera, size)
     }
 
+    const set = injectState.set
+
     return {
       // The intersect consists of the previous root state
       ...rootState,
@@ -542,7 +544,7 @@ function Portal({ state = {}, children, container }: PortalProps): React.JSX.Ele
       viewport: { ...rootState.viewport, ...viewport },
       // Layers are allowed to override events
       setEvents: (events: Partial<EventManager<any>>) =>
-        injectState.set((state) => ({ ...state, events: { ...state.events, ...events } })),
+        set((state) => ({ ...state, events: { ...state.events, ...events } })),
     } as RootState
   })
 

--- a/packages/fiber/tests/index.test.tsx
+++ b/packages/fiber/tests/index.test.tsx
@@ -286,6 +286,46 @@ describe('createPortal', () => {
     expect(groupHandle).toBeDefined()
     expect(prevUUID).not.toBe(groupHandle!.uuid)
   })
+
+  it('does not retain stale portal state in setEvents', async () => {
+    const scene = new THREE.Scene()
+    let rootStore: RootStore = null!
+    let portalState: RootState = null!
+
+    function PortalProbe() {
+      portalState = useThree()
+      return null
+    }
+
+    await act(async () => {
+      rootStore = root.render(createPortal(<PortalProbe />, scene, { scene }))
+    })
+
+    const stalePortalState = portalState
+    const staleSet = stalePortalState.set
+
+    await act(async () => {
+      rootStore.getState().set((state) => ({
+        size: { ...state.size },
+      }))
+    })
+
+    expect(portalState).not.toBe(stalePortalState)
+
+    stalePortalState.set = (() => {
+      throw new Error('stale portal state setter was retained')
+    }) as RootState['set']
+
+    try {
+      await act(async () => {
+        portalState.setEvents({ enabled: false })
+      })
+
+      expect(portalState.get().events.enabled).toBe(false)
+    } finally {
+      stalePortalState.set = staleSet
+    }
+  })
 })
 
 function getExports(source: string): string[] {


### PR DESCRIPTION
## Summary
Fixes #3751.

`Portal` rebuilt its layered root state with a `setEvents` closure that captured the previous portal state object. Repeated parent store mutations could therefore retain a chain of stale portal states through those closures.

This hoists the stable portal store setter before creating `setEvents`, so the closure captures only the setter instead of the whole prior state object. A regression test mutates the parent root store, poisons the stale state's setter, and verifies the current portal `setEvents` path no longer reaches it.

## Validation
- `corepack yarn jest packages/fiber/tests/index.test.tsx --runInBand -t "does not retain stale portal state in setEvents"`
- `corepack yarn jest packages/fiber/tests/index.test.tsx --runInBand`
- `.\node_modules\.bin\eslint.cmd packages/fiber/src/core/renderer.tsx packages/fiber/tests/index.test.tsx` (0 errors; existing warnings in `renderer.tsx`)
- `corepack yarn prettier --check packages/fiber/src/core/renderer.tsx packages/fiber/tests/index.test.tsx .changeset/quiet-portal-events.md`
- `corepack yarn typecheck`
- `corepack yarn validate`
- `git diff --check origin/master...HEAD`
