### PR TITLE
fix: don't re-enter configure() while an async gl factory is pending

### DIFF
--- a/packages/fiber/src/core/renderer.tsx
+++ b/packages/fiber/src/core/renderer.tsx
@@ -185,9 +185,19 @@ export function createRoot<TCanvas extends HTMLCanvasElement | OffscreenCanvas>(
 
   let configured = false
   let pending: Promise<void> | null = null
+  let configuring: Promise<void> | null = null
 
   return {
     async configure(props: RenderProps<TCanvas> = {}): Promise<ReconcilerRoot<TCanvas>> {
+      // configure runs from the Canvas layout effect on every commit. When an
+      // async gl factory is still initializing, a re-render would re-enter this
+      // body past the `if (!state.gl)` guard and create a second renderer on
+      // the same canvas. Wait for any in-flight configure to settle so
+      // re-entrant calls run against settled state.
+      while (configuring) await configuring
+      let finishConfiguring!: () => void
+      configuring = new Promise<void>((_finish) => (finishConfiguring = _finish))
+
       let resolve!: () => void
       pending = new Promise<void>((_resolve) => (resolve = _resolve))
 
@@ -399,6 +409,8 @@ export function createRoot<TCanvas extends HTMLCanvasElement | OffscreenCanvas>(
       // Set locals
       onCreated = onCreatedCallback
       configured = true
+      configuring = null
+      finishConfiguring()
       resolve()
       return this
     },

--- a/packages/fiber/tests/index.test.tsx
+++ b/packages/fiber/tests/index.test.tsx
@@ -41,6 +41,24 @@ describe('createRoot', () => {
     expect(() => store.getState()).not.toThrow()
   })
 
+  it('does not invoke an async gl factory twice when configure re-enters during init', async () => {
+    let calls = 0
+    const gl = async (props: any) => {
+      calls++
+      // Simulate async renderer init (e.g. WebGPURenderer.init)
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      return new THREE.WebGLRenderer(props)
+    }
+
+    // A re-render of the Canvas owner while the factory is pending re-enters
+    // configure before the first call has resolved.
+    await act(async () => {
+      await Promise.all([root.configure({ gl }), root.configure({ gl })])
+    })
+
+    expect(calls).toBe(1)
+  })
+
   it('will make an Orthographic Camera & set the position', async () => {
     const store = await act(async () =>
       (await root.configure({ orthographic: true, camera: { position: [0, 0, 5] } })).render(<group />),


### PR DESCRIPTION
Fixes #3782.

## Why:

 `configure()` runs from the Canvas layout effect on every commit and guards renderer creation with `if (!state.gl)`. That check runs before the `await` of an async `gl` factory resolves. When the owner re-renders while the factory is still pending (a `setState` from a sibling effect is enough), a second `configure()` slips past the guard and invokes the factory again. With a WebGPU renderer that means two renderers on one canvas, and every frame fails GPU validation on a depth-buffer size mismatch. We also traced silent WebGPU canvas death on client-side navigation in static exports to this same race.

## The fix: 
serialize `configure()` on a per-root latch. A re-entrant call waits for the in-flight configure to settle, then runs against settled state, sees `state.gl` is set, and skips renderer creation. The latch clears synchronously at the end, so a synchronous `gl` config stays synchronous and the existing XR path is unaffected.

## Test plan:
- New regression test: two concurrent `configure()` calls with an async `gl` factory invoke it once, not twice. Fails on master (factory called twice), passes with the fix.
- Full suite green (169 passed), typecheck and lint clean.

> *Transparency note: this issue and its PR were drafted with AI assistance. I'm a human, I've personally verified the bug and the fix, and I'm happy to answer any questions or concerns directly. Thanks for the great library.*