### PR TITLE
[codex] Guard pointer event connection against null targets

### DIFF
--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -82,7 +82,7 @@ export interface EventManager<TTarget> {
   /** All the pointer event handlers through which the host forwards native events */
   handlers?: Events
   /** Allows re-connecting to another target */
-  connect?: (target: TTarget) => void
+  connect?: (target: TTarget | null) => void
   /** Removes all existing events handlers from the target */
   disconnect?: () => void
   /** Triggers a onPointerMove with the last known event. This can be useful to enable raycasting without

--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -28,7 +28,7 @@ export interface CanvasProps
    */
   resize?: ResizeOptions
   /** The target where events are being subscribed to, default: the div that wraps canvas */
-  eventSource?: HTMLElement | React.RefObject<HTMLElement>
+  eventSource?: HTMLElement | React.RefObject<HTMLElement | null>
   /** The event prefix that is cast into canvas pointer x/y events, default: "offset" */
   eventPrefix?: 'offset' | 'client' | 'page' | 'layer' | 'screen'
 }

--- a/packages/fiber/src/web/events.ts
+++ b/packages/fiber/src/web/events.ts
@@ -37,7 +37,9 @@ export function createPointerEvents(store: RootStore): EventManager<HTMLElement>
       const { events, internal } = store.getState()
       if (internal.lastEvent?.current && events.handlers) events.handlers.onPointerMove(internal.lastEvent.current)
     },
-    connect: (target: HTMLElement) => {
+    connect: (target: HTMLElement | null) => {
+      if (!target) return
+
       const { set, events } = store.getState()
       events.disconnect?.()
       set((state) => ({ events: { ...state.events, connected: target } }))

--- a/packages/fiber/tests/events.test.tsx
+++ b/packages/fiber/tests/events.test.tsx
@@ -8,6 +8,20 @@ extend(THREE as any)
 const getContainer = () => document.querySelector('canvas')?.parentNode?.parentNode as HTMLDivElement
 
 describe('events', () => {
+  it('does not throw when connecting to a null event source ref', async () => {
+    const eventSource = React.createRef<HTMLElement>()
+
+    await expect(
+      act(async () => {
+        render(
+          <Canvas eventSource={eventSource}>
+            <group />
+          </Canvas>,
+        )
+      }),
+    ).resolves.toBeUndefined()
+  })
+
   it('can handle onPointerDown', async () => {
     const handlePointerDown = jest.fn()
 


### PR DESCRIPTION
## Summary

Fixes #3754.

This makes the web pointer event manager tolerate a transient `null` event target before it calls DOM APIs. The `EventManager.connect` type now accepts `null`, and `CanvasProps.eventSource` accepts React 19-style refs whose `current` value can be `null`.

A regression test mounts `<Canvas>` with a null `eventSource` ref and verifies the async mount path resolves instead of throwing from `target.addEventListener`.

## Validation

- `corepack yarn jest packages/fiber/tests/events.test.tsx --runInBand`
- `corepack yarn prettier --check packages/fiber/src/core/events.ts packages/fiber/src/web/events.ts packages/fiber/src/web/Canvas.tsx packages/fiber/tests/events.test.tsx`
- `corepack yarn eslint packages/fiber/src/core/events.ts packages/fiber/src/web/events.ts packages/fiber/src/web/Canvas.tsx packages/fiber/tests/events.test.tsx` (passes with existing warning-only repo baseline)
- `corepack yarn typecheck`
- `corepack yarn build`
- `git diff --check`