### PR TITLE
fix(v10): alpha hardening — portal leaks, WebGPU race, canvas fallback, events, uniforms, useLoader cacheKey

### DIFF
--- a/docs/API/hooks.mdx
+++ b/docs/API/hooks.mdx
@@ -223,6 +223,21 @@ useLoader(loader, url, extensions, (xhr) => {
 })
 ```
 
+### Custom cache keys
+
+By default the request URL is also the cache key. When the URL changes on every request — for example signed or authenticated URLs — that would defeat caching and reload the same asset. Pass an explicit cache key as the fifth argument to load from the changing URL but cache under a stable key:
+
+```jsx
+const model = useLoader(GLTFLoader, signedUrl, undefined, undefined, '/model.glb')
+```
+
+`preload` and `clear` accept the same cache key so the entries line up:
+
+```jsx
+useLoader.preload(GLTFLoader, signedUrl, undefined, undefined, '/model.glb')
+useLoader.clear(GLTFLoader, signedUrl, '/model.glb')
+```
+
 ### Special treatment of GLTFLoaders and all loaders that return a scene prop
 
 If a `result.scene` prop is found the hook will automatically create a object & material collection: `{ nodes, materials }`. This lets you build immutable scene graphs selectively. You can also specifically alter the data without having to traverse it. [GLTFJSX](https://github.com/pmndrs/gltfjsx) specifically relies on this data.

--- a/packages/fiber/src/core/Canvas.tsx
+++ b/packages/fiber/src/core/Canvas.tsx
@@ -114,6 +114,8 @@ function CanvasImpl({
   const handleDropMissed = useMutableCallback(onDropMissed)
   const [block, setBlock] = React.useState<SetBlock>(false)
   const [error, setError] = React.useState<any>(false)
+  // Set when renderer setup fails and a `fallback` should be shown as visible DOM (#3757)
+  const [fallbackVisible, setFallbackVisible] = React.useState(false)
 
   // Suspend this component if block is a promise (2nd run)
   if (block) throw block
@@ -128,6 +130,8 @@ function CanvasImpl({
 
   useIsomorphicLayoutEffect(() => {
     effectActiveRef.current = true
+    // A prior renderer setup failed and we're showing the fallback DOM; don't re-attempt.
+    if (fallbackVisible) return
     const canvas = canvasRef.current
 
     if (effectiveSize.width > 0 && effectiveSize.height > 0 && canvas) {
@@ -162,54 +166,68 @@ function CanvasImpl({
         // Bail out if effect was cleaned up while awaiting (HMR race condition)
         if (!effectActiveRef.current || !root.current) return
 
-        await root.current.configure({
-          id,
-          primaryCanvas,
-          scheduler,
-          gl,
-          renderer,
-          scene,
-          events,
-          shadows,
-          orthographic,
-          frameloop,
-          dpr,
-          performance,
-          raycaster,
-          camera,
-          autoUpdateFrustum,
-          occlusion,
-          size: effectiveSize,
-          // Store size props for reset functionality
-          _sizeProps: width !== undefined || height !== undefined ? { width, height } : null,
-          forceEven,
-          // Pass mutable reference to onPointerMissed so it's free to update
-          onPointerMissed: (...args) => handlePointerMissed.current?.(...args),
-          onDragOverMissed: (...args) => handleDragOverMissed.current?.(...args),
-          onDropMissed: (...args) => handleDropMissed.current?.(...args),
-          onCreated: (state) => {
-            // Connect to event source
-            state.events.connect?.(
-              eventSource ? (isRef(eventSource) ? eventSource.current : eventSource) : divRef.current,
-            )
-            // Set up compute function
-            if (eventPrefix) {
-              state.setEvents({
-                compute: (event, state) => {
-                  const x = event[(eventPrefix + 'X') as keyof DomEvent] as number
-                  const y = event[(eventPrefix + 'Y') as keyof DomEvent] as number
-                  state.pointer.set((x / state.size.width) * 2 - 1, -(y / state.size.height) * 2 + 1)
-                  state.raycaster.setFromCamera(state.pointer, state.camera)
-                },
-              })
-            }
-            // Call onCreated callback
-            onCreated?.(state)
-          },
-        })
+        const configured = await root.current
+          .configure({
+            id,
+            primaryCanvas,
+            scheduler,
+            gl,
+            renderer,
+            scene,
+            events,
+            shadows,
+            orthographic,
+            frameloop,
+            dpr,
+            performance,
+            raycaster,
+            camera,
+            autoUpdateFrustum,
+            occlusion,
+            size: effectiveSize,
+            // Store size props for reset functionality
+            _sizeProps: width !== undefined || height !== undefined ? { width, height } : null,
+            forceEven,
+            // Pass mutable reference to onPointerMissed so it's free to update
+            onPointerMissed: (...args) => handlePointerMissed.current?.(...args),
+            onDragOverMissed: (...args) => handleDragOverMissed.current?.(...args),
+            onDropMissed: (...args) => handleDropMissed.current?.(...args),
+            onCreated: (state) => {
+              // Connect to event source
+              state.events.connect?.(
+                eventSource ? (isRef(eventSource) ? eventSource.current : eventSource) : divRef.current,
+              )
+              // Set up compute function
+              if (eventPrefix) {
+                state.setEvents({
+                  compute: (event, state) => {
+                    const x = event[(eventPrefix + 'X') as keyof DomEvent] as number
+                    const y = event[(eventPrefix + 'Y') as keyof DomEvent] as number
+                    state.pointer.set((x / state.size.width) * 2 - 1, -(y / state.size.height) * 2 + 1)
+                    state.raycaster.setFromCamera(state.pointer, state.camera)
+                  },
+                })
+              }
+              // Call onCreated callback
+              onCreated?.(state)
+            },
+          })
+          .then(
+            () => true,
+            // Renderer setup failed (e.g. no WebGL/WebGPU support). The `fallback` prop lives
+            // inside <canvas>, which browsers don't display, so surface it as visible DOM
+            // instead; with no fallback, rethrow to an external error boundary. (#3757)
+            (setupError) => {
+              if (effectActiveRef.current) {
+                if (fallback != null) setFallbackVisible(true)
+                else setError(setupError)
+              }
+              return false
+            },
+          )
 
-        // Bail out if effect was cleaned up while awaiting configure
-        if (!effectActiveRef.current || !root.current) return
+        // Bail out if setup failed or the effect was cleaned up while awaiting configure
+        if (!configured || !effectActiveRef.current || !root.current) return
 
         root.current.render(
           <Bridge>
@@ -301,15 +319,21 @@ function CanvasImpl({
         ...style,
       }}
       {...props}>
-      <div ref={containerRef} className="r3f-canvas-container" style={{ width: '100%', height: '100%' }}>
-        <canvas
-          ref={canvasRef}
-          id={id}
-          className="r3f-canvas"
-          style={{ display: 'block', width: '100%', height: '100%' }}>
-          {fallback}
-        </canvas>
-      </div>
+      {fallbackVisible ? (
+        // Renderer setup failed: render the fallback as visible DOM. Inside <canvas> (below)
+        // it exists in the tree but browsers never paint it, which is the whole bug (#3757).
+        fallback
+      ) : (
+        <div ref={containerRef} className="r3f-canvas-container" style={{ width: '100%', height: '100%' }}>
+          <canvas
+            ref={canvasRef}
+            id={id}
+            className="r3f-canvas"
+            style={{ display: 'block', width: '100%', height: '100%' }}>
+            {fallback}
+          </canvas>
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/fiber/src/core/hooks/useLoader.tsx
+++ b/packages/fiber/src/core/hooks/useLoader.tsx
@@ -76,15 +76,22 @@ export function useLoader<I extends InputLike, L extends LoaderLike | Constructo
   input: I,
   extensions?: Extensions<L>,
   onProgress?: (event: ProgressEvent<EventTarget>) => void,
+  cacheKey?: InputLike,
 ) {
-  // Use suspense to load async assets
-  const keys = (Array.isArray(input) ? input : [input]) as string[]
+  // What to load
+  const inputs = (Array.isArray(input) ? input : [input]) as string[]
+  // What to cache under. Defaults to the input URLs, but can be overridden so assets fetched
+  // from URLs that change per request (signed/auth URLs) still reuse the same cache entry.
+  const cacheKeys = (Array.isArray(cacheKey ?? input) ? (cacheKey ?? input) : [cacheKey ?? input]) as string[]
 
   // Create the loading function once to ensure consistent function reference across suspend calls
   const fn = loadingFn(extensions, onProgress)
 
-  // Call suspend individually for each key to match preload cache structure
-  const results = keys.map((key) => suspend(fn, [loader, key], { equal: is.equ }))
+  // Call suspend individually for each key to match preload cache structure.
+  // Suspend caches on `key`, but the closure always loads the matching `input`.
+  const results = cacheKeys.map((key, index) =>
+    suspend(() => fn(loader, inputs[index]), [loader, key], { equal: is.equ }),
+  )
 
   // Return the object(s)
   return (Array.isArray(input) ? results : results[0]) as I extends any[] ? LoaderResult<L>[] : LoaderResult<L>
@@ -98,10 +105,14 @@ useLoader.preload = function <I extends InputLike, L extends LoaderLike | Constr
   input: I,
   extensions?: Extensions<L>,
   onProgress?: (event: ProgressEvent<EventTarget>) => void,
+  cacheKey?: InputLike,
 ): void {
-  const keys = (Array.isArray(input) ? input : [input]) as string[]
+  const inputs = (Array.isArray(input) ? input : [input]) as string[]
+  const cacheKeys = (Array.isArray(cacheKey ?? input) ? (cacheKey ?? input) : [cacheKey ?? input]) as string[]
   // Preload each key individually so cache keys match useLoader calls
-  keys.forEach((key) => preload(loadingFn(extensions, onProgress), [loader, key]))
+  cacheKeys.forEach((key, index) =>
+    preload(() => loadingFn(extensions, onProgress)(loader, inputs[index]), [loader, key]),
+  )
 }
 
 /**
@@ -110,10 +121,11 @@ useLoader.preload = function <I extends InputLike, L extends LoaderLike | Constr
 useLoader.clear = function <I extends InputLike, L extends LoaderLike | ConstructorRepresentation<LoaderLike>>(
   loader: L,
   input: I,
+  cacheKey?: InputLike,
 ): void {
-  const keys = (Array.isArray(input) ? input : [input]) as string[]
-  // Clear each key individually to match how they were cached
-  keys.forEach((key) => clear([loader, key]))
+  const cacheKeys = (Array.isArray(cacheKey ?? input) ? (cacheKey ?? input) : [cacheKey ?? input]) as string[]
+  // Clear each key individually to match how they were cached (custom cache key when provided)
+  cacheKeys.forEach((key) => clear([loader, key]))
 }
 
 /**

--- a/packages/fiber/src/core/reconciler.tsx
+++ b/packages/fiber/src/core/reconciler.tsx
@@ -361,6 +361,9 @@ function swapInstances(): void {
     // So, we manually check if an instance was hidden and unhide it.
     if (instance.isHidden) unhideInstance(instance)
 
+    // The old object is being discarded. Scrub it from the interaction manager so it isn't
+    // left behind as a dead raycast target (and doesn't leak) after reconstruction (#3778).
+    if (isObject3D(instance.object)) removeInteractivity(findInitialRoot(instance), instance.object)
     // Dispose of old object if able
     if (instance.object.__r3f) delete instance.object.__r3f
     if (instance.type !== 'primitive') disposeOnIdle(instance.object)
@@ -382,6 +385,14 @@ function swapInstances(): void {
 
       // Clear appliedOnce so once() props can be reapplied to the new object
       delete instance.appliedOnce
+
+      // The instance is reused across reconstruction, so eventCount/handlers still reflect the
+      // OLD object. Reset them so applyProps re-derives handlers from the new props and
+      // re-registers the NEW object in the interaction manager — otherwise prevHandlers ===
+      // eventCount, the registration block is skipped, and pointer events silently stop working
+      // after an args change (#3778).
+      instance.eventCount = 0
+      instance.handlers = {}
 
       // Set initial props
       applyProps(instance.object, instance.props)

--- a/packages/fiber/src/core/renderer.tsx
+++ b/packages/fiber/src/core/renderer.tsx
@@ -987,6 +987,11 @@ function PortalInner({ state = {}, children, container }: PortalInnerProps): JSX
       if (camera !== rootState.camera) updateCamera(camera, resolvedSize)
     }
 
+    // Capture only the stable Zustand setter, not the whole injectState. Referencing
+    // injectState.set inside the setEvents closure below would anchor the entire previous
+    // portal state in memory, chaining every replaced state through setEvents → unbounded leak (#3751).
+    const set = injectState.set
+
     return {
       // The intersect consists of the previous root state
       ...rootState,
@@ -1006,7 +1011,7 @@ function PortalInner({ state = {}, children, container }: PortalInnerProps): JSX
       viewport: { ...rootState.viewport, ...viewport },
       // Layers are allowed to override events
       setEvents: (events: Partial<EventManager<any>>) =>
-        injectState.set((state) => ({ ...state, events: { ...state.events, ...events } })),
+        set((state) => ({ ...state, events: { ...state.events, ...events } })),
       // Container for child attachment - the portalScene (injected or container itself)
       internal: { ...rootState.internal, ...injectState.internal, container: portalScene },
     } as RootState

--- a/packages/fiber/src/core/renderer.tsx
+++ b/packages/fiber/src/core/renderer.tsx
@@ -136,6 +136,8 @@ export function createRoot<TCanvas extends HTMLCanvasElement | OffscreenCanvas>(
 
   let configured = false
   let pending: Promise<void> | null = null
+  // In-flight renderer creation, shared across overlapping configure() calls (see #3752)
+  let rendererSetup: Promise<void> | null = null
 
   return {
     async configure(props: RenderProps<TCanvas> = {}): Promise<ReconcilerRoot<TCanvas>> {
@@ -177,7 +179,7 @@ export function createRoot<TCanvas extends HTMLCanvasElement | OffscreenCanvas>(
           (rendererConfig as any).textureColorSpace) ||
         THREE.SRGBColorSpace
 
-      const state = store.getState()
+      let state = store.getState()
 
       //* Renderer Initialization ==============================
 
@@ -249,93 +251,116 @@ export function createRoot<TCanvas extends HTMLCanvasElement | OffscreenCanvas>(
       }
 
       //* Create Renderer (one time only) ==============================
-      if (R3F_BUILD_LEGACY && wantsGL && !state.internal.actualRenderer) {
-        //* WebGL path ---
-        renderer = (await resolveRenderer(glConfig, defaultGLProps, WebGLRenderer)) as WebGLRenderer
-        state.internal.actualRenderer = renderer
-        // Set both gl and renderer to the WebGLRenderer for backwards compatibility
-        // Self-reference primaryStore - this canvas is its own primary
-        state.set({ isLegacy: true, gl: renderer, renderer: renderer, primaryStore: store })
-      } else if (R3F_BUILD_WEBGPU && !wantsGL && primaryCanvas && !state.internal.actualRenderer) {
-        //* WebGPU Secondary Canvas path (shares renderer via CanvasTarget) ---
-        // Wait for primary canvas to be registered (handles async init timing)
-        const primary = await waitForPrimary(primaryCanvas)
+      // Serialize concurrent configure() calls. Renderer creation is async — the gl/renderer
+      // factory and WebGPU renderer.init() are awaited, and `actualRenderer` is only assigned
+      // afterwards — so overlapping configure() calls (e.g. a parent re-render while a slow
+      // WebGPU init is in flight) would each pass the `!actualRenderer` guard and invoke the
+      // factory multiple times (#3752). The first call owns creation; later overlapping calls
+      // await the same promise, then re-read state below and apply their own (latest) size.
+      if (!state.internal.actualRenderer) {
+        if (!rendererSetup) {
+          rendererSetup = (async () => {
+            if (R3F_BUILD_LEGACY && wantsGL) {
+              //* WebGL path ---
+              renderer = (await resolveRenderer(glConfig, defaultGLProps, WebGLRenderer)) as WebGLRenderer
+              state.internal.actualRenderer = renderer
+              // Set both gl and renderer to the WebGLRenderer for backwards compatibility
+              // Self-reference primaryStore - this canvas is its own primary
+              state.set({ isLegacy: true, gl: renderer, renderer: renderer, primaryStore: store })
+            } else if (R3F_BUILD_WEBGPU && !wantsGL && primaryCanvas) {
+              //* WebGPU Secondary Canvas path (shares renderer via CanvasTarget) ---
+              // Wait for primary canvas to be registered (handles async init timing)
+              const primary = await waitForPrimary(primaryCanvas)
 
-        // Use the primary's renderer
-        renderer = primary.renderer
-        state.internal.actualRenderer = renderer
+              // Use the primary's renderer
+              renderer = primary.renderer
+              state.internal.actualRenderer = renderer
 
-        // Create a CanvasTarget for this secondary canvas
-        const canvasTarget = new THREE.CanvasTarget(canvas as HTMLCanvasElement)
+              // Create a CanvasTarget for this secondary canvas
+              const canvasTarget = new THREE.CanvasTarget(canvas as HTMLCanvasElement)
 
-        // Enable multi-canvas mode on the primary canvas
-        primary.store.setState((prev) => ({
-          internal: { ...prev.internal, isMultiCanvas: true },
-        }))
+              // Enable multi-canvas mode on the primary canvas
+              primary.store.setState((prev) => ({
+                internal: { ...prev.internal, isMultiCanvas: true },
+              }))
 
-        // Store secondary canvas info in internal state
-        // primaryStore points to the primary canvas's store for shared TSL resources
-        state.set((prev) => ({
-          webGPUSupported: primary.store.getState().webGPUSupported,
-          renderer: renderer,
-          primaryStore: primary.store,
-          internal: {
-            ...prev.internal,
-            canvasTarget,
-            isMultiCanvas: true,
-            isSecondary: true,
-            targetId: primaryCanvas,
-          },
-        }))
-      } else if (R3F_BUILD_WEBGPU && !wantsGL && !state.internal.actualRenderer) {
-        //* WebGPU path ---
-        // This path is taken when:
-        // 1. WebGPU-only build (@react-three/fiber/webgpu) - always, even without renderer prop
-        // 2. Default build with explicit renderer prop
-        // If rendererConfig is undefined, resolveRenderer creates a default WebGPURenderer
-        renderer = (await resolveRenderer(rendererConfig, defaultGPUProps, WebGPURenderer)) as WebGPURenderer
+              // Store secondary canvas info in internal state
+              // primaryStore points to the primary canvas's store for shared TSL resources
+              state.set((prev) => ({
+                webGPUSupported: primary.store.getState().webGPUSupported,
+                renderer: renderer,
+                primaryStore: primary.store,
+                internal: {
+                  ...prev.internal,
+                  canvasTarget,
+                  isMultiCanvas: true,
+                  isSecondary: true,
+                  targetId: primaryCanvas,
+                },
+              }))
+            } else if (R3F_BUILD_WEBGPU && !wantsGL) {
+              //* WebGPU path ---
+              // This path is taken when:
+              // 1. WebGPU-only build (@react-three/fiber/webgpu) - always, even without renderer prop
+              // 2. Default build with explicit renderer prop
+              // If rendererConfig is undefined, resolveRenderer creates a default WebGPURenderer
+              renderer = (await resolveRenderer(rendererConfig, defaultGPUProps, WebGPURenderer)) as WebGPURenderer
 
-        // WebGPU-specific setup - only init if not already initialized
-        // Allows users to pass pre-initialized external renderers
-        // @see https://github.com/pmndrs/react-three-fiber/issues/3651
-        if (!renderer.hasInitialized?.()) {
-          // Set canvas dimensions before init to ensure depth buffer is created at correct size
-          // WebGPU creates GPU resources during init() based on canvas.width/height
-          // Without this, depth buffer uses default 300x150 causing size mismatch errors
-          const size = computeInitialSize(canvas, propsSize)
-          if (size.width > 0 && size.height > 0) {
-            const pixelRatio = calculateDpr(dpr)
-            ;(canvas as HTMLCanvasElement).width = size.width * pixelRatio
-            ;(canvas as HTMLCanvasElement).height = size.height * pixelRatio
-          }
-          await renderer.init()
+              // WebGPU-specific setup - only init if not already initialized
+              // Allows users to pass pre-initialized external renderers
+              // @see https://github.com/pmndrs/react-three-fiber/issues/3651
+              if (!renderer.hasInitialized?.()) {
+                // Set canvas dimensions before init to ensure depth buffer is created at correct size
+                // WebGPU creates GPU resources during init() based on canvas.width/height
+                // Without this, depth buffer uses default 300x150 causing size mismatch errors
+                const size = computeInitialSize(canvas, propsSize)
+                if (size.width > 0 && size.height > 0) {
+                  const pixelRatio = calculateDpr(dpr)
+                  ;(canvas as HTMLCanvasElement).width = size.width * pixelRatio
+                  ;(canvas as HTMLCanvasElement).height = size.height * pixelRatio
+                }
+                await renderer.init()
+              }
+
+              // temp, stop the inspector
+              //renderer.inspector = new Inspector()
+
+              const backend = renderer.backend
+              const isWebGPUBackend = backend && 'isWebGPUBackend' in backend
+
+              state.internal.actualRenderer = renderer
+              // Set renderer to WebGPURenderer, gl stays null (not available in WebGPU-only)
+              // Self-reference primaryStore - this canvas is its own primary
+              state.set({ webGPUSupported: isWebGPUBackend, renderer: renderer, primaryStore: store })
+
+              //* Register as Primary Canvas ==============================
+              // If this canvas has an id, register it so other canvases can target it
+              // Also create a CanvasTarget for when multi-canvas mode is enabled
+              if (canvasId && !state.internal.isSecondary) {
+                const canvasTarget = new THREE.CanvasTarget(canvas as HTMLCanvasElement)
+                const unregisterPrimary = registerPrimary(canvasId, renderer as WebGPURenderer, store)
+                state.set((prev) => ({
+                  internal: {
+                    ...prev.internal,
+                    canvasTarget,
+                    unregisterPrimary,
+                  },
+                }))
+              }
+            }
+          })().catch((err) => {
+            // Reset so a subsequent configure() can retry after a failed setup
+            rendererSetup = null
+            throw err
+          })
         }
 
-        // temp, stop the inspector
-        //renderer.inspector = new Inspector()
-
-        const backend = renderer.backend
-        const isWebGPUBackend = backend && 'isWebGPUBackend' in backend
-
-        state.internal.actualRenderer = renderer
-        // Set renderer to WebGPURenderer, gl stays null (not available in WebGPU-only)
-        // Self-reference primaryStore - this canvas is its own primary
-        state.set({ webGPUSupported: isWebGPUBackend, renderer: renderer, primaryStore: store })
-
-        //* Register as Primary Canvas ==============================
-        // If this canvas has an id, register it so other canvases can target it
-        // Also create a CanvasTarget for when multi-canvas mode is enabled
-        if (canvasId && !state.internal.isSecondary) {
-          const canvasTarget = new THREE.CanvasTarget(canvas as HTMLCanvasElement)
-          const unregisterPrimary = registerPrimary(canvasId, renderer as WebGPURenderer, store)
-          state.set((prev) => ({
-            internal: {
-              ...prev.internal,
-              canvasTarget,
-              unregisterPrimary,
-            },
-          }))
-        }
+        await rendererSetup
+        // Re-read state after the shared async setup so the remainder of configure() (size,
+        // dpr, shadows, …) operates on the latest store — this is how the newest configure's
+        // size wins even though the renderer was created by an earlier overlapping call.
+        state = store.getState()
+        renderer = state.internal.actualRenderer as WebGPURenderer | WebGLRenderer
       }
 
       //* Default Raycaster Initialization ==============================

--- a/packages/fiber/src/core/utils/props.ts
+++ b/packages/fiber/src/core/utils/props.ts
@@ -333,6 +333,24 @@ export function applyProps<T = any>(object: Instance<T>['object'], props: Instan
       // Otherwise just set single value
       else target.set(value)
     }
+    // ShaderMaterial uniforms must keep a stable target reference so that pierced updates
+    // (uniforms-foo-value) and references held by animation code keep working across renders.
+    else if (root instanceof THREE.ShaderMaterial && key === 'uniforms' && is.obj(value)) {
+      if (!is.obj(root.uniforms)) root.uniforms = {}
+      const uniforms = root.uniforms as Record<string, THREE.Uniform>
+      const nextUniforms = value as Record<string, THREE.Uniform | { value: unknown }>
+
+      for (const name in nextUniforms) {
+        const uniform = nextUniforms[name]
+        const targetUniform = uniforms[name]
+
+        if (targetUniform) Object.assign(targetUniform, uniform)
+        else {
+          const nextUniform = uniform instanceof THREE.Uniform ? uniform.clone() : new THREE.Uniform(uniform.value)
+          uniforms[name] = nextUniform
+        }
+      }
+    }
     // Else, just overwrite the value
     else {
       root[key] = value

--- a/packages/fiber/tests/canvas.test.tsx
+++ b/packages/fiber/tests/canvas.test.tsx
@@ -66,6 +66,86 @@ describe('web Canvas', () => {
     expect(() => renderer.unmount()).not.toThrow()
   })
 
+  // Regression for #3757: the `fallback` prop lives inside <canvas>, which browsers never
+  // paint, so a renderer-setup failure must surface the fallback as visible sibling DOM.
+  it('renders the fallback outside the canvas when renderer setup fails', async () => {
+    // Suppress the expected error log from the failed renderer setup
+    const originalError = console.error
+    console.error = vi.fn()
+
+    try {
+      const renderer = await act(async () =>
+        render(
+          <Canvas
+            fallback={<div>Sorry no WebGL supported!</div>}
+            gl={() => {
+              throw new Error('WebGL unavailable')
+            }}>
+            <group />
+          </Canvas>,
+        ),
+      )
+
+      // Allow the async configure() rejection + fallback state update to flush
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50))
+      })
+
+      const fallbackEl = renderer.getByText('Sorry no WebGL supported!')
+      expect(fallbackEl).toBeTruthy()
+      // Must be rendered as visible DOM, not as a child of <canvas>
+      expect(fallbackEl.closest('canvas')).toBe(null)
+    } finally {
+      console.error = originalError
+    }
+  })
+
+  // When no fallback is supplied, a renderer-setup failure should propagate to an
+  // external error boundary rather than silently swallowing the error.
+  it('surfaces renderer setup failure to an error boundary when no fallback is given', async () => {
+    const originalError = console.error
+    console.error = vi.fn()
+
+    let caughtError: Error | null = null
+    class TestErrorBoundary extends React.Component<{ children: React.ReactNode }, { hasError: boolean }> {
+      state = { hasError: false }
+      static getDerivedStateFromError() {
+        return { hasError: true }
+      }
+      componentDidCatch(error: Error) {
+        caughtError = error
+      }
+      render() {
+        if (this.state.hasError) return <div data-testid="boundary">boom</div>
+        return this.props.children
+      }
+    }
+
+    try {
+      const renderer = await act(async () =>
+        render(
+          <TestErrorBoundary>
+            <Canvas
+              gl={() => {
+                throw new Error('WebGL unavailable')
+              }}>
+              <group />
+            </Canvas>
+          </TestErrorBoundary>,
+        ),
+      )
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50))
+      })
+
+      expect(caughtError).toBeInstanceOf(Error)
+      expect(renderer.getByTestId('boundary')).toBeTruthy()
+    } finally {
+      console.error = originalError
+    }
+  })
+
   it('plays nice with react SSR', async () => {
     const useLayoutEffect = vi.spyOn(React, 'useLayoutEffect')
     const useEffect = vi.spyOn(React, 'useEffect')

--- a/packages/fiber/tests/events.test.tsx
+++ b/packages/fiber/tests/events.test.tsx
@@ -47,6 +47,48 @@ describe('events', () => {
     expect(handlePointerDown).toHaveBeenCalled()
   })
 
+  // Regression for #3778: when an element's `args` change, R3F reconstructs the underlying
+  // THREE object (swapInstances). The new object must be re-registered in the interaction
+  // manager, or pointer events silently stop working after the first reconstruction.
+  it('keeps pointer events working after an args-triggered reconstruction', async () => {
+    const handlePointerDown = vi.fn()
+    let setSwap: (v: boolean) => void = () => {}
+
+    function Scene() {
+      const [swap, _setSwap] = React.useState(false)
+      setSwap = _setSwap
+      // Geometry identity changes once → mesh args change → reconstruction
+      const geometry = React.useMemo(() => new THREE.BoxGeometry(2, 2, 2), [swap])
+      const material = React.useMemo(() => new THREE.MeshBasicMaterial(), [])
+      return <mesh args={[geometry, material]} onPointerDown={handlePointerDown} />
+    }
+
+    await act(async () => {
+      render(
+        <Canvas>
+          <Scene />
+        </Canvas>,
+      )
+    })
+
+    // Works before reconstruction
+    await act(async () => {
+      fireEvent(getContainer(), createPointerEvent('pointerdown'))
+    })
+    expect(handlePointerDown).toHaveBeenCalledTimes(1)
+
+    // Force the args change that reconstructs the mesh
+    await act(async () => {
+      setSwap(true)
+    })
+
+    // Must still fire after reconstruction
+    await act(async () => {
+      fireEvent(getContainer(), createPointerEvent('pointerdown'))
+    })
+    expect(handlePointerDown).toHaveBeenCalledTimes(2)
+  })
+
   it('can handle onPointerMissed', async () => {
     const handleClick = vi.fn()
     const handleMissed = vi.fn()

--- a/packages/fiber/tests/renderer.test.tsx
+++ b/packages/fiber/tests/renderer.test.tsx
@@ -926,6 +926,31 @@ describe('renderer', () => {
     expect(store.getState().frameloop).toBe('demand')
   })
 
+  // Regression for #3752: when the gl/renderer factory is async and slow, overlapping
+  // configure() calls (e.g. a parent re-render mid-init) must not each build a renderer.
+  it('serializes overlapping configure() calls with an async gl factory (#3752)', async () => {
+    const glFactory = vi.fn(async (props: any) => {
+      // Simulate a slow async renderer init so both configures overlap in-flight.
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      return new THREE.WebGLRenderer(props)
+    })
+
+    let store: RootStore = null!
+    await act(async () => {
+      // Kick off two configures before the first has finished initializing the renderer.
+      const first = root.configure({ gl: glFactory as any, size: { width: 100, height: 100, top: 0, left: 0 } })
+      const second = root.configure({ gl: glFactory as any, size: { width: 300, height: 300, top: 0, left: 0 } })
+      await Promise.all([first, second])
+      store = root.render(null)
+    })
+
+    // The factory must run exactly once despite two overlapping configures.
+    expect(glFactory).toHaveBeenCalledTimes(1)
+    // The latest configure's size wins after the shared renderer resolves.
+    expect(store.getState().size.width).toBe(300)
+    expect(store.getState().size.height).toBe(300)
+  })
+
   it('should preserve setDpr changes from child component across re-configure', async () => {
     // Test scenario: Canvas has dpr={[1, 2]} prop
     // A child component calls setDpr(1) after mount

--- a/packages/fiber/tests/renderer.test.tsx
+++ b/packages/fiber/tests/renderer.test.tsx
@@ -12,6 +12,7 @@ import {
   createPortal,
   useFrame,
 } from '../src/index'
+import type { RootState, RootStore } from '../src/index'
 import { suspend } from 'suspend-react'
 
 extend(THREE as any)
@@ -1289,6 +1290,98 @@ describe('renderer', () => {
       expect(portalSceneActual).toBeDefined()
       expect(portalSceneInUseFrame!.uuid).toBe(portalSceneActual!.uuid)
       expect(portalSceneInUseFrame!.uuid).not.toBe(rootSceneUuid)
+    })
+
+    // Regression for #3751: Portal's setEvents closure must capture only the stable
+    // store setter, not the whole previous portal state, or every replaced state stays
+    // anchored in memory through a setEvents → injectState chain (unbounded leak).
+    it('does not retain stale portal state in setEvents (#3751)', async () => {
+      const container = new THREE.Group()
+      let portalState: RootState = null!
+
+      function PortalProbe() {
+        portalState = useThree()
+        return null
+      }
+
+      const rootStore: RootStore = await act(async () =>
+        root.render(
+          <>
+            <primitive object={container} />
+            {createPortal(<PortalProbe />, container)}
+          </>,
+        ),
+      )
+
+      const stalePortalState = portalState
+      const staleSet = stalePortalState.set
+
+      // Mutating the parent root store rebuilds the portal state via the inject callback,
+      // replacing portalState with a fresh object.
+      await act(async () => {
+        rootStore.getState().set((state) => ({ size: { ...state.size } }))
+      })
+      expect(portalState).not.toBe(stalePortalState)
+
+      // Poison the *property* on the stale state. The fixed setEvents captured the setter
+      // by value, so it is unaffected; the buggy version looked it up off the retained
+      // injectState at call time and would route through (and throw on) this.
+      stalePortalState.set = (() => {
+        throw new Error('stale portal state setter was retained')
+      }) as RootState['set']
+
+      try {
+        await act(async () => {
+          portalState.setEvents({ enabled: false })
+        })
+        expect(portalState.get().events.enabled).toBe(false)
+      } finally {
+        stalePortalState.set = staleSet
+      }
+    })
+
+    // Regression for the second Portal leak reported on #3760: the subscription to the
+    // parent (previous) root store must be torn down when the portal unmounts. It lives in
+    // a layout effect that returns its unsubscribe; if that subscription is ever moved back
+    // into the useMemo (where the unsubscribe is discarded), every portal mount would pin
+    // its THREE.Scene in the parent store's listener set for good.
+    it('unsubscribes from the parent root store when the portal unmounts', async () => {
+      const container = new THREE.Group()
+
+      // Render the parent tree once (no portal) to obtain the real root store.
+      const rootStore: RootStore = await act(async () => root.render(<primitive object={container} />))
+
+      // Track subscriptions added through the store from here on, and drop them as their
+      // unsubscribe fires, so `live` reflects the currently-attached listeners.
+      const live = new Set<() => void>()
+      const realSubscribe = rootStore.subscribe.bind(rootStore)
+      const subscribeSpy = vi.spyOn(rootStore, 'subscribe').mockImplementation((listener: any) => {
+        const unsub = realSubscribe(listener)
+        live.add(unsub)
+        return () => {
+          live.delete(unsub)
+          unsub()
+        }
+      })
+
+      const baseline = live.size
+
+      // Mount the portal — PortalInner subscribes to the parent store.
+      await act(async () =>
+        root.render(
+          <>
+            <primitive object={container} />
+            {createPortal(<mesh />, container)}
+          </>,
+        ),
+      )
+      expect(live.size).toBeGreaterThan(baseline)
+
+      // Unmount the portal — the subscription must be cleaned up, not leaked.
+      await act(async () => root.render(<primitive object={container} />))
+      expect(live.size).toBe(baseline)
+
+      subscribeSpy.mockRestore()
     })
   })
 })

--- a/packages/fiber/tests/useLoader.test.tsx
+++ b/packages/fiber/tests/useLoader.test.tsx
@@ -181,6 +181,70 @@ describe('useLoader', () => {
     useLoader.clear(TestLoader, [URL_A, URL_B])
   })
 
+  // #3711: a custom cacheKey lets URLs that change per request (signed/auth URLs) reuse the
+  // same cached asset instead of reloading.
+  it('reuses the cache across changing input URLs when a stable cacheKey is given', async () => {
+    const loadCalls: string[] = []
+    class TestLoader extends THREE.Loader<string, string> {
+      load(url: string, onLoad: (result: string) => void): void {
+        loadCalls.push(url)
+        onLoad(`loaded:${url}`)
+      }
+    }
+
+    const CACHE_KEY = '/model.glb'
+    const SIGNED_A = '/model.glb?token=aaa'
+    const SIGNED_B = '/model.glb?token=bbb'
+
+    let result: string | undefined
+    const Comp = ({ url }: { url: string }) => {
+      result = useLoader(TestLoader, url, undefined, undefined, CACHE_KEY)
+      return null
+    }
+
+    await act(async () => root.render(<Comp url={SIGNED_A} />))
+    expect(loadCalls).toEqual([SIGNED_A])
+    expect(result).toBe(`loaded:${SIGNED_A}`)
+
+    // A different signed URL but the SAME cache key → served from cache, no reload.
+    await act(async () => root.render(<Comp url={SIGNED_B} />))
+    expect(loadCalls).toEqual([SIGNED_A])
+    expect(result).toBe(`loaded:${SIGNED_A}`)
+
+    useLoader.clear(TestLoader, SIGNED_A, CACHE_KEY)
+  })
+
+  it('preload and clear honor a custom cacheKey', async () => {
+    const loadCalls: string[] = []
+    class TestLoader extends THREE.Loader<string, string> {
+      load(url: string, onLoad: (result: string) => void): void {
+        loadCalls.push(url)
+        onLoad(`loaded:${url}`)
+      }
+    }
+
+    const CACHE_KEY = '/asset.bin'
+    const SIGNED = '/asset.bin?sig=xyz'
+
+    // Preload the real (signed) URL but cache it under the stable key.
+    useLoader.preload(TestLoader, SIGNED, undefined, undefined, CACHE_KEY)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(loadCalls).toEqual([SIGNED])
+
+    // useLoader with the same cache key (yet another signed URL) hits the preloaded entry.
+    let result: string | undefined
+    const Comp = () => {
+      result = useLoader(TestLoader, '/asset.bin?sig=other', undefined, undefined, CACHE_KEY)
+      return null
+    }
+    await act(async () => root.render(<Comp />))
+    expect(loadCalls).toEqual([SIGNED])
+    expect(result).toBe(`loaded:${SIGNED}`)
+
+    // clear with the cache key removes the entry.
+    useLoader.clear(TestLoader, SIGNED, CACHE_KEY)
+  })
+
   it('can abort loader with loadAsync and clears suspend', async () => {
     const URL_SLOW = '/slow-load.glb'
     let abortCalled = false

--- a/packages/fiber/tests/utils.test.ts
+++ b/packages/fiber/tests/utils.test.ts
@@ -411,6 +411,44 @@ describe('applyProps', () => {
     expect(target.foo.value).toBe(false)
   })
 
+  it('should merge shader material uniforms into a stable target', () => {
+    const material = new THREE.ShaderMaterial({ uniforms: { time: { value: 1 } } })
+    const uniforms = material.uniforms
+    const time = material.uniforms.time
+
+    const nextUniforms = {
+      time: { value: 2 },
+      resolution: { value: new THREE.Vector2(4, 8) },
+    }
+
+    applyProps(material, { uniforms: nextUniforms })
+
+    // The uniforms object is copied in leaving a stable ref
+    expect(material.uniforms).toBe(uniforms)
+    expect(material.uniforms).not.toBe(nextUniforms)
+    // Individual uniforms are also copied into if present
+    expect(material.uniforms.time).toBe(time)
+    expect(material.uniforms.time).not.toBe(nextUniforms.time)
+    expect(material.uniforms.time.value).toBe(2)
+    // When it is a new uniform it gets cloned instead of assigning by ref
+    expect(material.uniforms.resolution).not.toBe(nextUniforms.resolution)
+    expect(material.uniforms.resolution.value.toArray()).toStrictEqual([4, 8])
+  })
+
+  it('should merge pierced uniform props into stable shader uniforms', () => {
+    const material = new THREE.ShaderMaterial({
+      uniforms: { uColor: { value: new THREE.Color('hotpink') } },
+    })
+    const uniforms = material.uniforms
+    const uColor = material.uniforms.uColor
+
+    applyProps(material, { 'uniforms-uColor-value': 'royalblue' })
+
+    expect(material.uniforms).toBe(uniforms)
+    expect(material.uniforms.uColor).toBe(uColor)
+    expect((material.uniforms.uColor.value as THREE.Color).getHex()).toBe(new THREE.Color('royalblue').getHex())
+  })
+
   it('should prefer to copy potentially read-only math classes', () => {
     const one = new THREE.Vector3(1, 1, 1)
     const two = new THREE.Vector3(2, 2, 2)


### PR DESCRIPTION
Batch of small, independently-reviewable fixes for the v10 alpha, each with a regression test. Every commit is scoped to one issue.

## Fixes

- **Portal memory leaks (`#3751`)** — `setEvents` captured the whole previous portal state, chaining every replaced state in memory; it now captures only the stable store setter. Plus a regression test guarding that the parent-store subscription is torn down on unmount.
- **WebGPU / async `configure()` race (`#3752`)** — overlapping `configure()` calls each invoked the `gl`/renderer factory, and a resize mid-init could leave the depth buffer at a stale size. Overlapping calls now share one in-flight renderer-setup promise and re-read state after it resolves so the latest size wins.
- **`Canvas` `fallback` not visible (`#3757`)** — the fallback sits inside `<canvas>`, which browsers never paint. Renderer-setup failures are now caught: with a `fallback` it renders as visible sibling DOM; without one the error is surfaced to an external error boundary.
- **Pointer events die after `args` reconstruction (`#3778`)** — `swapInstances` reused the instance so `eventCount` still reflected the old object and `applyProps` skipped re-registration. It now scrubs the old object from the interaction manager and resets `eventCount`/`handlers` so the new object is re-registered.

## Features (v9 → v10 parity / ports)

- **Stable `ShaderMaterial` uniforms** — `applyProps` merges into the existing `uniforms` object instead of overwriting it, keeping references stable for pierced updates (`uniforms-foo-value`) and animation code. Ports the work in `#3739` (original by @krispya).
- **`useLoader` custom `cacheKey`** — optional 5th arg on `useLoader`/`preload`/`clear` to reuse cached assets across signed/auth URLs that change per request. Ports `#3711` (original by @Shushovan015). Includes docs.

## Notes

- Supersedes PRs #3739, #3711, and #3761 (they can be closed).
- #3748 (default shadow map → `PCFShadowMap`) is already true on v10; nothing to merge.
- Full fiber suite green (466 passed / 6 todo), typecheck + eslint + prettier clean.

Fixes #3751
Fixes #3752
Fixes #3757
Fixes #3778

🤖 Generated with [Claude Code](https://claude.com/claude-code)