### PR TITLE
fix(fiber): serialize async renderer configuration

### DIFF
--- a/packages/fiber/src/core/renderer.tsx
+++ b/packages/fiber/src/core/renderer.tsx
@@ -189,7 +189,12 @@ export function createRoot<TCanvas extends HTMLCanvasElement | OffscreenCanvas>(
   return {
     async configure(props: RenderProps<TCanvas> = {}): Promise<ReconcilerRoot<TCanvas>> {
       let resolve!: () => void
-      pending = new Promise<void>((_resolve) => (resolve = _resolve))
+      const previous = pending
+      const current = new Promise<void>((_resolve) => (resolve = _resolve))
+      const nextPending = previous ? previous.then(() => current) : current
+      pending = nextPending
+
+      if (previous) await previous
 
       let {
         gl: glConfig,
@@ -400,20 +405,28 @@ export function createRoot<TCanvas extends HTMLCanvasElement | OffscreenCanvas>(
       onCreated = onCreatedCallback
       configured = true
       resolve()
+      if (pending === nextPending) pending = null
       return this
     },
     render(children: React.ReactNode): RootStore {
       // The root has to be configured before it can be rendered
       if (!configured && !pending) this.configure()
 
-      pending!.then(() => {
+      const render = (): void => {
+        if (pending) {
+          pending.then(render)
+          return
+        }
+
         reconciler.updateContainer(
           <Provider store={store} children={children} onCreated={onCreated} rootElement={canvas} />,
           fiber,
           null,
           () => undefined,
         )
-      })
+      }
+
+      render()
 
       return store
     },

--- a/packages/fiber/tests/renderer.test.tsx
+++ b/packages/fiber/tests/renderer.test.tsx
@@ -51,6 +51,32 @@ describe('renderer', () => {
     expect(scene.children.length).toBe(0)
   })
 
+  it('should serialize async renderer configuration', async () => {
+    let resolveRenderer!: () => void
+    const rendererReady = new Promise<void>((resolve) => (resolveRenderer = resolve))
+    const gl = jest.fn(async (props) => {
+      await rendererReady
+      return new THREE.WebGLRenderer(props)
+    })
+
+    const firstConfigure = root.configure({ gl, size: { width: 300, height: 150, top: 0, left: 0 } })
+    const secondConfigure = root.configure({ gl, size: { width: 500, height: 400, top: 0, left: 0 } })
+
+    await Promise.resolve()
+
+    expect(gl).toHaveBeenCalledTimes(1)
+
+    let store!: ReturnType<ReconcilerRoot<HTMLCanvasElement>['render']>
+    await act(async () => {
+      store = root.render(null)
+      resolveRenderer()
+      await Promise.all([firstConfigure, secondConfigure])
+    })
+
+    expect(gl).toHaveBeenCalledTimes(1)
+    expect(store.getState().size).toMatchObject({ width: 500, height: 400 })
+  })
+
   it('should render native elements', async () => {
     const store = await act(async () => root.render(<group name="native" />))
     const { scene } = store.getState()


### PR DESCRIPTION
## Summary
Fixes #3752.

Serializes overlapping `root.configure()` calls so a slow async renderer initialization cannot start multiple renderer factories for the same root. Later configuration still runs after the pending setup resolves, so the latest size wins before rendering.

## Validation
- `corepack yarn jest packages/fiber/tests/renderer.test.tsx --runInBand`
- `.\node_modules\.bin\eslint.cmd packages/fiber/src/core/renderer.tsx packages/fiber/tests/renderer.test.tsx` (exits 0; existing warning-class output remains)
- `corepack yarn prettier --check packages/fiber/src/core/renderer.tsx packages/fiber/tests/renderer.test.tsx`
- `corepack yarn typecheck`
- `corepack yarn validate`
- `git diff --check origin/master...HEAD`