### PR TITLE
fix: render Canvas fallback when renderer setup fails

### DIFF
--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -73,6 +73,7 @@ function CanvasImpl({
   const handlePointerMissed = useMutableCallback(onPointerMissed)
   const [block, setBlock] = React.useState<SetBlock>(false)
   const [error, setError] = React.useState<any>(false)
+  const [canvasFallback, setCanvasFallback] = React.useState(false)
 
   // Suspend this component if block is a promise (2nd run)
   if (block) throw block
@@ -132,7 +133,14 @@ function CanvasImpl({
           </Bridge>,
         )
       }
-      run()
+      run().catch((error) => {
+        if (fallback != null) {
+          root.current?.unmount()
+          setCanvasFallback(true)
+        } else {
+          setError(error)
+        }
+      })
     }
   })
 
@@ -158,9 +166,13 @@ function CanvasImpl({
       }}
       {...props}>
       <div ref={containerRef} style={{ width: '100%', height: '100%' }}>
-        <canvas ref={canvasRef} style={{ display: 'block' }}>
-          {fallback}
-        </canvas>
+        {canvasFallback ? (
+          fallback
+        ) : (
+          <canvas ref={canvasRef} style={{ display: 'block' }}>
+            {fallback}
+          </canvas>
+        )}
       </div>
     </div>
   )

--- a/packages/fiber/tests/canvas.test.tsx
+++ b/packages/fiber/tests/canvas.test.tsx
@@ -15,6 +15,21 @@ describe('web Canvas', () => {
     expect(renderer.container).toMatchSnapshot()
   })
 
+  it('should render fallback when renderer setup fails', async () => {
+    const renderer = render(
+      <Canvas
+        gl={() => {
+          throw new Error('WebGL unsupported')
+        }}
+        fallback={<div>Sorry no WebGL supported!</div>}>
+        <group />
+      </Canvas>,
+    )
+
+    expect(await renderer.findByText('Sorry no WebGL supported!')).toBeTruthy()
+    expect(renderer.container.querySelector('canvas')).toBeNull()
+  })
+
   it('should forward ref', async () => {
     const ref = React.createRef<HTMLCanvasElement>()
 


### PR DESCRIPTION
## Summary
Fixes #3757.

When renderer setup fails before the reconciler tree renders, the `Canvas` fallback was left as children of `<canvas>`, which browsers do not display. This catches async renderer setup failures, unmounts the failed root, and renders the provided fallback as visible DOM instead of leaving a blank canvas.

## Validation
- `corepack yarn jest packages/fiber/tests/canvas.test.tsx --runInBand`
- `.\node_modules\.bin\eslint.cmd packages/fiber/src/web/Canvas.tsx packages/fiber/tests/canvas.test.tsx`
- `corepack yarn prettier --check packages/fiber/src/web/Canvas.tsx packages/fiber/tests/canvas.test.tsx`
- `corepack yarn typecheck`
- `corepack yarn validate`
- `git diff --check origin/master...HEAD`