### PR TITLE
test: port scheduler ordering regression into the @pmndrs/scheduler idiom

### DIFF
--- a/packages/fiber/tests/useFrame.test.tsx
+++ b/packages/fiber/tests/useFrame.test.tsx
@@ -648,3 +648,41 @@ describe('useFrame outside Canvas', () => {
     expect(seen[0]).toBe(fakeRenderer)
   })
 })
+
+//* System-job ordering: Bug #1 regression ==============================
+// The frustum/visibility system jobs register with { before: 'render' } (see
+// renderer.tsx). They must run after update but before render — previously they
+// used a bogus 'preRender' phase that the sorter appended after render/finish,
+// leaving state.frustum one frame stale for render-phase consumers.
+
+describe('system job ordering', () => {
+  beforeEach(() => {
+    Scheduler.reset()
+    getScheduler().frameloop = 'never' // drive frames manually
+  })
+
+  afterEach(() => {
+    Scheduler.reset()
+  })
+
+  it('runs { before: render } jobs after update and before render', () => {
+    const calls: string[] = []
+    const scheduler = getScheduler()
+    scheduler.registerRoot('test-root', { getState: () => ({}) })
+
+    // Mirror renderer.tsx registration order/options for the system jobs
+    scheduler.register(() => calls.push('update'), { id: 'update-job', rootId: 'test-root', phase: 'update' })
+    scheduler.register(() => calls.push('render'), { id: 'render-job', rootId: 'test-root', phase: 'render' })
+    scheduler.register(() => calls.push('frustum'), { id: 'frustum', rootId: 'test-root', before: 'render' })
+    scheduler.register(() => calls.push('visibility'), {
+      id: 'visibility',
+      rootId: 'test-root',
+      before: 'render',
+      after: 'frustum',
+    })
+
+    scheduler.step(1000)
+
+    expect(calls).toEqual(['update', 'frustum', 'visibility', 'render'])
+  })
+})


### PR DESCRIPTION
## What

One test: the Bug #1 scheduler-ordering regression (frustum/visibility system jobs registered with `{ before: 'render' }` must run after `update` and before `render`), re-added in the extracted-`@pmndrs/scheduler` idiom. Its original `describe` block was removed from `useFrame.test.tsx` when the scheduler moved upstream (#3774), which dropped this repo-side guard of the renderer's system-job registration options.

> Scope note: this PR was originally broader; the alphaPrep planning docs were removed from it — they live on Notion, not in the repo. Browser-gate results (C0/C11–C17) and the TSL HMR audit that came out of them are tracked there; the HMR fix work proceeds on `fix/webgpu-hmr` (red-baseline tests already pushed), and **C16 blocks the alpha.3 cut**.

## Test plan

- `vitest run packages/fiber/tests/useFrame.test.tsx` — 23/23 pass locally, including the ported test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)