### PR TITLE
fix(docs): remove outdated koestlich README link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -255,7 +255,6 @@ There is a vibrant and extensive ecosystem around three-fiber, full of libraries
 - [`miniplex`](https://github.com/hmans/miniplex) &ndash; ECS (entity management system)
 - [`composer-suite`](https://github.com/hmans/composer-suite) &ndash; composing shaders, particles, effects and game mechanics
 - [`triplex`](https://triplex.dev/) &ndash; visual editor for react-three-fiber
-- [`koestlich`](https://github.com/coconut-xr/koestlich) &ndash; UI component library for react-three-fiber
 
 [Usage Trend of the @react-three Family](https://npm-compare.com/@react-three/a11y,@react-three/cannon,@react-three/csg,@react-three/drei,@react-three/flex,@react-three/gltfjsx,@react-three/gpu-pathtracer,@react-three/offscreen,@react-three/p2,@react-three/postprocessing,@react-three/rapier,@react-three/test-renderer,@react-three/uikit,@react-three/xr)
 


### PR DESCRIPTION
## Summary
- remove the `koestlich` ecosystem entry from `readme.md`
- avoid pointing readers to a repository that currently returns 404

## Test plan
- [x] verify `readme.md` no longer contains `koestlich`
- [x] confirm the docs change is limited to a single deleted bullet

Made with [Cursor](https://cursor.com)