### PR TITLE
feat(fiber): add state.timer alongside state.clock

### DIFF
--- a/.changeset/clock-timer-deprecation.md
+++ b/.changeset/clock-timer-deprecation.md
@@ -1,0 +1,7 @@
+---
+'@react-three/fiber': minor
+---
+
+feat: add `state.timer` (THREE.Timer) and deprecate `state.clock`
+
+Adds `state.timer`, a `THREE.Timer` instance, available on three r178+ (otherwise `undefined`). `state.clock` is unchanged but marked deprecated; prefer `state.timer` where available.

--- a/.changeset/clock-timer-deprecation.md
+++ b/.changeset/clock-timer-deprecation.md
@@ -3,5 +3,3 @@
 ---
 
 feat: add `state.timer` (THREE.Timer) and deprecate `state.clock`
-
-Adds `state.timer`, a `THREE.Timer` instance, available on three r178+ (otherwise `undefined`). `state.clock` is unchanged but marked deprecated; prefer `state.timer` where available.

--- a/packages/fiber/src/core/loop.ts
+++ b/packages/fiber/src/core/loop.ts
@@ -68,6 +68,8 @@ function update(timestamp: number, state: RootState, frame?: XRFrame) {
     state.clock.elapsedTime = timestamp
   }
 
+  ;(state.timer as any)?.update(timestamp)
+
   // Call subscribers (useFrame)
   subscribers = state.internal.subscribers
   for (let i = 0; i < subscribers.length; i++) {

--- a/packages/fiber/src/core/loop.ts
+++ b/packages/fiber/src/core/loop.ts
@@ -68,7 +68,7 @@ function update(timestamp: number, state: RootState, frame?: XRFrame) {
     state.clock.elapsedTime = timestamp
   }
 
-  ;(state.timer as any)?.update(timestamp)
+  state.timer?.update(timestamp)
 
   // Call subscribers (useFrame)
   subscribers = state.internal.subscribers

--- a/packages/fiber/src/core/loop.ts
+++ b/packages/fiber/src/core/loop.ts
@@ -68,7 +68,7 @@ function update(timestamp: number, state: RootState, frame?: XRFrame) {
     state.clock.elapsedTime = timestamp
   }
 
-  state.timer?.update(timestamp)
+  ;(state.timer as any)?.update(timestamp)
 
   // Call subscribers (useFrame)
   subscribers = state.internal.subscribers

--- a/packages/fiber/src/core/reconciler.tsx
+++ b/packages/fiber/src/core/reconciler.tsx
@@ -135,7 +135,7 @@ interface HostConfig {
   TransitionStatus: null
 }
 
-const catalogue: Catalogue = {}
+export const catalogue: Catalogue = {}
 
 const PREFIX_REGEX = /^three(?=[A-Z])/
 

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -4,14 +4,14 @@ import { type StoreApi } from 'zustand'
 import { createWithEqualityFn, type UseBoundStoreWithEqualityFn } from 'zustand/traditional'
 import type { DomEvent, EventManager, PointerCaptureTarget, ThreeEvent } from './events'
 import { calculateDpr, type Camera, isOrthographicCamera, updateCamera } from './utils'
+import { catalogue } from './reconciler'
 
 export interface Intersection extends THREE.Intersection {
   eventObject: THREE.Object3D
 }
 
-const _Timer = 'Timer' in THREE ? THREE.Timer : undefined
-type TimerType = typeof _Timer extends new () => infer T ? T : any
-const Timer = _Timer as TimerType
+type TimerType = (typeof THREE & { Timer?: unknown })['Timer'] extends new () => infer T ? T : any
+const getTimer = (): (new () => TimerType) | undefined => (catalogue as any).Timer
 
 export type Subscription = {
   ref: React.RefObject<RenderCallback>
@@ -206,7 +206,10 @@ export const createStore = (
       flat: false,
 
       controls: null,
-      timer: Timer ? new Timer() : undefined,
+      timer: (() => {
+        const Timer = getTimer()
+        return Timer ? new Timer() : undefined
+      })(),
       clock: new THREE.Clock(),
       pointer,
       mouse: pointer,

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -10,9 +10,10 @@ export interface Intersection extends THREE.Intersection {
   eventObject: THREE.Object3D
 }
 
-type TimerType = (typeof THREE & { Timer?: unknown })['Timer'] extends new () => infer T ? T : any
-function getTimer() {
+type TimerType = (typeof THREE & { Timer?: unknown })['Timer'] extends new () => infer T ? T : undefined
+function getTimer(): TimerType {
   if ('Timer' in catalogue) return new catalogue.Timer() as TimerType
+  return undefined as any as TimerType
 }
 
 export type Subscription = {
@@ -95,7 +96,7 @@ export interface RootState {
   /** Default raycaster */
   raycaster: THREE.Raycaster
   /** Default timer */
-  timer?: TimerType
+  timer: TimerType
   /**
    * Default clock
    * @deprecated use `timer` instead
@@ -272,7 +273,7 @@ export const createStore = (
           clock.start()
           clock.elapsedTime = 0
         }
-        get().timer?.reset()
+        ;(get().timer as any)?.reset()
         set(() => ({ frameloop }))
       },
       previousRoot: undefined,

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -11,7 +11,9 @@ export interface Intersection extends THREE.Intersection {
 }
 
 type TimerType = (typeof THREE & { Timer?: unknown })['Timer'] extends new () => infer T ? T : any
-const getTimer = (): (new () => TimerType) | undefined => (catalogue as any).Timer
+function getTimer() {
+  if ('Timer' in catalogue) return new catalogue.Timer() as TimerType
+}
 
 export type Subscription = {
   ref: React.RefObject<RenderCallback>
@@ -206,10 +208,7 @@ export const createStore = (
       flat: false,
 
       controls: null,
-      timer: (() => {
-        const Timer = getTimer()
-        return Timer ? new Timer() : undefined
-      })(),
+      timer: getTimer(),
       clock: new THREE.Clock(),
       pointer,
       mouse: pointer,

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -9,6 +9,9 @@ export interface Intersection extends THREE.Intersection {
   eventObject: THREE.Object3D
 }
 
+const Timer = 'Timer' in THREE ? THREE.Timer : undefined
+type TimerType = typeof Timer
+
 export type Subscription = {
   ref: React.RefObject<RenderCallback>
   priority: number
@@ -88,7 +91,12 @@ export interface RootState {
   scene: THREE.Scene
   /** Default raycaster */
   raycaster: THREE.Raycaster
-  /** Default clock */
+  /** Default timer */
+  timer?: TimerType
+  /**
+   * Default clock
+   * @deprecated use `timer` instead
+   */
   clock: THREE.Clock
   /** Event layer interface, contains the event handler and the node they're connected to */
   events: EventManager<any>
@@ -197,6 +205,7 @@ export const createStore = (
       flat: false,
 
       controls: null,
+      timer: Timer ? new (Timer as any)() : undefined,
       clock: new THREE.Clock(),
       pointer,
       mouse: pointer,
@@ -260,6 +269,7 @@ export const createStore = (
           clock.start()
           clock.elapsedTime = 0
         }
+        ;(get().timer as any)?.reset()
         set(() => ({ frameloop }))
       },
       previousRoot: undefined,

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -9,8 +9,9 @@ export interface Intersection extends THREE.Intersection {
   eventObject: THREE.Object3D
 }
 
-const Timer = 'Timer' in THREE ? THREE.Timer : undefined
-type TimerType = typeof Timer
+const _Timer = 'Timer' in THREE ? THREE.Timer : undefined
+type TimerType = typeof _Timer extends new () => infer T ? T : any
+const Timer = _Timer as TimerType
 
 export type Subscription = {
   ref: React.RefObject<RenderCallback>
@@ -205,7 +206,7 @@ export const createStore = (
       flat: false,
 
       controls: null,
-      timer: Timer ? new (Timer as any)() : undefined,
+      timer: Timer ? new Timer() : undefined,
       clock: new THREE.Clock(),
       pointer,
       mouse: pointer,
@@ -269,7 +270,7 @@ export const createStore = (
           clock.start()
           clock.elapsedTime = 0
         }
-        ;(get().timer as any)?.reset()
+        get().timer?.reset()
         set(() => ({ frameloop }))
       },
       previousRoot: undefined,

--- a/packages/fiber/tests/hooks.test.tsx
+++ b/packages/fiber/tests/hooks.test.tsx
@@ -86,6 +86,26 @@ describe('hooks', () => {
     expect(frameCalls.length).toBeGreaterThan(0)
   })
 
+  it('exposes a timer when THREE.Timer is available and advances it each frame', async () => {
+    const TimerConstructor = (THREE as { Timer?: new () => unknown }).Timer
+    const timerRoot = createRoot(createCanvas())
+    const store = await act(async () => (await timerRoot.configure({ frameloop: 'never' })).render(<group />))
+    const { timer } = store.getState()
+
+    if (TimerConstructor) {
+      expect(timer).toBeInstanceOf(TimerConstructor)
+
+      const before = timer!.getElapsed()
+      timer!.update(performance.now())
+      expect(timer!.getElapsed()).toBeGreaterThanOrEqual(before)
+      expect(Number.isFinite(timer!.getElapsed())).toBe(true)
+    } else {
+      expect(timer).toBeUndefined()
+    }
+
+    await act(async () => timerRoot.unmount())
+  })
+
   it('can handle useLoader hook', async () => {
     const MockMesh = new THREE.Mesh()
     MockMesh.name = 'Scene'

--- a/packages/fiber/tests/hooks.test.tsx
+++ b/packages/fiber/tests/hooks.test.tsx
@@ -95,10 +95,10 @@ describe('hooks', () => {
     if (TimerConstructor) {
       expect(timer).toBeInstanceOf(TimerConstructor)
 
-      const before = timer!.getElapsed()
-      timer!.update(performance.now())
-      expect(timer!.getElapsed()).toBeGreaterThanOrEqual(before)
-      expect(Number.isFinite(timer!.getElapsed())).toBe(true)
+      const before = (timer as any).getElapsed()
+      ;(timer as any).update(performance.now())
+      expect((timer as any).getElapsed()).toBeGreaterThanOrEqual(before)
+      expect(Number.isFinite((timer as any).getElapsed())).toBe(true)
     } else {
       expect(timer).toBeUndefined()
     }


### PR DESCRIPTION
Adds `state.timer` (a `THREE.Timer`) next to the existing `state.clock`, since `THREE.Clock` is deprecated as of three r183. Refs #3741.

- `state.timer` is a `THREE.Timer` on three r178+, otherwise `undefined`. It's advanced every frame, so you can use `useFrame(({ timer }) => timer?.getElapsed())`.
- `state.clock` is untouched — still works exactly as before, just marked `@deprecated`.

Purely additive. Whether to eventually drop `Clock` / raise the three floor is left for later.