### PR TITLE
fix: render Canvas fallback after renderer setup failure

### DIFF
--- a/packages/fiber/src/web/Canvas.tsx
+++ b/packages/fiber/src/web/Canvas.tsx
@@ -73,6 +73,7 @@ function CanvasImpl({
   const handlePointerMissed = useMutableCallback(onPointerMissed)
   const [block, setBlock] = React.useState<SetBlock>(false)
   const [error, setError] = React.useState<any>(false)
+  const [fallbackVisible, setFallbackVisible] = React.useState(false)
 
   // Suspend this component if block is a promise (2nd run)
   if (block) throw block
@@ -82,55 +83,62 @@ function CanvasImpl({
   const root = React.useRef<ReconcilerRoot<HTMLCanvasElement>>(null!)
 
   useIsomorphicLayoutEffect(() => {
+    if (fallbackVisible) return
+
     const canvas = canvasRef.current
     if (containerRect.width > 0 && containerRect.height > 0 && canvas) {
       if (!root.current) root.current = createRoot<HTMLCanvasElement>(canvas)
 
       async function run() {
-        await root.current.configure({
-          gl,
-          scene,
-          events,
-          shadows,
-          linear,
-          flat,
-          legacy,
-          orthographic,
-          frameloop,
-          dpr,
-          performance,
-          raycaster,
-          camera,
-          size: containerRect,
-          // Pass mutable reference to onPointerMissed so it's free to update
-          onPointerMissed: (...args) => handlePointerMissed.current?.(...args),
-          onCreated: (state) => {
-            // Connect to event source
-            state.events.connect?.(
-              eventSource ? (isRef(eventSource) ? eventSource.current : eventSource) : divRef.current,
-            )
-            // Set up compute function
-            if (eventPrefix) {
-              state.setEvents({
-                compute: (event, state) => {
-                  const x = event[(eventPrefix + 'X') as keyof DomEvent] as number
-                  const y = event[(eventPrefix + 'Y') as keyof DomEvent] as number
-                  state.pointer.set((x / state.size.width) * 2 - 1, -(y / state.size.height) * 2 + 1)
-                  state.raycaster.setFromCamera(state.pointer, state.camera)
-                },
-              })
-            }
-            // Call onCreated callback
-            onCreated?.(state)
-          },
-        })
-        root.current.render(
-          <Bridge>
-            <ErrorBoundary set={setError}>
-              <React.Suspense fallback={<Block set={setBlock} />}>{children ?? null}</React.Suspense>
-            </ErrorBoundary>
-          </Bridge>,
-        )
+        try {
+          await root.current.configure({
+            gl,
+            scene,
+            events,
+            shadows,
+            linear,
+            flat,
+            legacy,
+            orthographic,
+            frameloop,
+            dpr,
+            performance,
+            raycaster,
+            camera,
+            size: containerRect,
+            // Pass mutable reference to onPointerMissed so it's free to update
+            onPointerMissed: (...args) => handlePointerMissed.current?.(...args),
+            onCreated: (state) => {
+              // Connect to event source
+              state.events.connect?.(
+                eventSource ? (isRef(eventSource) ? eventSource.current : eventSource) : divRef.current,
+              )
+              // Set up compute function
+              if (eventPrefix) {
+                state.setEvents({
+                  compute: (event, state) => {
+                    const x = event[(eventPrefix + 'X') as keyof DomEvent] as number
+                    const y = event[(eventPrefix + 'Y') as keyof DomEvent] as number
+                    state.pointer.set((x / state.size.width) * 2 - 1, -(y / state.size.height) * 2 + 1)
+                    state.raycaster.setFromCamera(state.pointer, state.camera)
+                  },
+                })
+              }
+              // Call onCreated callback
+              onCreated?.(state)
+            },
+          })
+          root.current.render(
+            <Bridge>
+              <ErrorBoundary set={setError}>
+                <React.Suspense fallback={<Block set={setBlock} />}>{children ?? null}</React.Suspense>
+              </ErrorBoundary>
+            </Bridge>,
+          )
+        } catch (e) {
+          if (fallback != null) setFallbackVisible(true)
+          else setError(e)
+        }
       }
       run()
     }
@@ -157,11 +165,15 @@ function CanvasImpl({
         ...style,
       }}
       {...props}>
-      <div ref={containerRef} style={{ width: '100%', height: '100%' }}>
-        <canvas ref={canvasRef} style={{ display: 'block' }}>
-          {fallback}
-        </canvas>
-      </div>
+      {fallbackVisible ? (
+        fallback
+      ) : (
+        <div ref={containerRef} style={{ width: '100%', height: '100%' }}>
+          <canvas ref={canvasRef} style={{ display: 'block' }}>
+            {fallback}
+          </canvas>
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/fiber/tests/canvas.test.tsx
+++ b/packages/fiber/tests/canvas.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import { Canvas, act } from '../src'
 
 describe('web Canvas', () => {
@@ -61,6 +61,24 @@ describe('web Canvas', () => {
     )
 
     expect(() => renderer.unmount()).not.toThrow()
+  })
+
+  it('should render fallback outside the canvas when renderer creation fails', async () => {
+    const renderer = await act(async () =>
+      render(
+        <Canvas
+          fallback={<div>Sorry no WebGL supported!</div>}
+          gl={() => {
+            throw new Error('WebGL unavailable')
+          }}>
+          <group />
+        </Canvas>,
+      ),
+    )
+
+    await waitFor(() => {
+      expect(renderer.getByText('Sorry no WebGL supported!').closest('canvas')).toBe(null)
+    })
   })
 
   it('plays nice with react SSR', async () => {


### PR DESCRIPTION
## Summary

Fixes #3757.

When renderer setup fails before React Three Fiber can render into the canvas, the existing `fallback` prop remains as a child of the `<canvas>` element. Browsers do not visibly render canvas children when the canvas element itself is supported, so users get a blank area even though the fallback is present in the DOM.

This change tracks renderer setup failure and renders the fallback in the Canvas wrapper instead of leaving it inside the canvas. If no fallback is supplied, the setup error is surfaced through Canvas state so an external error boundary can still handle it.

## Validation

- `corepack yarn jest packages/fiber/tests/canvas.test.tsx --runInBand`
- `& .\node_modules\.bin\eslint.cmd packages/fiber/src/web/Canvas.tsx packages/fiber/tests/canvas.test.tsx`
- `corepack yarn prettier --check packages/fiber/src/web/Canvas.tsx packages/fiber/tests/canvas.test.tsx`
- `corepack yarn typecheck`
- `git diff --check`