### PR TITLE
[codex] Fix async renderer configure race

### DIFF
--- a/packages/fiber/src/core/renderer.tsx
+++ b/packages/fiber/src/core/renderer.tsx
@@ -41,6 +41,7 @@ interface OffscreenCanvas extends EventTarget {}
 export const _roots = new Map<HTMLCanvasElement | OffscreenCanvas, Root>()
 
 const shallowLoose = { objects: 'shallow', strict: false } as EquConfig
+const isPromise = <T,>(value: T | Promise<T>): value is Promise<T> => typeof (value as Promise<T>)?.then === 'function'
 
 export type DefaultGLProps = Omit<THREE.WebGLRendererParameters, 'canvas'> & {
   canvas: HTMLCanvasElement | OffscreenCanvas
@@ -185,6 +186,7 @@ export function createRoot<TCanvas extends HTMLCanvasElement | OffscreenCanvas>(
 
   let configured = false
   let pending: Promise<void> | null = null
+  let rendererInit: THREE.WebGLRenderer | Promise<THREE.WebGLRenderer> | null = null
 
   return {
     async configure(props: RenderProps<TCanvas> = {}): Promise<ReconcilerRoot<TCanvas>> {
@@ -215,27 +217,47 @@ export function createRoot<TCanvas extends HTMLCanvasElement | OffscreenCanvas>(
       // Set up renderer (one time only!)
       let gl = state.gl
       if (!state.gl) {
-        const defaultProps: DefaultGLProps = {
-          canvas: canvas as HTMLCanvasElement,
-          powerPreference: 'high-performance',
-          antialias: true,
-          alpha: true,
+        if (!rendererInit) {
+          const defaultProps: DefaultGLProps = {
+            canvas: canvas as HTMLCanvasElement,
+            powerPreference: 'high-performance',
+            antialias: true,
+            alpha: true,
+          }
+
+          const createRenderer = (customRenderer: any) => {
+            if (isRenderer(customRenderer)) {
+              return customRenderer
+            }
+
+            return new THREE.WebGLRenderer({
+              ...defaultProps,
+              ...(typeof glConfig === 'function' ? {} : glConfig),
+            })
+          }
+
+          const customRenderer =
+            typeof glConfig === 'function' ? glConfig(defaultProps) : (glConfig as THREE.WebGLRenderer)
+
+          rendererInit = isPromise(customRenderer)
+            ? customRenderer.then(createRenderer)
+            : createRenderer(customRenderer)
+
+          if (isPromise(rendererInit)) rendererInit.catch(() => (rendererInit = null))
         }
 
-        const customRenderer = (
-          typeof glConfig === 'function' ? await glConfig(defaultProps) : glConfig
-        ) as THREE.WebGLRenderer
+        const initializedRenderer = rendererInit
+        if (!initializedRenderer) throw new Error('Renderer could not be initialized')
 
-        if (isRenderer(customRenderer)) {
-          gl = customRenderer
+        gl = isPromise(initializedRenderer) ? await initializedRenderer : initializedRenderer
+        state = store.getState()
+
+        if (!state.gl) {
+          state.set({ gl })
+          state = store.getState()
         } else {
-          gl = new THREE.WebGLRenderer({
-            ...defaultProps,
-            ...glConfig,
-          })
+          gl = state.gl
         }
-
-        state.set({ gl })
       }
 
       // Set up raycaster (one time only!)

--- a/packages/fiber/tests/index.test.tsx
+++ b/packages/fiber/tests/index.test.tsx
@@ -190,6 +190,34 @@ describe('createRoot', () => {
     expect(gl instanceof Renderer).toBe(true)
   })
 
+  it('should reuse async gl initialization while configure is pending', async () => {
+    class Renderer extends THREE.WebGLRenderer {}
+
+    let resolve!: () => void
+    const ready = new Promise<void>((res) => {
+      resolve = res
+    })
+    const gl = jest.fn(async (props) => {
+      await ready
+      return new Renderer(props)
+    })
+
+    const first = root.configure({ gl, size: { width: 300, height: 150, top: 0, left: 0 } })
+    const second = root.configure({ gl, size: { width: 500, height: 400, top: 0, left: 0 } })
+
+    expect(gl).toHaveBeenCalledTimes(1)
+
+    let store: RootStore = null!
+    await act(async () => {
+      resolve()
+      await Promise.all([first, second])
+      store = root.render(<group />)
+    })
+
+    expect(store.getState().gl).toBeInstanceOf(Renderer)
+    expect(store.getState().size).toMatchObject({ width: 500, height: 400 })
+  })
+
   it('should respect color management preferences via gl', async () => {
     let gl: THREE.WebGLRenderer & { outputColorSpace?: string } = null!
     let texture: THREE.Texture & { colorSpace?: string } = null!


### PR DESCRIPTION
## Summary

Fixes #3752.

This caches the in-flight async renderer initialization inside `createRoot.configure`, so repeated configure calls while a WebGPU-style `gl` callback is still resolving reuse the same renderer setup instead of invoking `gl` multiple times. After the shared renderer resolves, configuration rereads current root state before continuing so the latest pending configure can apply the latest size.

A regression test covers two concurrent configure calls with an async `gl` callback and different sizes, asserting that `gl` is called once and the final store size comes from the latest configure call.

## Validation

- `corepack yarn jest packages/fiber/tests/index.test.tsx --runInBand`
- `corepack yarn prettier --check packages/fiber/src/core/renderer.tsx packages/fiber/tests/index.test.tsx`
- `corepack yarn eslint packages/fiber/src/core/renderer.tsx packages/fiber/tests/index.test.tsx` (passes with existing warning-only repo baseline)
- `corepack yarn typecheck`
- `corepack yarn build`
- `git diff --check`