### PR TITLE
docs(changelog): correct three alpha.3 entries before the release cut

### DIFF
--- a/CHANGELOG-ALPHA.md
+++ b/CHANGELOG-ALPHA.md
@@ -6,6 +6,19 @@ This changelog tracks changes during the v10 alpha period. For the full per-pack
 
 ## 10.0.0-alpha.3
 
+### Breaking Changes
+
+#### three.js peer floor raised to `>=0.185.0`
+
+The `three` peer range moved from `>=0.181.2` to **`>=0.185.0`**. **If you are on r181–r184 you cannot install alpha.3** — upgrade three alongside R3F.
+
+```diff
+- "three": ">=0.181.2"
++ "three": ">=0.185.0"
+```
+
+The floor moved because v10 now uses three's own APIs rather than shadowing them: `RenderPipeline` (renamed from `PostProcessing` in r183), `CubeRenderTarget`, and the real `UniformNode` types. Keeping a fallback path for older three meant maintaining a parallel implementation of types three already ships.
+
 ### Features
 
 #### Interactive Priority (userData.interactivePriority)
@@ -275,8 +288,8 @@ constraints, per-callback fps throttling and the single shared RAF all behave as
 - Fixed memory leak in `createPortal` where subscriptions to parent store were never cleaned up. When portals were created/destroyed frequently (e.g., with rapidly changing data), each portal subscribed to `previousRoot` but never unsubscribed, keeping the portal's zustand store and all its state in memory indefinitely.
 - Fixed portal `size` state being overwritten by parent resize events. Portals now correctly preserve their own size override when the root canvas resizes, matching the existing behavior for `events`. This also fixes nested portals ignoring their size configuration.
 - Fixed `setSize` not triggering a frame in demand mode. Now calls `scheduler.invalidate()` directly so `useFrame` callbacks can respond to size changes.
-- Fixed frustum culling and visibility events running one frame late. The checks now run via
-  `{ before: 'render' }` rather than an unregistered `preRender` phase.
+- Fixed `state.frustum` being stale when read during the render phase. The frustum and visibility
+  checks now run via `{ before: 'render' }` rather than an unregistered `preRender` phase.
 - Fixed `autoUpdateFrustum` and `occlusion` Canvas props not being forwarded to `configure()` —
   they fell through to the wrapper `<div>` instead.
 - Fixed the `background` URL detection regex, which was over-escaped and never matched.
@@ -286,8 +299,8 @@ constraints, per-callback fps throttling and the single shared RAF all behave as
 - Fixed runtime `setFrameloop()` never reaching the scheduler, so imperative mode changes had no
   effect on the RAF loop.
 - Fixed `useRenderPipeline` constructing `THREE.PostProcessing`, which three deprecated in r183 in
-  favour of `RenderPipeline` and which warns on construction. R3F now builds `RenderPipeline` when
-  the installed three exports it, falling back for three < r183.
+  favour of `RenderPipeline` and which warns on construction. R3F now constructs `THREE.RenderPipeline`
+  directly — with the peer floor at r185 there is no version left to fall back for.
 - Fixed React 19.2's `cloneRootViewTransitionContainer` / `removeRootViewTransitionClone` host
   methods throwing `Not implemented.`; they are now no-ops.
 - Fixed an async `gl` factory being invoked more than once when `configure()` calls overlapped.


### PR DESCRIPTION
Three corrections to the alpha.3 section of `CHANGELOG-ALPHA.md`, flagged on the agent scratchpad. All three feed the release announcement and conference material, so worth getting right while the cut is still open.

### 1. 🔴 The frustum entry overstates the fix

> `- Fixed frustum culling and visibility events running one frame late.`

The visibility half isn't true. `onFramed`/`onVisible` run after `update` either way and were never frame-late; `onOccluded` being one frame deferred is inherent to GPU occlusion queries — not fixed here, and not fixable. The real defect was narrower: **`state.frustum` was stale when read during the render phase.**

This overstatement has round-tripped back in twice now (the June handoff called it out, `02-bugs-and-cleanup.md` corrected it, and it reappeared in the shipping changelog), so it's worth stating precisely rather than approximately.

### 2. 🔴 The three.js peer bump was missing entirely

`three` moved from `>=0.181.2` at the `v10.0.0-alpha.2` tag to `>=0.185.0` on `v10` — **verified against the tag, not inferred.** Anyone on r181–r184 **cannot install alpha.3**.

alpha.3 had no `### Breaking Changes` section at all (alpha.2 does), and `0.185` / `r185` / `peer` appeared nowhere in the file. It landed as a `chore:` commit, which is likely why it never reached the changelog — it reads as maintenance from inside the repo and as a breaking change from outside it.

Added as the leading Breaking Changes entry for alpha.3, with the reason the floor moved (v10 now uses three's own `RenderPipeline`, `CubeRenderTarget` and `UniformNode` rather than shadowing them).

### 3. 🟡 The `RenderPipeline` fallback sentence is stale

It still says R3F builds `RenderPipeline` "falling back for three < r183". `db3a98c1` deleted the fallback and `76c50f01` raised the floor above it — there is no version left to fall back for.

---

`prettier --check` clean. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)