### PR TITLE
fix(fiber): defer invalidation during root updates

### DIFF
--- a/packages/fiber/src/core/loop.ts
+++ b/packages/fiber/src/core/loop.ts
@@ -134,6 +134,7 @@ export function loop(timestamp: number): void {
 export function invalidate(state?: RootState, frames = 1): void {
   if (!state) return _roots.forEach((root) => invalidate(root.store.getState(), frames))
   if (state.gl.xr?.isPresenting || !state.internal.active || state.frameloop === 'never') return
+  if (state.internal.updating) return
 
   if (frames > 1) {
     // legacy support for people using frames parameters

--- a/packages/fiber/src/core/renderer.tsx
+++ b/packages/fiber/src/core/renderer.tsx
@@ -185,6 +185,11 @@ export function createRoot<TCanvas extends HTMLCanvasElement | OffscreenCanvas>(
 
   let configured = false
   let pending: Promise<void> | null = null
+  let pendingUpdates = 0
+
+  function setUpdating(delta: number): void {
+    store.getState().internal.updating += delta
+  }
 
   return {
     async configure(props: RenderProps<TCanvas> = {}): Promise<ReconcilerRoot<TCanvas>> {
@@ -210,195 +215,202 @@ export function createRoot<TCanvas extends HTMLCanvasElement | OffscreenCanvas>(
         onPointerMissed,
       } = props
 
-      let state = store.getState()
+      const state = store.getState()
+      setUpdating(1)
 
-      // Set up renderer (one time only!)
-      let gl = state.gl
-      if (!state.gl) {
-        const defaultProps: DefaultGLProps = {
-          canvas: canvas as HTMLCanvasElement,
-          powerPreference: 'high-performance',
-          antialias: true,
-          alpha: true,
+      try {
+        // Set up renderer (one time only!)
+        let gl = state.gl
+        if (!state.gl) {
+          const defaultProps: DefaultGLProps = {
+            canvas: canvas as HTMLCanvasElement,
+            powerPreference: 'high-performance',
+            antialias: true,
+            alpha: true,
+          }
+
+          const customRenderer = (
+            typeof glConfig === 'function' ? await glConfig(defaultProps) : glConfig
+          ) as THREE.WebGLRenderer
+
+          if (isRenderer(customRenderer)) {
+            gl = customRenderer
+          } else {
+            gl = new THREE.WebGLRenderer({
+              ...defaultProps,
+              ...glConfig,
+            })
+          }
+
+          state.set({ gl })
         }
 
-        const customRenderer = (
-          typeof glConfig === 'function' ? await glConfig(defaultProps) : glConfig
-        ) as THREE.WebGLRenderer
+        // Set up raycaster (one time only!)
+        let raycaster = state.raycaster
+        if (!raycaster) state.set({ raycaster: (raycaster = new THREE.Raycaster()) })
 
-        if (isRenderer(customRenderer)) {
-          gl = customRenderer
-        } else {
-          gl = new THREE.WebGLRenderer({
-            ...defaultProps,
-            ...glConfig,
-          })
-        }
+        // Set raycaster options
+        const { params, ...options } = raycastOptions || {}
+        if (!is.equ(options, raycaster, shallowLoose)) applyProps(raycaster, { ...options } as any)
+        if (!is.equ(params, raycaster.params, shallowLoose))
+          applyProps(raycaster, { params: { ...raycaster.params, ...params } } as any)
 
-        state.set({ gl })
-      }
-
-      // Set up raycaster (one time only!)
-      let raycaster = state.raycaster
-      if (!raycaster) state.set({ raycaster: (raycaster = new THREE.Raycaster()) })
-
-      // Set raycaster options
-      const { params, ...options } = raycastOptions || {}
-      if (!is.equ(options, raycaster, shallowLoose)) applyProps(raycaster, { ...options } as any)
-      if (!is.equ(params, raycaster.params, shallowLoose))
-        applyProps(raycaster, { params: { ...raycaster.params, ...params } } as any)
-
-      // Create default camera, don't overwrite any user-set state
-      if (!state.camera || (state.camera === lastCamera && !is.equ(lastCamera, cameraOptions, shallowLoose))) {
-        lastCamera = cameraOptions
-        const isCamera = (cameraOptions as unknown as THREE.Camera | undefined)?.isCamera
-        const camera = isCamera
-          ? (cameraOptions as Camera)
-          : orthographic
-          ? new THREE.OrthographicCamera(0, 0, 0, 0, 0.1, 1000)
-          : new THREE.PerspectiveCamera(75, 0, 0.1, 1000)
-        if (!isCamera) {
-          camera.position.z = 5
-          if (cameraOptions) {
-            applyProps(camera, cameraOptions as any)
-            // Preserve user-defined frustum if possible
-            // https://github.com/pmndrs/react-three-fiber/issues/3160
-            if (!(camera as any).manual) {
-              if (
-                'aspect' in cameraOptions ||
-                'left' in cameraOptions ||
-                'right' in cameraOptions ||
-                'bottom' in cameraOptions ||
-                'top' in cameraOptions
-              ) {
-                ;(camera as any).manual = true
-                camera.updateProjectionMatrix()
+        // Create default camera, don't overwrite any user-set state
+        if (!state.camera || (state.camera === lastCamera && !is.equ(lastCamera, cameraOptions, shallowLoose))) {
+          lastCamera = cameraOptions
+          const isCamera = (cameraOptions as unknown as THREE.Camera | undefined)?.isCamera
+          const camera = isCamera
+            ? (cameraOptions as Camera)
+            : orthographic
+            ? new THREE.OrthographicCamera(0, 0, 0, 0, 0.1, 1000)
+            : new THREE.PerspectiveCamera(75, 0, 0.1, 1000)
+          if (!isCamera) {
+            camera.position.z = 5
+            if (cameraOptions) {
+              applyProps(camera, cameraOptions as any)
+              // Preserve user-defined frustum if possible
+              // https://github.com/pmndrs/react-three-fiber/issues/3160
+              if (!(camera as any).manual) {
+                if (
+                  'aspect' in cameraOptions ||
+                  'left' in cameraOptions ||
+                  'right' in cameraOptions ||
+                  'bottom' in cameraOptions ||
+                  'top' in cameraOptions
+                ) {
+                  ;(camera as any).manual = true
+                  camera.updateProjectionMatrix()
+                }
               }
             }
+            // Always look at center by default
+            if (!state.camera && !cameraOptions?.rotation) camera.lookAt(0, 0, 0)
           }
-          // Always look at center by default
-          if (!state.camera && !cameraOptions?.rotation) camera.lookAt(0, 0, 0)
-        }
-        state.set({ camera })
+          state.set({ camera })
 
-        // Configure raycaster
-        // https://github.com/pmndrs/react-xr/issues/300
-        raycaster.camera = camera
-      }
-
-      // Set up scene (one time only!)
-      if (!state.scene) {
-        let scene: THREE.Scene
-
-        if ((sceneOptions as unknown as THREE.Scene | undefined)?.isScene) {
-          scene = sceneOptions as THREE.Scene
-          prepare(scene, store, '', {})
-        } else {
-          scene = new THREE.Scene()
-          prepare(scene, store, '', {})
-          if (sceneOptions) applyProps(scene as any, sceneOptions as any)
+          // Configure raycaster
+          // https://github.com/pmndrs/react-xr/issues/300
+          raycaster.camera = camera
         }
 
-        state.set({ scene })
-      }
+        // Set up scene (one time only!)
+        if (!state.scene) {
+          let scene: THREE.Scene
 
-      // Store events internally
-      if (events && !state.events.handlers) state.set({ events: events(store) })
-      // Check size, allow it to take on container bounds initially
-      const size = computeInitialSize(canvas, propsSize)
-      if (!is.equ(size, state.size, shallowLoose)) {
-        state.setSize(size.width, size.height, size.top, size.left)
-      }
-      // Check pixelratio
-      if (dpr && state.viewport.dpr !== calculateDpr(dpr)) state.setDpr(dpr)
-      // Check frameloop
-      if (state.frameloop !== frameloop) state.setFrameloop(frameloop)
-      // Check pointer missed
-      if (!state.onPointerMissed) state.set({ onPointerMissed })
-      // Check performance
-      if (performance && !is.equ(performance, state.performance, shallowLoose))
-        state.set((state) => ({ performance: { ...state.performance, ...performance } }))
-
-      // Set up XR (one time only!)
-      if (!state.xr) {
-        // Handle frame behavior in WebXR
-        const handleXRFrame: XRFrameRequestCallback = (timestamp: number, frame?: XRFrame) => {
-          const state = store.getState()
-          if (state.frameloop === 'never') return
-          advance(timestamp, true, state, frame)
-        }
-
-        // Toggle render switching on session
-        const handleSessionChange = () => {
-          const state = store.getState()
-          state.gl.xr.enabled = state.gl.xr.isPresenting
-
-          state.gl.xr.setAnimationLoop(state.gl.xr.isPresenting ? handleXRFrame : null)
-          if (!state.gl.xr.isPresenting) invalidate(state)
-        }
-
-        // WebXR session manager
-        const xr = {
-          connect() {
-            const gl = store.getState().gl
-            gl.xr.addEventListener('sessionstart', handleSessionChange)
-            gl.xr.addEventListener('sessionend', handleSessionChange)
-          },
-          disconnect() {
-            const gl = store.getState().gl
-            gl.xr.removeEventListener('sessionstart', handleSessionChange)
-            gl.xr.removeEventListener('sessionend', handleSessionChange)
-          },
-        }
-
-        // Subscribe to WebXR session events
-        if (typeof gl.xr?.addEventListener === 'function') xr.connect()
-        state.set({ xr })
-      }
-
-      // Set shadowmap
-      if (gl.shadowMap) {
-        const oldEnabled = gl.shadowMap.enabled
-        const oldType = gl.shadowMap.type
-        gl.shadowMap.enabled = !!shadows
-
-        if (is.boo(shadows)) {
-          gl.shadowMap.type = THREE.PCFSoftShadowMap
-        } else if (is.str(shadows)) {
-          const types = {
-            basic: THREE.BasicShadowMap,
-            percentage: THREE.PCFShadowMap,
-            soft: THREE.PCFSoftShadowMap,
-            variance: THREE.VSMShadowMap,
+          if ((sceneOptions as unknown as THREE.Scene | undefined)?.isScene) {
+            scene = sceneOptions as THREE.Scene
+            prepare(scene, store, '', {})
+          } else {
+            scene = new THREE.Scene()
+            prepare(scene, store, '', {})
+            if (sceneOptions) applyProps(scene as any, sceneOptions as any)
           }
-          gl.shadowMap.type = types[shadows] ?? THREE.PCFSoftShadowMap
-        } else if (is.obj(shadows)) {
-          Object.assign(gl.shadowMap, shadows)
+
+          state.set({ scene })
         }
 
-        if (oldEnabled !== gl.shadowMap.enabled || oldType !== gl.shadowMap.type) gl.shadowMap.needsUpdate = true
+        // Store events internally
+        if (events && !state.events.handlers) state.set({ events: events(store) })
+        // Check size, allow it to take on container bounds initially
+        const size = computeInitialSize(canvas, propsSize)
+        if (!is.equ(size, state.size, shallowLoose)) {
+          state.setSize(size.width, size.height, size.top, size.left)
+        }
+        // Check pixelratio
+        if (dpr && state.viewport.dpr !== calculateDpr(dpr)) state.setDpr(dpr)
+        // Check frameloop
+        if (state.frameloop !== frameloop) state.setFrameloop(frameloop)
+        // Check pointer missed
+        if (!state.onPointerMissed) state.set({ onPointerMissed })
+        // Check performance
+        if (performance && !is.equ(performance, state.performance, shallowLoose))
+          state.set((state) => ({ performance: { ...state.performance, ...performance } }))
+
+        // Set up XR (one time only!)
+        if (!state.xr) {
+          // Handle frame behavior in WebXR
+          const handleXRFrame: XRFrameRequestCallback = (timestamp: number, frame?: XRFrame) => {
+            const state = store.getState()
+            if (state.frameloop === 'never') return
+            advance(timestamp, true, state, frame)
+          }
+
+          // Toggle render switching on session
+          const handleSessionChange = () => {
+            const state = store.getState()
+            state.gl.xr.enabled = state.gl.xr.isPresenting
+
+            state.gl.xr.setAnimationLoop(state.gl.xr.isPresenting ? handleXRFrame : null)
+            if (!state.gl.xr.isPresenting) invalidate(state)
+          }
+
+          // WebXR session manager
+          const xr = {
+            connect() {
+              const gl = store.getState().gl
+              gl.xr.addEventListener('sessionstart', handleSessionChange)
+              gl.xr.addEventListener('sessionend', handleSessionChange)
+            },
+            disconnect() {
+              const gl = store.getState().gl
+              gl.xr.removeEventListener('sessionstart', handleSessionChange)
+              gl.xr.removeEventListener('sessionend', handleSessionChange)
+            },
+          }
+
+          // Subscribe to WebXR session events
+          if (typeof gl.xr?.addEventListener === 'function') xr.connect()
+          state.set({ xr })
+        }
+
+        // Set shadowmap
+        if (gl.shadowMap) {
+          const oldEnabled = gl.shadowMap.enabled
+          const oldType = gl.shadowMap.type
+          gl.shadowMap.enabled = !!shadows
+
+          if (is.boo(shadows)) {
+            gl.shadowMap.type = THREE.PCFSoftShadowMap
+          } else if (is.str(shadows)) {
+            const types = {
+              basic: THREE.BasicShadowMap,
+              percentage: THREE.PCFShadowMap,
+              soft: THREE.PCFSoftShadowMap,
+              variance: THREE.VSMShadowMap,
+            }
+            gl.shadowMap.type = types[shadows] ?? THREE.PCFSoftShadowMap
+          } else if (is.obj(shadows)) {
+            Object.assign(gl.shadowMap, shadows)
+          }
+
+          if (oldEnabled !== gl.shadowMap.enabled || oldType !== gl.shadowMap.type) gl.shadowMap.needsUpdate = true
+        }
+
+        THREE.ColorManagement.enabled = !legacy
+
+        // Set color space and tonemapping preferences
+        if (!configured) {
+          gl.outputColorSpace = linear ? THREE.LinearSRGBColorSpace : THREE.SRGBColorSpace
+          gl.toneMapping = flat ? THREE.NoToneMapping : THREE.ACESFilmicToneMapping
+        }
+
+        // Update color management state
+        if (state.legacy !== legacy) state.set(() => ({ legacy }))
+        if (state.linear !== linear) state.set(() => ({ linear }))
+        if (state.flat !== flat) state.set(() => ({ flat }))
+
+        // Set gl props
+        if (glConfig && !is.fun(glConfig) && !isRenderer(glConfig) && !is.equ(glConfig, gl, shallowLoose))
+          applyProps(gl, glConfig as any)
+
+        // Set locals
+        onCreated = onCreatedCallback
+        configured = true
+      } finally {
+        setUpdating(-1)
+        if (pendingUpdates === 0 && state.internal.active && !state.internal.updating) invalidate(state)
       }
 
-      THREE.ColorManagement.enabled = !legacy
-
-      // Set color space and tonemapping preferences
-      if (!configured) {
-        gl.outputColorSpace = linear ? THREE.LinearSRGBColorSpace : THREE.SRGBColorSpace
-        gl.toneMapping = flat ? THREE.NoToneMapping : THREE.ACESFilmicToneMapping
-      }
-
-      // Update color management state
-      if (state.legacy !== legacy) state.set(() => ({ legacy }))
-      if (state.linear !== linear) state.set(() => ({ linear }))
-      if (state.flat !== flat) state.set(() => ({ flat }))
-
-      // Set gl props
-      if (glConfig && !is.fun(glConfig) && !isRenderer(glConfig) && !is.equ(glConfig, gl, shallowLoose))
-        applyProps(gl, glConfig as any)
-
-      // Set locals
-      onCreated = onCreatedCallback
-      configured = true
       resolve()
       return this
     },
@@ -407,12 +419,29 @@ export function createRoot<TCanvas extends HTMLCanvasElement | OffscreenCanvas>(
       if (!configured && !pending) this.configure()
 
       pending!.then(() => {
-        reconciler.updateContainer(
-          <Provider store={store} children={children} onCreated={onCreated} rootElement={canvas} />,
-          fiber,
-          null,
-          () => undefined,
-        )
+        setUpdating(1)
+        pendingUpdates++
+        let called = false
+        const callback = () => {
+          if (called) return
+          called = true
+          setUpdating(-1)
+          pendingUpdates--
+          const state = store.getState()
+          if (pendingUpdates === 0 && state.internal.active && !state.internal.updating) invalidate(state)
+        }
+
+        try {
+          reconciler.updateContainer(
+            <Provider store={store} children={children} onCreated={onCreated} rootElement={canvas} />,
+            fiber,
+            null,
+            callback,
+          )
+        } catch (error) {
+          callback()
+          throw error
+        }
       })
 
       return store

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -64,6 +64,8 @@ export interface InternalState {
   initialClick: [x: number, y: number]
   initialHits: THREE.Object3D[]
   lastEvent: React.RefObject<DomEvent | null>
+  /** Number of root updates in-flight (configure/render). */
+  updating: number
   active: boolean
   priority: number
   frames: number
@@ -272,6 +274,7 @@ export const createStore = (
         initialHits: [],
         capturedMap: new Map(),
         lastEvent: React.createRef(),
+        updating: 0,
 
         // Updates
         active: false,

--- a/packages/fiber/tests/renderer.test.tsx
+++ b/packages/fiber/tests/renderer.test.tsx
@@ -1,6 +1,17 @@
 import * as React from 'react'
 import * as THREE from 'three'
-import { ReconcilerRoot, createRoot, act, extend, ThreeElement, ThreeElements, flushSync, useThree } from '../src/index'
+import {
+  ReconcilerRoot,
+  createRoot,
+  act,
+  extend,
+  ThreeElement,
+  ThreeElements,
+  advance,
+  flushSync,
+  useFrame,
+  useThree,
+} from '../src/index'
 import { suspend } from 'suspend-react'
 
 extend(THREE as any)
@@ -863,5 +874,42 @@ describe('renderer', () => {
 
     await act(async () => root.render(<TestComponent />))
     await act(async () => updateSynchronously(1))
+  })
+
+  it('updates camera and objects atomically during prop-driven scene updates', async () => {
+    const framePairs: [meshX: number, cameraZ: number][] = []
+
+    function Test({ step }: { step: number }) {
+      const mesh = React.useRef<THREE.Mesh>(null!)
+      const camera = useThree((state) => state.camera)
+
+      useFrame(() => {
+        if (!mesh.current) return
+        framePairs.push([mesh.current.position.x, camera.position.z])
+      })
+
+      camera.position.z = step
+
+      return <mesh position={[step, 0, 0]} ref={mesh} />
+    }
+
+    const store = await act(async () => (await root.configure({ frameloop: 'never' })).render(<Test step={0} />))
+    advance(Date.now())
+    framePairs.length = 0
+
+    await act(async () => root.render(<Test step={1} />))
+    advance(Date.now())
+
+    const hasMixedNewObjectOldCamera = framePairs.some(([meshX, cameraZ]) => meshX === 0 && cameraZ === 1)
+    const hasMixedOldObjectNewCamera = framePairs.some(([meshX, cameraZ]) => meshX === 1 && cameraZ === 0)
+    const hasAtomicFrame = framePairs.some(([meshX, cameraZ]) => meshX === 1 && cameraZ === 1)
+
+    expect(hasMixedNewObjectOldCamera).toBe(false)
+    expect(hasMixedOldObjectNewCamera).toBe(false)
+    expect(hasAtomicFrame).toBe(true)
+
+    await act(async () => {
+      store.getState().setFrameloop('always')
+    })
   })
 })


### PR DESCRIPTION
## Summary

Fixes #3750.

- Track in-flight root configure/render updates so invalidation is deferred until the update scope finishes.
- Skip frame invalidation while a root update is actively mutating camera/object state.
- Add regression coverage that updates camera and object props together and asserts no mixed old/new frame is observed.

## Validation

- `corepack yarn prettier --check packages/fiber/src/core/loop.ts packages/fiber/src/core/renderer.tsx packages/fiber/src/core/store.ts packages/fiber/tests/renderer.test.tsx`
- `corepack yarn eslint packages/fiber/src/core/loop.ts packages/fiber/src/core/renderer.tsx packages/fiber/src/core/store.ts packages/fiber/tests/renderer.test.tsx` (exits 0; repository has pre-existing warnings)
- `corepack yarn jest packages/fiber/tests/renderer.test.tsx -t "updates camera and objects atomically during prop-driven scene updates" --runInBand`
- `corepack yarn jest packages/fiber/tests/renderer.test.tsx --runInBand`
- `corepack yarn typecheck`
- `corepack yarn validate`
- `git diff --check`