### PR TITLE
fix: v10 alpha.3 functional bugs (#1, #2, #3, #4, #6)

### DIFF
--- a/packages/fiber/src/core/Canvas.tsx
+++ b/packages/fiber/src/core/Canvas.tsx
@@ -6,11 +6,12 @@ import { isRef, Block, ErrorBoundary, useMutableCallback, useIsomorphicLayoutEff
 import { extend, createRoot, unmountComponentAtNode, _roots } from './index'
 import { createPointerEvents } from './events'
 import { notifyAlpha } from './utils/notices'
-import { Environment, EnvironmentProps } from './components/Environment/Environment'
-import { presetsObj } from './components/Environment/environment-assets'
+import { Environment } from './components/Environment/Environment'
+import { parseBackground } from './utils/parseBackground'
+import { clearHmrCaches } from './utils/hmr'
 
 //* Type Imports ==============================
-import type { SetBlock, ReconcilerRoot, DomEvent, CanvasProps, BackgroundConfig } from '#types'
+import type { SetBlock, ReconcilerRoot, DomEvent, CanvasProps } from '#types'
 
 function CanvasImpl({
   ref,
@@ -32,6 +33,8 @@ function CanvasImpl({
   raycaster,
   camera,
   scene,
+  autoUpdateFrustum,
+  occlusion,
   onPointerMissed,
   onDragOverMissed,
   onDropMissed,
@@ -70,48 +73,8 @@ function CanvasImpl({
   const Bridge = useBridge()
 
   //* Background Prop Parsing ==============================
-  // Parse background prop into Environment-compatible props
-  const backgroundProps = React.useMemo((): EnvironmentProps | null => {
-    if (!background) return null
-
-    // Object form - pass through with mapping
-    if (typeof background === 'object' && !(background as any).isColor) {
-      const { backgroundMap, envMap, files, preset, ...rest } = background as BackgroundConfig
-      return {
-        ...rest,
-        preset,
-        files: envMap || files,
-        backgroundFiles: backgroundMap,
-        background: true,
-      }
-    }
-
-    // Number = hex color
-    if (typeof background === 'number') {
-      return { color: background, background: true }
-    }
-
-    // String - detect type
-    if (typeof background === 'string') {
-      // Preset?
-      if (background in presetsObj) {
-        return { preset: background as keyof typeof presetsObj, background: true }
-      }
-      // URL pattern or image extension?
-      if (/^(https?:\/\/|\/|\.\/|\.\.\/)|\\.(hdr|exr|jpg|jpeg|png|webp|gif)$/i.test(background)) {
-        return { files: background, background: true }
-      }
-      // Default to color
-      return { color: background, background: true }
-    }
-
-    // THREE.Color instance
-    if ((background as any).isColor) {
-      return { color: background as THREE.ColorRepresentation, background: true }
-    }
-
-    return null
-  }, [background])
+  // Parse background prop into Environment-compatible props (see ./utils/parseBackground)
+  const backgroundProps = React.useMemo(() => parseBackground(background), [background])
 
   //* Dynamic Debounce for Fast Initial Render ==============================
   // Track if we've gotten initial size measurement
@@ -230,6 +193,8 @@ function CanvasImpl({
           performance,
           raycaster,
           camera,
+          autoUpdateFrustum,
+          occlusion,
           size: effectiveSize,
           // Store size props for reset functionality
           _sizeProps: width !== undefined || height !== undefined ? { width, height } : null,
@@ -299,8 +264,8 @@ function CanvasImpl({
     }
   }, [])
 
-  //* HMR Support for TSL Nodes and Uniforms ==============================
-  // Automatically refresh nodes/uniforms when HMR is detected (dev mode only)
+  //* HMR Support for TSL Resources ==============================
+  // Automatically refresh nodes/uniforms/buffers/gpuStorage when HMR is detected (dev mode only)
   // Can be disabled with hmr={false} prop
   React.useEffect(() => {
     // Skip if explicitly disabled
@@ -315,15 +280,7 @@ function CanvasImpl({
     const handleHMR = () => {
       queueMicrotask(() => {
         const rootEntry = _roots.get(canvas)
-        if (rootEntry?.store) {
-          console.log('[R3F] HMR detected — rebuilding nodes/uniforms')
-          // Clear nodes/uniforms and increment _hmrVersion to trigger creators to re-run
-          rootEntry.store.setState((state) => ({
-            nodes: {},
-            uniforms: {},
-            _hmrVersion: state._hmrVersion + 1,
-          }))
-        }
+        if (rootEntry?.store) clearHmrCaches(rootEntry.store)
       })
     }
 

--- a/packages/fiber/src/core/hooks/usePrimaryStore.tsx
+++ b/packages/fiber/src/core/hooks/usePrimaryStore.tsx
@@ -1,0 +1,51 @@
+import { useMemo } from 'react'
+import { useStore } from './index'
+
+//* Type Imports ==============================
+import type { RootState, RootStore } from '#types'
+
+/**
+ * Resolve the authoritative store for shared TSL resources.
+ *
+ * In multi-canvas WebGPU mode, shared resources (nodes, uniforms, buffers, GPU
+ * storage) live on the PRIMARY canvas's store so every canvas sees the same
+ * resources. `primaryStore` is set on every store during renderer init: it
+ * self-references on the primary/single canvas and points at the primary on
+ * secondaries. It is `null` until init completes, so we fall back to the local
+ * store (also the steady state for single-canvas / WebGL).
+ *
+ * @internal
+ */
+function resolvePrimary(local: RootStore): RootStore {
+  return local.getState().primaryStore ?? local
+}
+
+/**
+ * Imperative handle to the primary store for `getState()` / `setState()`.
+ * Falls back to the local store when `primaryStore` is absent.
+ */
+export function usePrimaryStore(): RootStore {
+  const local = useStore()
+  const primary = local.getState().primaryStore
+  return useMemo(() => primary ?? local, [primary, local])
+}
+
+/**
+ * Reactive selector against the PRIMARY store (mirrors {@link useThree} but
+ * subscribes to the primary so a secondary canvas re-renders when the primary's
+ * shared TSL state changes). Falls back to the local store when `primaryStore`
+ * is absent.
+ *
+ * Resolves the store and makes exactly ONE unconditional bound-store hook call
+ * (`primary(selector, eq)`); zustand re-reads `subscribe`/`getSnapshot` each
+ * render, so the one-time `null → primary` init transition is safe and does not
+ * violate the rules of hooks.
+ */
+export function usePrimaryThree<T = RootState>(
+  selector: (state: RootState) => T = (state) => state as unknown as T,
+  equalityFn?: (a: T, b: T) => boolean,
+): T {
+  const local = useStore()
+  const primary = resolvePrimary(local)
+  return primary(selector, equalityFn)
+}

--- a/packages/fiber/src/core/renderer.tsx
+++ b/packages/fiber/src/core/renderer.tsx
@@ -649,7 +649,9 @@ export function createRoot<TCanvas extends HTMLCanvasElement | OffscreenCanvas>(
         )
 
         // Register frustum update job - updates frustum from camera before render
-        // Runs in preRender phase so it captures any camera movement from update phase
+        // Uses { before: 'render' } so it runs after 'update' (capturing this frame's
+        // camera movement) but before 'render', keeping state.frustum fresh for the
+        // render phase. This resolves to an auto-generated 'before:render' phase.
         const unregisterFrustum = scheduler.register(
           () => {
             const state = store.getState()
@@ -660,14 +662,17 @@ export function createRoot<TCanvas extends HTMLCanvasElement | OffscreenCanvas>(
           {
             id: `${newRootId}_frustum`,
             rootId: newRootId,
-            phase: 'preRender',
+            before: 'render',
             system: true,
           },
         )
 
         // Register visibility check job - checks onFramed, onOccluded, onVisible events
-        // Runs in 'preRender' phase BEFORE render so occlusionTest flag is set before rendering
-        // (isOccluded reads from previous frame's render results)
+        // Runs before 'render' (same 'before:render' phase as the frustum job) and after
+        // the frustum job. Frustum/onFramed checks are pure CPU math off the camera, so
+        // running before render keeps them current. Occlusion (onOccluded / the occlusion
+        // half of onVisible) reads internal.occlusionCache, which the render pass populates;
+        // that data is inherently one frame deferred regardless of this job's ordering.
         const unregisterVisibility = scheduler.register(
           () => {
             const state = store.getState()
@@ -676,7 +681,7 @@ export function createRoot<TCanvas extends HTMLCanvasElement | OffscreenCanvas>(
           {
             id: `${newRootId}_visibility`,
             rootId: newRootId,
-            phase: 'preRender',
+            before: 'render',
             system: true,
             after: `${newRootId}_frustum`,
           },

--- a/packages/fiber/src/core/utils/hmr.ts
+++ b/packages/fiber/src/core/utils/hmr.ts
@@ -1,0 +1,19 @@
+import type { RootStore } from '#types'
+
+// NOTE: intentionally NOT re-exported from ./index — internal helper only.
+
+/**
+ * Clear all TSL resource caches on HMR and bump `_hmrVersion` so creators re-run.
+ *
+ * All four maps must be cleared: leaving `buffers`/`gpuStorage` in place lets
+ * particle/compute buffers and storage textures go stale after a hot reload.
+ */
+export function clearHmrCaches(store: RootStore): void {
+  store.setState((state) => ({
+    nodes: {},
+    uniforms: {},
+    buffers: {},
+    gpuStorage: {},
+    _hmrVersion: state._hmrVersion + 1,
+  }))
+}

--- a/packages/fiber/src/core/utils/parseBackground.ts
+++ b/packages/fiber/src/core/utils/parseBackground.ts
@@ -1,0 +1,55 @@
+import type * as THREE from '#three'
+import type { BackgroundProp, BackgroundConfig } from '#types'
+import type { EnvironmentProps } from '../components/Environment/Environment'
+import { presetsObj } from '../components/Environment/environment-assets'
+
+// NOTE: intentionally NOT re-exported from ./index — this is an internal helper.
+// Keeping it out of the barrel avoids leaking it into the public package API.
+
+/**
+ * Parse the Canvas `background` prop into Environment-compatible props.
+ *
+ * Detection order for string values: preset name → URL / file path → CSS color.
+ * Returns `null` when no background is set.
+ */
+export function parseBackground(background: BackgroundProp | undefined): EnvironmentProps | null {
+  if (!background) return null
+
+  // Object form - pass through with mapping
+  if (typeof background === 'object' && !(background as any).isColor) {
+    const { backgroundMap, envMap, files, preset, ...rest } = background as BackgroundConfig
+    return {
+      ...rest,
+      preset,
+      files: envMap || files,
+      backgroundFiles: backgroundMap,
+      background: true,
+    }
+  }
+
+  // Number = hex color
+  if (typeof background === 'number') {
+    return { color: background, background: true }
+  }
+
+  // String - detect type
+  if (typeof background === 'string') {
+    // Preset?
+    if (background in presetsObj) {
+      return { preset: background as keyof typeof presetsObj, background: true }
+    }
+    // URL pattern (prefix) or image extension (suffix)?
+    if (/^(https?:\/\/|\/|\.\/|\.\.\/)|\.(hdr|exr|jpg|jpeg|png|webp|gif)$/i.test(background)) {
+      return { files: background, background: true }
+    }
+    // Default to color
+    return { color: background, background: true }
+  }
+
+  // THREE.Color instance
+  if ((background as any).isColor) {
+    return { color: background as THREE.ColorRepresentation, background: true }
+  }
+
+  return null
+}

--- a/packages/fiber/src/core/visibility.ts
+++ b/packages/fiber/src/core/visibility.ts
@@ -307,7 +307,8 @@ export function updateVisibilityHandlers(
 
 /**
  * Check visibility state for all registered objects.
- * Called each frame in the preRender phase.
+ * Called each frame before the render phase (via the frustum/visibility jobs'
+ * { before: 'render' } scheduling).
  *
  * @param state - The current root state
  */

--- a/packages/fiber/src/webgpu/hooks/useBuffers.tsx
+++ b/packages/fiber/src/webgpu/hooks/useBuffers.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react'
-import { useStore, useThree } from '../../core/hooks'
+import { useStore } from '../../core/hooks'
+import { usePrimaryStore, usePrimaryThree } from '../../core/hooks/usePrimaryStore'
 import { createLazyCreatorState, type CreatorState } from './ScopedStore'
 import type { BufferLike, BufferRecord } from '#types'
 
@@ -128,7 +129,7 @@ export function useBuffers<T extends Record<string, BufferLike>>(
   | BuffersWithUtils<T>
   | BuffersWithUtils<Record<string, BufferLike>>
   | BuffersWithUtils<Record<string, BufferLike> & Record<string, Record<string, BufferLike>>> {
-  const store = useStore()
+  const store = usePrimaryStore()
 
   //* Utils ==============================
   // Memoized util functions that capture store reference
@@ -231,11 +232,11 @@ export function useBuffers<T extends Record<string, BufferLike>>(
   // Subscribe to buffers changes for reader modes
   // This ensures useBuffers() and useBuffers('scope') reactively update when store changes
   // For creator mode, we intentionally don't use this value to avoid re-running the creator
-  const storeBuffers = useThree((s) => s.buffers)
+  const storeBuffers = usePrimaryThree((s) => s.buffers)
 
   // Subscribe to HMR version for creator modes
   // This allows rebuildBuffers() to bust the memoization cache and force re-creation
-  const hmrVersion = useThree((s) => s._hmrVersion)
+  const hmrVersion = usePrimaryThree((s) => s._hmrVersion)
 
   // Extracted deps to avoid complex expressions in useMemo dependency array
   const scopeDep = typeof creatorOrScope === 'string' ? creatorOrScope : scope
@@ -338,6 +339,8 @@ export function useBuffers<T extends Record<string, BufferLike>>(
  * @param scope - Optional scope to rebuild ('root' for root only, string for specific scope, undefined for all)
  */
 export function rebuildAllBuffers(store: ReturnType<typeof useStore>, scope?: string) {
+  // Resolve to the primary store so shared TSL resources rebuild on the authoritative store
+  store = store.getState().primaryStore ?? store
   store.setState((state) => {
     let newBuffers = state.buffers
     if (scope && scope !== 'root') {

--- a/packages/fiber/src/webgpu/hooks/useGPUStorage.tsx
+++ b/packages/fiber/src/webgpu/hooks/useGPUStorage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react'
-import { useStore, useThree } from '../../core/hooks'
+import { useStore } from '../../core/hooks'
+import { usePrimaryStore, usePrimaryThree } from '../../core/hooks/usePrimaryStore'
 import { createLazyCreatorState, type CreatorState } from './ScopedStore'
 import type { StorageLike, StorageRecord } from '#types'
 
@@ -130,7 +131,7 @@ export function useGPUStorage<T extends Record<string, StorageLike>>(
   | StorageWithUtils<T>
   | StorageWithUtils<Record<string, StorageLike>>
   | StorageWithUtils<Record<string, StorageLike> & Record<string, Record<string, StorageLike>>> {
-  const store = useStore()
+  const store = usePrimaryStore()
 
   //* Utils ==============================
   // Memoized util functions that capture store reference
@@ -233,11 +234,11 @@ export function useGPUStorage<T extends Record<string, StorageLike>>(
   // Subscribe to gpuStorage changes for reader modes
   // This ensures useGPUStorage() and useGPUStorage('scope') reactively update when store changes
   // For creator mode, we intentionally don't use this value to avoid re-running the creator
-  const storeStorage = useThree((s) => s.gpuStorage)
+  const storeStorage = usePrimaryThree((s) => s.gpuStorage)
 
   // Subscribe to HMR version for creator modes
   // This allows rebuildStorage() to bust the memoization cache and force re-creation
-  const hmrVersion = useThree((s) => s._hmrVersion)
+  const hmrVersion = usePrimaryThree((s) => s._hmrVersion)
 
   // Extracted deps to avoid complex expressions in useMemo dependency array
   const scopeDep = typeof creatorOrScope === 'string' ? creatorOrScope : scope
@@ -354,6 +355,8 @@ export function useGPUStorage<T extends Record<string, StorageLike>>(
  * @param scope - Optional scope to rebuild ('root' for root only, string for specific scope, undefined for all)
  */
 export function rebuildAllStorage(store: ReturnType<typeof useStore>, scope?: string) {
+  // Resolve to the primary store so shared TSL resources rebuild on the authoritative store
+  store = store.getState().primaryStore ?? store
   store.setState((state) => {
     let newStorage = state.gpuStorage
     if (scope && scope !== 'root') {

--- a/packages/fiber/src/webgpu/hooks/useNodes.tsx
+++ b/packages/fiber/src/webgpu/hooks/useNodes.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react'
-import { useStore, useThree } from '../../core/hooks'
+import { useStore } from '../../core/hooks'
+import { usePrimaryStore, usePrimaryThree } from '../../core/hooks/usePrimaryStore'
 import { createLazyCreatorState, type CreatorState } from './ScopedStore'
 
 //* Types ==============================
@@ -113,7 +114,7 @@ export function useNodes<T extends Record<string, TSLNodeLike>>(
   | NodesWithUtils<T>
   | NodesWithUtils<Record<string, TSLNodeLike>>
   | NodesWithUtils<Record<string, TSLNodeLike> & Record<string, Record<string, TSLNodeLike>>> {
-  const store = useStore()
+  const store = usePrimaryStore()
 
   //* Utils ==============================
   // Memoized util functions that capture store reference
@@ -193,11 +194,11 @@ export function useNodes<T extends Record<string, TSLNodeLike>>(
   // Subscribe to nodes changes for reader modes
   // This ensures useNodes() and useNodes('scope') reactively update when store changes
   // For creator mode, we intentionally don't use this value to avoid re-running the creator
-  const storeNodes = useThree((s) => s.nodes)
+  const storeNodes = usePrimaryThree((s) => s.nodes)
 
   // Subscribe to HMR version for creator modes
   // This allows rebuildNodes() to bust the memoization cache and force re-creation
-  const hmrVersion = useThree((s) => s._hmrVersion)
+  const hmrVersion = usePrimaryThree((s) => s._hmrVersion)
 
   // Extracted deps to avoid complex expressions in useMemo dependency array
   const scopeDep = typeof creatorOrScope === 'string' ? creatorOrScope : scope
@@ -296,6 +297,8 @@ export function useNodes<T extends Record<string, TSLNodeLike>>(
  * @param scope - Optional scope to rebuild ('root' for root only, string for specific scope, undefined for all)
  */
 export function rebuildAllNodes(store: ReturnType<typeof useStore>, scope?: string) {
+  // Resolve to the primary store so shared TSL resources rebuild on the authoritative store
+  store = store.getState().primaryStore ?? store
   store.setState((state) => {
     let newNodes = state.nodes
     if (scope && scope !== 'root') {
@@ -392,14 +395,14 @@ export type LocalNodeCreator<T extends Record<string, unknown>> = (state: Creato
  * ```
  */
 export function useLocalNodes<T extends Record<string, unknown>>(creator: LocalNodeCreator<T>): T {
-  const store = useStore()
+  const store = usePrimaryStore()
 
   // Subscribe to trigger recreation when these change
-  const uniforms = useThree((s) => s.uniforms)
-  const nodes = useThree((s) => s.nodes)
-  const textures = useThree((s) => s.textures)
+  const uniforms = usePrimaryThree((s) => s.uniforms)
+  const nodes = usePrimaryThree((s) => s.nodes)
+  const textures = usePrimaryThree((s) => s.textures)
   // Subscribe to HMR version to rebuild on hot reload
-  const hmrVersion = useThree((s) => s._hmrVersion)
+  const hmrVersion = usePrimaryThree((s) => s._hmrVersion)
 
   return useMemo(() => {
     // Lazy ScopedStore wrapping - Proxies only created if uniforms/nodes accessed

--- a/packages/fiber/src/webgpu/hooks/useUniforms.tsx
+++ b/packages/fiber/src/webgpu/hooks/useUniforms.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react'
-import { useStore, useThree } from '../../core/hooks'
+import { useStore } from '../../core/hooks'
+import { usePrimaryStore, usePrimaryThree } from '../../core/hooks/usePrimaryStore'
 import * as THREE from '#three'
 import { uniform } from '#three/tsl'
 import { vectorize } from './utils'
@@ -136,7 +137,7 @@ export function useUniforms<T extends UniformInputRecord = UniformInputRecord>(
   creatorOrScope?: UniformCreator<T> | T | string,
   scope?: string,
 ): UniformsWithUtils<UniformRecord> | UniformsWithUtils<UniformRecord & Record<string, UniformRecord>> {
-  const store = useStore()
+  const store = usePrimaryStore()
 
   //* Utils ==============================
   // Memoized util functions that capture store reference
@@ -250,11 +251,11 @@ export function useUniforms<T extends UniformInputRecord = UniformInputRecord>(
 
   // Subscribe to uniforms changes for reader modes
   // This ensures useUniforms() and useUniforms('scope') reactively update when store changes
-  const storeUniforms = useThree((s) => s.uniforms)
+  const storeUniforms = usePrimaryThree((s) => s.uniforms)
 
   // Subscribe to HMR version for creator modes
   // This ensures rebuildUniforms() triggers re-creation
-  const hmrVersion = useThree((s) => s._hmrVersion)
+  const hmrVersion = usePrimaryThree((s) => s._hmrVersion)
 
   // Extracted deps to avoid complex expressions in useMemo dependency array
   const readerDep = isReader ? storeUniforms : null
@@ -364,6 +365,8 @@ export function useUniforms<T extends UniformInputRecord = UniformInputRecord>(
  * @param scope - Optional scope to rebuild ('root' for root only, string for specific scope, undefined for all)
  */
 export function rebuildAllUniforms(store: ReturnType<typeof useStore>, scope?: string) {
+  // Resolve to the primary store so shared TSL resources rebuild on the authoritative store
+  store = store.getState().primaryStore ?? store
   store.setState((state) => {
     let newUniforms: typeof state.uniforms = {}
     if (scope && scope !== 'root') {

--- a/packages/fiber/tests/canvas.test.tsx
+++ b/packages/fiber/tests/canvas.test.tsx
@@ -244,4 +244,51 @@ describe('web Canvas', () => {
       expect(environmentRendered).toBe(true)
     })
   })
+
+  describe('frustum / occlusion props', () => {
+    // Regression for Bug #2: autoUpdateFrustum/occlusion were not destructured in
+    // CanvasImpl, so they fell into ...props and were spread onto the wrapper <div>
+    // instead of being forwarded to configure().
+    it('forwards autoUpdateFrustum to configure', async () => {
+      let value: boolean | undefined
+
+      function Checker() {
+        value = useThree((s) => s.autoUpdateFrustum)
+        return null
+      }
+
+      await act(async () =>
+        render(
+          <Canvas autoUpdateFrustum={false}>
+            <Checker />
+          </Canvas>,
+        ),
+      )
+
+      expect(value).toBe(false)
+    })
+
+    it('forwards occlusion to configure (warns on WebGL)', async () => {
+      // Occlusion needs WebGPU; under the jsdom WebGL test renderer, configure()
+      // forwarding the prop reaches enableOcclusion(), which warns once. The warning
+      // is proof the prop was forwarded (it was silently dropped before the fix).
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      try {
+        await act(async () =>
+          render(
+            <Canvas occlusion>
+              <group />
+            </Canvas>,
+          ),
+        )
+
+        expect(
+          warn.mock.calls.some(([msg]) => typeof msg === 'string' && /occlusion queries require WebGPU/i.test(msg)),
+        ).toBe(true)
+      } finally {
+        warn.mockRestore()
+      }
+    })
+  })
 })

--- a/packages/fiber/tests/hmr.test.ts
+++ b/packages/fiber/tests/hmr.test.ts
@@ -1,0 +1,31 @@
+import { createStore } from '../src/core/store'
+import { clearHmrCaches } from '../src/core/utils/hmr'
+
+describe('clearHmrCaches', () => {
+  // Regression for Bug #4: the HMR handler cleared only nodes/uniforms, leaving
+  // buffers/gpuStorage stale after a hot reload. It must clear all four maps.
+  it('clears all four TSL resource maps and bumps _hmrVersion', () => {
+    const store = createStore(
+      () => {},
+      () => {},
+    )
+
+    store.setState({
+      nodes: { n: 1 } as any,
+      uniforms: { u: 2 } as any,
+      buffers: { b: 3 } as any,
+      gpuStorage: { g: 4 } as any,
+    })
+
+    const before = store.getState()._hmrVersion
+
+    clearHmrCaches(store)
+
+    const state = store.getState()
+    expect(state.nodes).toEqual({})
+    expect(state.uniforms).toEqual({})
+    expect(state.buffers).toEqual({})
+    expect(state.gpuStorage).toEqual({})
+    expect(state._hmrVersion).toBe(before + 1)
+  })
+})

--- a/packages/fiber/tests/parseBackground.test.ts
+++ b/packages/fiber/tests/parseBackground.test.ts
@@ -1,0 +1,70 @@
+import * as THREE from 'three'
+import { parseBackground } from '../src/core/utils/parseBackground'
+
+describe('parseBackground', () => {
+  it('returns null when no background is set', () => {
+    expect(parseBackground(undefined)).toBeNull()
+    expect(parseBackground('')).toBeNull()
+  })
+
+  describe('colors', () => {
+    it('treats CSS color names as colors', () => {
+      expect(parseBackground('red')).toEqual({ color: 'red', background: true })
+    })
+
+    it('treats hex strings as colors', () => {
+      expect(parseBackground('#ff0000')).toEqual({ color: '#ff0000', background: true })
+    })
+
+    it('treats hex numbers as colors', () => {
+      expect(parseBackground(0x00ff00)).toEqual({ color: 0x00ff00, background: true })
+    })
+
+    it('treats THREE.Color instances as colors', () => {
+      const color = new THREE.Color('blue')
+      expect(parseBackground(color as any)).toEqual({ color, background: true })
+    })
+  })
+
+  describe('presets', () => {
+    it('treats known preset names as presets', () => {
+      expect(parseBackground('city')).toEqual({ preset: 'city', background: true })
+    })
+  })
+
+  describe('files / URLs', () => {
+    // Regression for Bug #3: the extension branch used `\\.` (escaped backslash)
+    // instead of `\.`, so bare filenames fell through and were mis-parsed as colors.
+    it.each(['sky.hdr', 'sky.exr', 'sky.jpg', 'sky.jpeg', 'sky.png', 'sky.webp', 'sky.gif'])(
+      'treats bare filename %s as a file',
+      (file) => {
+        expect(parseBackground(file)).toEqual({ files: file, background: true })
+      },
+    )
+
+    it.each(['./sky.jpg', '../sky.jpg', '/env.hdr', 'https://example.com/env.hdr', 'http://example.com/x.png'])(
+      'treats prefixed path/URL %s as a file',
+      (url) => {
+        expect(parseBackground(url)).toEqual({ files: url, background: true })
+      },
+    )
+  })
+
+  describe('object form', () => {
+    it('maps envMap/backgroundMap into Environment props', () => {
+      expect(
+        parseBackground({
+          backgroundMap: 'sky.jpg',
+          envMap: 'env.hdr',
+          backgroundBlurriness: 0.5,
+        } as any),
+      ).toEqual({
+        preset: undefined,
+        files: 'env.hdr',
+        backgroundFiles: 'sky.jpg',
+        backgroundBlurriness: 0.5,
+        background: true,
+      })
+    })
+  })
+})

--- a/packages/fiber/tests/useFrame.test.tsx
+++ b/packages/fiber/tests/useFrame.test.tsx
@@ -388,6 +388,33 @@ describe('Scheduler', () => {
     expect(calls).toEqual(['job1'])
   })
 
+  // Regression: Bug #1 — frustum/visibility jobs registered with { before: 'render' }
+  // must run AFTER the update phase but BEFORE render (previously they used a bogus
+  // 'preRender' phase that the sorter appended after render/finish, leaving state.frustum
+  // one frame stale for render-phase consumers).
+  it('runs { before: render } jobs after update and before render', () => {
+    const calls: string[] = []
+
+    // Mirror renderer.tsx registration order/options for the system jobs
+    scheduler.register(() => calls.push('update'), { id: 'update-job', rootId: 'test-root', phase: 'update' })
+    scheduler.register(() => calls.push('render'), { id: 'render-job', rootId: 'test-root', phase: 'render' })
+    scheduler.register(() => calls.push('frustum'), { id: 'frustum', rootId: 'test-root', before: 'render' })
+    scheduler.register(() => calls.push('visibility'), {
+      id: 'visibility',
+      rootId: 'test-root',
+      before: 'render',
+      after: 'frustum',
+    })
+
+    scheduler.step()
+
+    // update precedes both checks; both checks precede render; frustum precedes visibility
+    expect(calls.indexOf('update')).toBeLessThan(calls.indexOf('frustum'))
+    expect(calls.indexOf('frustum')).toBeLessThan(calls.indexOf('visibility'))
+    expect(calls.indexOf('visibility')).toBeLessThan(calls.indexOf('render'))
+    expect(calls).toEqual(['update', 'frustum', 'visibility', 'render'])
+  })
+
   it('supports frameloop getter/setter', () => {
     // With a root registered, frameloop defaults to 'never' until set
     scheduler.frameloop = 'never'

--- a/packages/fiber/tests/webgpu/primaryStore.test.tsx
+++ b/packages/fiber/tests/webgpu/primaryStore.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * @fileoverview Bug #6 regression — multi-canvas TSL state sharing via primaryStore.
+ *
+ * In multi-canvas WebGPU mode every store carries a `primaryStore`; shared TSL
+ * resources must live on the PRIMARY store so secondary canvases see them. The
+ * WebGPU hooks previously read/wrote only the local store, so secondaries never
+ * shared state. These tests prove the centralized resolver (usePrimaryStore /
+ * usePrimaryThree) routes both writes and reactive reads to the primary, and that
+ * `useUniforms` adopts it.
+ */
+import * as React from 'react'
+import { act } from 'react'
+import { render } from '@testing-library/react'
+import { createStore, context } from '../../src/core/store'
+import { usePrimaryStore, usePrimaryThree } from '../../src/core/hooks/usePrimaryStore'
+import { useUniforms } from '../../src/webgpu'
+import type { RootStore } from '../../src'
+
+const noop = () => {}
+const makeStore = () => createStore(noop, noop)
+
+/** Render `children` with `useStore()` resolving to the given store. */
+function withStore(store: RootStore, children: React.ReactNode) {
+  return render(<context.Provider value={store}>{children}</context.Provider>)
+}
+
+describe('multi-canvas primaryStore sharing', () => {
+  describe('usePrimaryStore (imperative writes)', () => {
+    it('routes setState to the primary store from a secondary canvas', async () => {
+      const primary = makeStore()
+      const secondary = makeStore()
+      secondary.setState({ primaryStore: primary })
+
+      function Writer() {
+        const store = usePrimaryStore()
+        React.useEffect(() => {
+          store.setState({ uniforms: { uShared: 1 } as any })
+        }, [store])
+        return null
+      }
+
+      await act(async () => {
+        withStore(secondary, <Writer />)
+      })
+
+      expect(primary.getState().uniforms.uShared).toBe(1)
+      expect(secondary.getState().uniforms.uShared).toBeUndefined()
+    })
+
+    it('falls back to the local store when primaryStore is absent (single-canvas)', async () => {
+      const local = makeStore() // primaryStore stays null
+
+      function Writer() {
+        const store = usePrimaryStore()
+        React.useEffect(() => {
+          store.setState({ uniforms: { uLocal: 2 } as any })
+        }, [store])
+        return null
+      }
+
+      await act(async () => {
+        withStore(local, <Writer />)
+      })
+
+      expect(local.getState().uniforms.uLocal).toBe(2)
+    })
+  })
+
+  describe('usePrimaryThree (reactive reads)', () => {
+    it('subscribes a secondary-canvas reader to primary-store updates', async () => {
+      const primary = makeStore()
+      const secondary = makeStore()
+      secondary.setState({ primaryStore: primary })
+
+      const seen: Array<number | undefined> = []
+      function Reader() {
+        const value = usePrimaryThree((s) => (s.uniforms as any).uLate as number | undefined)
+        seen.push(value)
+        return null
+      }
+
+      await act(async () => {
+        withStore(secondary, <Reader />)
+      })
+      expect(seen.at(-1)).toBeUndefined()
+
+      // Mutate the PRIMARY directly — a local-store reader would never see this.
+      await act(async () => {
+        primary.setState((s) => ({ uniforms: { ...s.uniforms, uLate: 42 } as any }))
+      })
+
+      expect(seen.at(-1)).toBe(42)
+    })
+  })
+
+  describe('useUniforms adopts the resolver', () => {
+    it('creates shared uniforms on the primary store from a secondary canvas', async () => {
+      const primary = makeStore()
+      const secondary = makeStore()
+      secondary.setState({ primaryStore: primary })
+
+      function Component() {
+        useUniforms({ uShared: 5 })
+        return null
+      }
+
+      await act(async () => {
+        withStore(secondary, <Component />)
+      })
+
+      // The uniform node was created on the primary, not the local secondary store.
+      expect(primary.getState().uniforms.uShared).toBeDefined()
+      expect(secondary.getState().uniforms.uShared).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
Fixes five audit-flagged functional bugs from the v10 alpha.3 pass. Each lands with a regression test. Scoped to `packages/` only.

## Fixes

**Bug #1 — frustum/visibility ran after render** (`463d3fa4`)
The frustum + visibility jobs registered with a bogus `phase: 'preRender'`, which the sorter appends *after* render/finish, leaving `state.frustum` one frame stale for render-phase consumers. Switched both to `{ before: 'render' }` (resolves to an auto `before:render` phase between `update` and `render`); the frustum→visibility order is preserved via the `after` constraint. Occlusion's one-frame lag is inherent (GPU readback) and unchanged.

**Bug #2 — `autoUpdateFrustum`/`occlusion` Canvas props had no effect** (`0b249b91`)
They weren't destructured in `CanvasImpl`, so they were spread onto the wrapper `<div>` instead of reaching `configure()`. Destructured and forwarded both.

**Bug #3 — `background` URL regex broken for bare filenames** (`0b249b91`)
The extension branch used `\\.` instead of `\.`, so `background="sky.jpg"` was mis-parsed as a CSS color. Fixed the regex and extracted the detection into an internal `parseBackground()` helper for unit testing.

**Bug #4 — HMR left `buffers`/`gpuStorage` stale** (`0b249b91`)
The HMR handler cleared only `nodes`/`uniforms`. Now clears all four maps (decision B2) via an extracted `clearHmrCaches()`, and the unconditional `console.log` is removed.

**Bug #6 — multi-canvas hooks didn't share state via `primaryStore`** (release blocker) (`b6f2c03b`)
The four TSL hooks read/wrote only the local store, so secondary canvases never shared uniforms/nodes/buffers/gpuStorage with the primary. Added an internal resolver (`usePrimaryStore`/`usePrimaryThree`) that routes both writes and reactive reads to the primary, with local-store fallback. The hooks adopt it; `rebuildAll*` resolve to the primary too.

## Testing
- New: `parseBackground.test.ts`, `hmr.test.ts`, `webgpu/primaryStore.test.tsx`; added frustum-ordering + Canvas prop-forwarding cases.
- Full suite green (441 passing), `typecheck` and `eslint` clean.
- All 56 existing WebGPU tests pass unchanged (single-canvas fallback verified).

## Notes
- `usePrimaryStore`/`usePrimaryThree` are intentionally **internal** (not re-exported) — no public API change; the API snapshot is unchanged.
- **Bug #6 still needs C13 browser validation** in a real multi-canvas WebGPU page before beta.
- Bug #5 (runtime `setFrameloop`) is intentionally **not** here — it belongs with the in-flight `@pmndrs/scheduler` extraction.
- ⚠️ Heads-up: the scheduler-extraction branch also edits `renderer.tsx`/`phaseGraph.ts`/`sorter.ts`/`useFrame.test.tsx`, so it will need to rebase onto the Bug #1 changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)