### PR TITLE
Fix(events): guard connect against null target - #3754

### DIFF
--- a/.changeset/hungry-eagles-jump.md
+++ b/.changeset/hungry-eagles-jump.md
@@ -1,0 +1,5 @@
+---
+'@react-three/fiber': patch
+---
+
+fix: prevent TypeError when events.connect is called with a null target, e.g. when the canvas wrapper ref is momentarily null during DOM reparenting

--- a/packages/fiber/src/web/events.ts
+++ b/packages/fiber/src/web/events.ts
@@ -38,6 +38,7 @@ export function createPointerEvents(store: RootStore): EventManager<HTMLElement>
       if (internal.lastEvent?.current && events.handlers) events.handlers.onPointerMove(internal.lastEvent.current)
     },
     connect: (target: HTMLElement) => {
+      if (!target) return
       const { set, events } = store.getState()
       events.disconnect?.()
       set((state) => ({ events: { ...state.events, connected: target } }))

--- a/packages/fiber/tests/events.test.tsx
+++ b/packages/fiber/tests/events.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { render, fireEvent, RenderResult } from '@testing-library/react'
-import { Canvas, act, extend } from '../src'
+import { Canvas, act, extend, type RootState } from '../src'
 import THREE from 'three'
 
 extend(THREE as any)
@@ -584,6 +584,33 @@ describe('events', () => {
         </Canvas>,
       )
     })
+
+    const evt = new PointerEvent('pointerdown')
+    Object.defineProperty(evt, 'offsetX', { get: () => 577 })
+    Object.defineProperty(evt, 'offsetY', { get: () => 480 })
+
+    fireEvent(getContainer(), evt)
+
+    expect(handlePointerDown).toHaveBeenCalled()
+  })
+
+  it('should not throw and keeps the previous connection when connect is called with a null target', async () => {
+    const handlePointerDown = jest.fn()
+    let state: RootState = null!
+
+    await act(async () => {
+      render(
+        <Canvas onCreated={(s) => (state = s)}>
+          <mesh onPointerDown={handlePointerDown}>
+            <boxGeometry args={[2, 2]} />
+            <meshBasicMaterial />
+          </mesh>
+        </Canvas>,
+      )
+    })
+
+    expect(() => state.events.connect?.(null as unknown as HTMLElement)).not.toThrow()
+    expect(state.events.connected).not.toBeNull()
 
     const evt = new PointerEvent('pointerdown')
     Object.defineProperty(evt, 'offsetX', { get: () => 577 })


### PR DESCRIPTION
**Fixes #3754**

`connect` crashes with a TypeError when the target is null (happens when the canvas is reparented mid-animation and the wrapper ref is briefly null). `disconnect` already guards against this, `connect` didn't.

Added an early return before the disconnect call, so a transient null doesn't tear down a working connection — the effect reconnects once the ref is back anyway. Added a regression test + changeset.