### PR TITLE
fix(webgpu): atomic, generation-aware TSL resource registration (C16 HMR blocker)

### DIFF
--- a/docs/webgpu/compute.mdx
+++ b/docs/webgpu/compute.mdx
@@ -54,7 +54,7 @@ Returns `BuffersWithUtils<BufferRecord>` - your buffers by name, **plus four uti
 
 - **`removeBuffers`** - remove buffers by name from root or a scope (store only).
 - **`clearBuffers`** - clear a scope, `'root'` for root only, or no argument for everything.
-- **`rebuildBuffers`** - clear the cache and bump the HMR version to force re-creation (all, `'root'`, or a scope).
+- **`rebuildBuffers`** - invalidate the cache and bump the HMR version to force re-creation (all, `'root'`, or a scope). See [TSL HMR](./hmr) for the rebuild guarantees.
 - **`disposeBuffers`** - releases GPU resources (`.dispose()`) **and** removes from the store.
 
 ### What Can Be Stored

--- a/docs/webgpu/hmr.mdx
+++ b/docs/webgpu/hmr.mdx
@@ -6,7 +6,7 @@ nav: 19
 
 v10 includes automatic Hot Module Replacement (HMR) support for the WebGPU TSL hooks. When you save changes to files containing TSL node, uniform, buffer, or storage definitions, R3F refreshes the affected state without a full page reload.
 
-The `Canvas` component detects HMR events from Vite or webpack and bumps an internal HMR version on R3F state, which busts the memoization caches of the creator hooks and re-runs their creators.
+The `Canvas` component detects HMR events from Vite or webpack, invalidates the TSL resource caches, and bumps an internal HMR version on R3F state, which re-runs every creator hook.
 
 ```tsx
 // Just works - save your file and see changes immediately
@@ -33,6 +33,41 @@ All four creator families re-run their creators when the HMR version is bumped:
 
 `useLocalNodes` also rebuilds because it subscribes to the HMR version directly, alongside its `uniforms`/`nodes`/`textures` triggers.
 
+## Rebuild Guarantees
+
+A rebuild — whether from a hot update or a manual `rebuild*` call — is **atomic** from a reader's point of view:
+
+- The shared maps are never emptied. Readers keep the previous generation of nodes/uniforms until the re-run creators commit the new one, then see a single swap from old-complete to new-complete. A reader can never observe an empty or half-rebuilt scope (which would strip `*Node` props off materials mid-reload).
+- Creators never write to the store during render. New entries are registered in React's commit phase, so a rebuild can't interrupt other components mid-render.
+- Reuse is generation-aware. After an invalidation, previously cached entries can't be re-adopted into the new generation — every creator produces fresh resources, no matter how re-runs interleave (StrictMode double-invokes, multiple canvases sharing a `primaryStore`, and so on).
+
+Two consequences worth knowing:
+
+- **Removed creators leave their last generation in place.** If an edit deletes a creator component (or a whole scope), the old entries stay visible to readers until something re-registers the scope or you call `clearNodes`/`removeNodes`. During a hot reload, last-good data beats an empty scene.
+- **Captured references go stale across rebuilds.** A rebuild replaces uniform/node objects. Code that reads through the hooks each render picks up the new generation automatically, but a long-lived closure that captured a uniform object directly (for example a `useFrame` callback or an external library callback holding `uTime` from an old generation) keeps writing to the replaced object. Prefer reading through the hook, or re-capture inside the component so the closure refreshes with the rebuild.
+
+## Effects Must Be Re-Run Safe
+
+Fast Refresh re-runs your components' effects on every hot update, while R3F's reconciler correctly keeps the underlying three.js objects alive. An effect that mutates a reconciler-managed object must therefore be idempotent:
+
+```tsx
+// ❌ accumulates 90° per hot update — after one edit the plane faces away
+useEffect(() => {
+  geometryRef.current?.rotateX(-Math.PI / 2)
+}, [])
+
+// ✅ guard per instance, safe to re-run
+useEffect(() => {
+  const geometry = geometryRef.current
+  if (geometry && !geometry.userData.rotated) {
+    geometry.userData.rotated = true
+    geometry.rotateX(-Math.PI / 2)
+  }
+}, [])
+```
+
+Where possible, prefer declarative props (`rotation` on the mesh) or bake transforms at creation time instead of mutating in effects.
+
 ## useRenderPipeline Does NOT Rebuild on HMR
 
 This is the important exception. `useRenderPipeline` callbacks do **not** re-run on a plain hot reload (same scene/camera). Re-running them rebuilds the TSL node graph, which can corrupt cached references (such as `SkinningNode`), so the hook intentionally skips re-running its `setupCB`/`mainCB` on HMR.
@@ -58,7 +93,7 @@ If you need to turn off automatic refresh (rare), use the `hmr` prop:
 
 ## Manual Rebuild
 
-Each creator hook returns a `rebuild*` util that clears its cache and bumps the HMR version to force re-creation. Pass a scope name to rebuild a single scope, `'root'` for root only, or no argument for everything.
+Each creator hook returns a `rebuild*` util that invalidates its cache and bumps the HMR version to force re-creation (with the same atomic-swap guarantees as automatic HMR). Pass a scope name to rebuild a single scope, `'root'` for root only, or no argument for everything. Other scopes are untouched — their entries keep their identity.
 
 ```tsx
 const { rebuildNodes } = useNodes(() => ({ wobble: sin(time.mul(2)) }))

--- a/docs/webgpu/tsl-hooks.mdx
+++ b/docs/webgpu/tsl-hooks.mdx
@@ -131,7 +131,7 @@ Returns `UniformsWithUtils<UniformRecord>` - your uniforms by name, **plus three
 
 - **`removeUniforms`** - remove specific uniforms by name from root or a scope.
 - **`clearUniforms`** - clear a scope, `'root'` for root only, or no argument to clear everything.
-- **`rebuildUniforms`** - clear the cache and bump the HMR version to force re-creation of the creators (all, `'root'`, or a named scope).
+- **`rebuildUniforms`** - invalidate the cache and bump the HMR version to force re-creation of the creators (all, `'root'`, or a named scope).
 
 ### Input Types
 
@@ -229,7 +229,7 @@ Returns `NodesWithUtils<NodeRecord>` - your nodes by name, **plus three util fun
 
 - **`removeNodes`** - remove specific nodes by name from root or a scope.
 - **`clearNodes`** - clear a scope, `'root'` for root only, or no argument to clear everything.
-- **`rebuildNodes`** - clear the cache and bump the HMR version to force re-creation of node creators (all, `'root'`, or a named scope).
+- **`rebuildNodes`** - invalidate the cache and bump the HMR version to force re-creation of node creators (all, `'root'`, or a named scope).
 
 > The `rebuild*` utils are returned by the hook directly; you do not need the standalone `rebuildAllNodes`/`rebuildAllUniforms` exports for in-component use.
 

--- a/example/src/demos/webgpu/seaNodes.tsx
+++ b/example/src/demos/webgpu/seaNodes.tsx
@@ -117,8 +117,13 @@ function makeSeaUniforms() {
 export const TerrainGeometry = () => {
   const geometryRef = useRef<PlaneGeometry>(null)
   useEffect(() => {
-    if (geometryRef.current) {
-      geometryRef.current.rotateX(-Math.PI / 2)
+    const geometry = geometryRef.current
+    // Guard per geometry instance: effects re-run on Fast Refresh while the
+    // reconciler keeps the same geometry, so an unguarded rotateX accumulates
+    // 90° per hot update until the terrain faces away from the camera.
+    if (geometry && !geometry.userData.rotatedToHorizontal) {
+      geometry.userData.rotatedToHorizontal = true
+      geometry.rotateX(-Math.PI / 2)
     }
   }, [])
 

--- a/packages/fiber/src/core/utils/hmr.ts
+++ b/packages/fiber/src/core/utils/hmr.ts
@@ -1,19 +1,25 @@
+import { invalidateAllResources } from './resourceRegistry'
 import type { RootStore } from '#types'
 
 // NOTE: intentionally NOT re-exported from ./index — internal helper only.
 
 /**
- * Clear all TSL resource caches on HMR and bump `_hmrVersion` so creators re-run.
+ * Invalidate all TSL resource caches on HMR and bump `_hmrVersion` so
+ * creators re-run and register a fresh generation.
  *
- * All four maps must be cleared: leaving `buffers`/`gpuStorage` in place lets
- * particle/compute buffers and storage textures go stale after a hot reload.
+ * The maps (`nodes`, `uniforms`, `buffers`, `gpuStorage`) are deliberately
+ * NOT wiped: a wipe notifies every subscribed reader with an empty scope
+ * before the creators have re-run, and the reconciler then strips the
+ * corresponding `*Node` material props (the C16 black-scene failure).
+ * Invalidation instead makes committed entries invisible to creator reuse
+ * while readers keep the previous generation until the rebuilt one lands in
+ * a single atomic transition (see `resourceRegistry.ts`).
+ *
+ * Resolves `primaryStore` first so multi-canvas setups invalidate the store
+ * the shared resources actually live on.
  */
 export function clearHmrCaches(store: RootStore): void {
-  store.setState((state) => ({
-    nodes: {},
-    uniforms: {},
-    buffers: {},
-    gpuStorage: {},
-    _hmrVersion: state._hmrVersion + 1,
-  }))
+  const primary = store.getState().primaryStore ?? store
+  invalidateAllResources(primary)
+  primary.setState((state) => ({ _hmrVersion: state._hmrVersion + 1 }))
 }

--- a/packages/fiber/src/core/utils/resourceRegistry.ts
+++ b/packages/fiber/src/core/utils/resourceRegistry.ts
@@ -1,0 +1,274 @@
+import type { RootState, RootStore } from '#types'
+
+/**
+ * @fileoverview Registration bookkeeping for the shared TSL resource maps
+ * (`nodes`, `uniforms`, `buffers`, `gpuStorage`).
+ *
+ * The resource hooks create entries during render, but writing to the zustand
+ * store during render notifies subscribed readers mid-render (React error
+ * "Cannot update a component while rendering") and exposes half-rebuilt state.
+ * This registry solves both by splitting registration in two:
+ *
+ *  1. Render phase: freshly created entries are *staged* here — plain module
+ *     state keyed by store, invisible to subscribers, safe to write anytime.
+ *  2. Commit phase: `flushStagedScope` moves everything staged for a scope
+ *     into the store in ONE immutable `setState`, so readers observe exactly
+ *     one transition per scope: old-complete → new-complete.
+ *
+ * Staleness is tracked per scope via a `valid` set instead of physically
+ * wiping the maps. HMR / `rebuild*` invalidate scopes (and bump `_hmrVersion`
+ * to re-run creators); until the new generation is flushed, readers keep
+ * seeing the previous entries — never an empty scope. A creator only reuses a
+ * committed entry when its scope is still valid, so invalidated entries can't
+ * be resurrected no matter how creator re-runs interleave.
+ */
+
+//* Types & Constants ==============================
+
+/** The four RootState maps managed through this registry. */
+export type ResourceKind = 'nodes' | 'uniforms' | 'buffers' | 'gpuStorage'
+
+export const RESOURCE_KINDS: readonly ResourceKind[] = ['nodes', 'uniforms', 'buffers', 'gpuStorage']
+
+/**
+ * Scope key for root-level entries (stored flat on the map, next to scope
+ * objects). The empty string can never collide with a user scope because the
+ * hooks treat a falsy scope argument as "root".
+ */
+export const ROOT_SCOPE = ''
+
+export type ResourceEntries = Record<string, unknown>
+
+/** Distinguishes leaf entries from scope sub-objects on a resource map. */
+export type LeafGuard = (value: unknown) => boolean
+
+interface KindRegistry {
+  /**
+   * Scopes whose committed entries may be reused by creators. A scope enters
+   * on flush and leaves on invalidation — so after an HMR/rebuild invalidation
+   * every committed entry is invisible to reuse until a creator re-registers.
+   */
+  valid: Set<string>
+  /** Entries created during render, awaiting the commit-phase flush. */
+  staged: Map<string, ResourceEntries>
+}
+
+/**
+ * Per-store registries, keyed by the store the hooks resolved (the primary
+ * store in multi-canvas setups, so all canvases share one registry).
+ * WeakMap: bookkeeping dies with the store, nothing to clean up on unmount.
+ */
+const registries = new WeakMap<RootStore, Record<ResourceKind, KindRegistry>>()
+
+function getKindRegistry(store: RootStore, kind: ResourceKind): KindRegistry {
+  let registry = registries.get(store)
+  if (!registry) {
+    registry = {
+      nodes: { valid: new Set(), staged: new Map() },
+      uniforms: { valid: new Set(), staged: new Map() },
+      buffers: { valid: new Set(), staged: new Map() },
+      gpuStorage: { valid: new Set(), staged: new Map() },
+    }
+    registries.set(store, registry)
+  }
+  return registry[kind]
+}
+
+/** Resolve the authoritative store for shared TSL resources (see usePrimaryStore). */
+function resolvePrimary(store: RootStore): RootStore {
+  return store.getState().primaryStore ?? store
+}
+
+//* Render-phase API (staging & reuse) ==============================
+
+/** Whether committed entries of a scope may be reused by creators. */
+export function isScopeValid(store: RootStore, kind: ResourceKind, scopeKey: string): boolean {
+  return getKindRegistry(store, kind).valid.has(scopeKey)
+}
+
+/** Entries staged for a scope this render pass, if any. */
+export function peekStaged(store: RootStore, kind: ResourceKind, scopeKey: string): ResourceEntries | undefined {
+  return getKindRegistry(store, kind).staged.get(scopeKey)
+}
+
+/**
+ * Stage freshly created entries for the commit-phase flush. Called during
+ * render — deliberately does NOT touch the store, so no subscriber is
+ * notified mid-render. Staging is cumulative per scope: multiple components
+ * contributing to one scope accumulate here and land in a single flush.
+ */
+export function stageEntries(store: RootStore, kind: ResourceKind, scopeKey: string, entries: ResourceEntries): void {
+  const { staged } = getKindRegistry(store, kind)
+  const current = staged.get(scopeKey)
+  if (current) Object.assign(current, entries)
+  else staged.set(scopeKey, { ...entries })
+}
+
+/**
+ * Read the committed entries of a scope for reuse lookups. For the root
+ * pseudo-scope this filters out scope sub-objects via the guard, so a scope
+ * stored under the same name as a requested leaf is never returned as one.
+ */
+export function readCommittedScope(map: ResourceEntries, scopeKey: string, isLeaf: LeafGuard): ResourceEntries {
+  if (scopeKey === ROOT_SCOPE) {
+    const leaves: ResourceEntries = {}
+    for (const [key, value] of Object.entries(map)) if (isLeaf(value)) leaves[key] = value
+    return leaves
+  }
+  const scopeData = map[scopeKey]
+  if (scopeData && typeof scopeData === 'object' && !isLeaf(scopeData)) return scopeData as ResourceEntries
+  return {}
+}
+
+/**
+ * A view of a committed resource map with this render pass's staged entries
+ * overlaid. Used by `CreatorState` so a creator can see resources that a
+ * sibling hook created earlier in the SAME render (e.g. a node creator
+ * deriving from a uniform created two lines above) before they are flushed.
+ * Returns the committed map untouched when nothing is staged.
+ */
+export function withStagedOverlay(store: RootStore, kind: ResourceKind, committed: ResourceEntries): ResourceEntries {
+  const { staged } = getKindRegistry(store, kind)
+  if (staged.size === 0) return committed
+
+  const view = { ...committed }
+  for (const [scopeKey, entries] of staged) {
+    if (scopeKey === ROOT_SCOPE) Object.assign(view, entries)
+    else view[scopeKey] = { ...(view[scopeKey] as ResourceEntries), ...entries }
+  }
+  return view
+}
+
+//* Commit-phase API (flush) ==============================
+
+/**
+ * Commit everything staged for a scope into the store — one immutable
+ * `setState`, one observable transition. If the scope was invalidated, its
+ * committed entries are REPLACED by the staged generation (root: leaf entries
+ * replaced, scope sub-objects kept — they flush independently); if it is
+ * still valid, staged entries merge in alongside other contributors'.
+ *
+ * Called from a commit-phase effect, where updating the store is legal and
+ * React batches the resulting reader re-renders before paint. No-op when
+ * nothing is staged, so it is safe to run on every commit.
+ */
+export function flushStagedScope(store: RootStore, kind: ResourceKind, scopeKey: string, isLeaf: LeafGuard): void {
+  const registry = getKindRegistry(store, kind)
+  const staged = registry.staged.get(scopeKey)
+  if (!staged) return
+  registry.staged.delete(scopeKey)
+
+  const replace = !registry.valid.has(scopeKey)
+  store.setState((state) => {
+    const map = state[kind] as ResourceEntries
+    if (scopeKey === ROOT_SCOPE) {
+      if (!replace) return { [kind]: { ...map, ...staged } } as Partial<RootState>
+      const next: ResourceEntries = {}
+      for (const [key, value] of Object.entries(map)) if (!isLeaf(value)) next[key] = value
+      return { [kind]: { ...next, ...staged } } as Partial<RootState>
+    }
+    const current = replace ? {} : ((map[scopeKey] as ResourceEntries) ?? {})
+    return { [kind]: { ...map, [scopeKey]: { ...current, ...staged } } } as Partial<RootState>
+  })
+  registry.valid.add(scopeKey)
+}
+
+//* Invalidation API (HMR & rebuild) ==============================
+
+/**
+ * Mark a scope (or, without `scopeKey`, an entire kind) stale: committed
+ * entries stay visible to readers but can no longer be reused by creators,
+ * and anything staged pre-invalidation is dropped (it belongs to the old
+ * generation — flushing it would mark the scope valid with stale entries).
+ */
+export function invalidateResource(store: RootStore, kind: ResourceKind, scopeKey?: string): void {
+  const registry = getKindRegistry(store, kind)
+  if (scopeKey === undefined) {
+    registry.valid.clear()
+    registry.staged.clear()
+  } else {
+    registry.valid.delete(scopeKey)
+    registry.staged.delete(scopeKey)
+  }
+}
+
+/**
+ * Invalidate a scope (or a whole kind) and bump `_hmrVersion` so every
+ * creator re-runs and re-registers a fresh generation. This is the shared
+ * implementation behind the hooks' `rebuild*` utils and the standalone
+ * `rebuildAll*` functions. The maps are intentionally NOT wiped — readers
+ * keep the previous generation until the new one is flushed atomically.
+ *
+ * @param userScope - as documented on the utils: a scope name, `'root'` for
+ *   root-level entries only, or `undefined` for everything of this kind.
+ */
+export function rebuildResource(store: RootStore, kind: ResourceKind, userScope?: string): void {
+  const primary = resolvePrimary(store)
+  invalidateResource(primary, kind, userScope === 'root' ? ROOT_SCOPE : userScope)
+  primary.setState((state) => ({ _hmrVersion: state._hmrVersion + 1 }))
+}
+
+/** Invalidate every scope of every kind. The HMR entry point (see `clearHmrCaches`). */
+export function invalidateAllResources(store: RootStore): void {
+  for (const kind of RESOURCE_KINDS) invalidateResource(store, kind)
+}
+
+//* Shared removal helpers ==============================
+// Explicit user-driven removal (`removeX`/`clearX` utils). Unlike rebuilds
+// these DO remove committed entries — readers observing the removal is the
+// requested behavior. Staged duplicates are dropped so a pending flush can't
+// resurrect what was just removed.
+
+/** Remove entries by name from the root level or a scope. */
+export function removeResourceEntries(
+  store: RootStore,
+  kind: ResourceKind,
+  names: string[],
+  scope: string | undefined,
+  isLeaf: LeafGuard,
+): void {
+  const staged = peekStaged(store, kind, scope ?? ROOT_SCOPE)
+  if (staged) for (const name of names) delete staged[name]
+
+  store.setState((state) => {
+    const map = state[kind] as ResourceEntries
+    if (scope) {
+      const currentScope = { ...(map[scope] as ResourceEntries) }
+      for (const name of names) delete currentScope[name]
+      return { [kind]: { ...map, [scope]: currentScope } } as Partial<RootState>
+    }
+    const next = { ...map }
+    for (const name of names) if (isLeaf(next[name])) delete next[name]
+    return { [kind]: next } as Partial<RootState>
+  })
+}
+
+/**
+ * Clear entries — a scope name removes that scope entirely, `'root'` removes
+ * root-level leaves only (scopes kept), `undefined` clears the whole map.
+ */
+export function clearResourceEntries(
+  store: RootStore,
+  kind: ResourceKind,
+  scope: string | undefined,
+  isLeaf: LeafGuard,
+): void {
+  const registry = getKindRegistry(store, kind)
+  if (scope && scope !== 'root') registry.staged.delete(scope)
+  else if (scope === 'root') registry.staged.delete(ROOT_SCOPE)
+  else registry.staged.clear()
+
+  store.setState((state) => {
+    const map = state[kind] as ResourceEntries
+    if (scope && scope !== 'root') {
+      const { [scope]: _, ...rest } = map
+      return { [kind]: rest } as Partial<RootState>
+    }
+    if (scope === 'root') {
+      const next: ResourceEntries = {}
+      for (const [key, value] of Object.entries(map)) if (!isLeaf(value)) next[key] = value
+      return { [kind]: next } as Partial<RootState>
+    }
+    return { [kind]: {} } as Partial<RootState>
+  })
+}

--- a/packages/fiber/src/webgpu/hooks/ScopedStore.ts
+++ b/packages/fiber/src/webgpu/hooks/ScopedStore.ts
@@ -18,7 +18,8 @@
  * ```
  */
 
-import type { RootState, BufferLike, StorageLike } from '#types'
+import { withStagedOverlay } from '../../core/utils/resourceRegistry'
+import type { RootState, RootStore, BufferLike, StorageLike } from '#types'
 
 //* Symbol for internal data storage ==============================
 const INTERNAL_DATA = Symbol('ScopedStore.data')
@@ -159,41 +160,51 @@ export type CreatorState = Omit<RootState, 'uniforms' | 'nodes' | 'buffers' | 'g
  * actually accessed, avoiding expensive Proxy creation when the creator
  * function doesn't need them.
  *
+ * When `store` is provided, the wrappers overlay entries STAGED during the
+ * current render pass on top of the committed maps. Registration is deferred
+ * to the commit phase, so without the overlay a creator could not see
+ * resources a sibling hook created earlier in the same render (e.g. a node
+ * deriving from a uniform declared two lines above).
+ *
  * @param state - The raw RootState from store.getState()
+ * @param store - The (primary-resolved) store, for the staged-entry overlay
  * @returns CreatorState with lazy-initialized ScopedStore wrappers
  *
  * @example
  * ```tsx
- * const wrappedState = createLazyCreatorState(store.getState())
+ * const wrappedState = createLazyCreatorState(store.getState(), store)
  * const result = creatorFn(wrappedState)
  * // Proxy only created if creatorFn accessed uniforms or nodes
  * ```
  */
-export function createLazyCreatorState(state: RootState): CreatorState {
+export function createLazyCreatorState(state: RootState, store?: RootStore): CreatorState {
   let _uniforms: ScopedStoreType<UniformNode> | null = null
   let _nodes: ScopedStoreType<TSLNodeType> | null = null
   let _buffers: ScopedStoreType<BufferLike> | null = null
   let _gpuStorage: ScopedStoreType<StorageLike> | null = null
 
+  const view = (kind: 'uniforms' | 'nodes' | 'buffers' | 'gpuStorage') =>
+    store ? withStagedOverlay(store, kind, state[kind]) : state[kind]
+
   return Object.create(state, {
     uniforms: {
       get() {
-        return (_uniforms ??= createScopedStore<UniformNode>(state.uniforms))
+        return (_uniforms ??= createScopedStore<UniformNode>(view('uniforms')))
       },
     },
     nodes: {
       get() {
-        return (_nodes ??= createScopedStore<TSLNodeType>(state.nodes))
+        return (_nodes ??= createScopedStore<TSLNodeType>(view('nodes')))
       },
     },
     buffers: {
       get() {
-        return (_buffers ??= createScopedStore<BufferLike>(state.buffers))
+        return (_buffers ??= createScopedStore<BufferLike>(view('buffers')))
       },
     },
     gpuStorage: {
       get() {
-        return (_gpuStorage ??= createScopedStore<StorageLike>(state.gpuStorage))
+        return (_gpuStorage ??= createScopedStore<StorageLike>(view('gpuStorage')))
       },
     },
   }) as CreatorState

--- a/packages/fiber/src/webgpu/hooks/useBuffers.tsx
+++ b/packages/fiber/src/webgpu/hooks/useBuffers.tsx
@@ -1,8 +1,10 @@
 // EXPERIMENTAL (A3): API may change before stable. Reactive GPU buffer registry for TSL.
-import { useCallback, useMemo } from 'react'
+import { useCallback } from 'react'
 import { useStore } from '../../core/hooks'
 import { usePrimaryStore, usePrimaryThree } from '../../core/hooks/usePrimaryStore'
+import { clearResourceEntries, rebuildResource, removeResourceEntries } from '../../core/utils/resourceRegistry'
 import { createLazyCreatorState, type CreatorState } from './ScopedStore'
+import { useScopedResource } from './useScopedResource'
 import type { BufferLike, BufferRecord } from '#types'
 
 //* Types ==============================
@@ -137,68 +139,20 @@ export function useBuffers<T extends Record<string, BufferLike>>(
 
   /** Remove buffers by name from root or a scope */
   const removeBuffers = useCallback<RemoveBuffersFn>(
-    (names, targetScope) => {
-      const nameArray = Array.isArray(names) ? names : [names]
-      store.setState((state) => {
-        if (targetScope) {
-          // Remove from scoped buffers
-          const currentScope = { ...(state.buffers[targetScope] as BufferRecord) }
-          for (const name of nameArray) delete currentScope[name]
-          return { buffers: { ...state.buffers, [targetScope]: currentScope } }
-        }
-        // Remove from root level
-        const buffers = { ...state.buffers }
-        for (const name of nameArray) if (isBufferLike(buffers[name])) delete buffers[name]
-        return { buffers }
-      })
-    },
+    (names, targetScope) =>
+      removeResourceEntries(store, 'buffers', Array.isArray(names) ? names : [names], targetScope, isBufferLike),
     [store],
   )
 
   /** Clear buffers - scope name, 'root' for root only, or undefined for all */
   const clearBuffers = useCallback<ClearBuffersFn>(
-    (targetScope) => {
-      store.setState((state) => {
-        // Clear specific scope
-        if (targetScope && targetScope !== 'root') {
-          const { [targetScope]: _, ...rest } = state.buffers
-          return { buffers: rest }
-        }
-        // Clear root only (preserve scopes)
-        if (targetScope === 'root') {
-          const buffers: typeof state.buffers = {}
-          for (const [key, value] of Object.entries(state.buffers)) {
-            if (!isBufferLike(value)) buffers[key] = value
-          }
-          return { buffers }
-        }
-        // Clear everything
-        return { buffers: {} }
-      })
-    },
+    (targetScope) => clearResourceEntries(store, 'buffers', targetScope, isBufferLike),
     [store],
   )
 
-  /** Rebuild buffers - clears cache and increments HMR version to trigger re-creation */
+  /** Rebuild buffers - invalidates the cache and increments HMR version to trigger re-creation */
   const rebuildBuffers = useCallback<RebuildBuffersFn>(
-    (targetScope) => {
-      store.setState((state) => {
-        // Clear the specified scope (or all) and bump version
-        let newBuffers = state.buffers
-        if (targetScope && targetScope !== 'root') {
-          const { [targetScope]: _, ...rest } = state.buffers
-          newBuffers = rest
-        } else if (targetScope === 'root') {
-          newBuffers = {}
-          for (const [key, value] of Object.entries(state.buffers)) {
-            if (!isBufferLike(value)) newBuffers[key] = value
-          }
-        } else {
-          newBuffers = {}
-        }
-        return { buffers: newBuffers, _hmrVersion: state._hmrVersion + 1 }
-      })
-    },
+    (targetScope) => rebuildResource(store, 'buffers', targetScope),
     [store],
   )
 
@@ -235,94 +189,39 @@ export function useBuffers<T extends Record<string, BufferLike>>(
   // For creator mode, we intentionally don't use this value to avoid re-running the creator
   const storeBuffers = usePrimaryThree((s) => s.buffers)
 
-  // Subscribe to HMR version for creator modes
-  // This allows rebuildBuffers() to bust the memoization cache and force re-creation
-  const hmrVersion = usePrimaryThree((s) => s._hmrVersion)
-
-  // Extracted deps to avoid complex expressions in useMemo dependency array
-  const scopeDep = typeof creatorOrScope === 'string' ? creatorOrScope : scope
-  const readerDep = isReader ? storeBuffers : null
-  const creatorDep = isReader ? null : hmrVersion
-
-  const buffers = useMemo(() => {
-    // Case 1: No arguments - return all buffers (root + scopes)
-    // Uses subscribed storeBuffers for reactivity
-    if (creatorOrScope === undefined) {
-      return storeBuffers as BufferRecordType & Record<string, BufferRecordType>
-    }
-
-    // Case 2: String argument - return buffers from that scope
-    // Uses subscribed storeBuffers for reactivity
-    if (typeof creatorOrScope === 'string') {
-      const scopeData = storeBuffers[creatorOrScope]
-      // Make sure we're returning a scope object, not a buffer
-      if (scopeData && !isBufferLike(scopeData)) return scopeData as BufferRecordType
-      return {}
-    }
-
-    // Case 3: Creator function - create if not exists
-    // Uses store.getState() snapshot to avoid re-running creator on unrelated buffer changes
-    const state = store.getState()
-    const set = store.setState
-    const creator = creatorOrScope
-
-    // Lazy ScopedStore wrapping - Proxies only created if uniforms/nodes/buffers accessed
-    const wrappedState = createLazyCreatorState(state)
-    const created = creator(wrappedState)
-    const result: Record<string, BufferLike> = {}
-    let hasNewBuffers = false
-
-    // Scoped buffers ---------------------------------
-    if (scope) {
-      const currentScope = (state.buffers[scope] as BufferRecord) ?? {}
-
-      for (const [name, buffer] of Object.entries(created)) {
-        if (currentScope[name]) {
-          result[name] = currentScope[name]
-        } else {
-          // Apply label for debugging if it's a TSL node
-          if ('setName' in buffer && typeof buffer.setName === 'function') {
-            buffer.setName(`${scope}.${name}`)
-          }
-          result[name] = buffer
-          hasNewBuffers = true
-        }
+  // Creator mode: run the creator and register the result through the shared
+  // staged-registration mechanism (render-phase creation, commit-phase store
+  // write). In reader mode this stages nothing and returns {}.
+  const created = useScopedResource<BufferLike>({
+    store,
+    kind: 'buffers',
+    scope: isReader ? undefined : scope,
+    isLeaf: isBufferLike,
+    create: () => {
+      if (isReader) return {}
+      // Lazy ScopedStore wrapping - Proxies only created if uniforms/nodes/buffers accessed
+      return (creatorOrScope as BufferCreator<T>)(createLazyCreatorState(store.getState(), store))
+    },
+    prepare: (name, buffer) => {
+      // Apply label for debugging if it's a TSL node
+      if ('setName' in buffer && typeof buffer.setName === 'function') {
+        buffer.setName(scope ? `${scope}.${name}` : name)
       }
+      return buffer
+    },
+  })
 
-      if (hasNewBuffers) {
-        set((s) => ({
-          buffers: {
-            ...s.buffers,
-            [scope]: { ...(s.buffers[scope] as BufferRecord), ...result },
-          },
-        }))
-      }
-
-      return result as T
-    }
-
-    // Root-level buffers ---------------------------------
-    for (const [name, buffer] of Object.entries(created)) {
-      const existing = state.buffers[name]
-      if (existing && isBufferLike(existing)) {
-        result[name] = existing
-      } else {
-        // Apply label for debugging if it's a TSL node
-        if ('setName' in buffer && typeof buffer.setName === 'function') {
-          buffer.setName(name)
-        }
-        result[name] = buffer
-        hasNewBuffers = true
-      }
-    }
-
-    if (hasNewBuffers) {
-      set((s) => ({ buffers: { ...s.buffers, ...result } }))
-    }
-
-    return result as T
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [store, scopeDep, readerDep, creatorDep])
+  // Case 1: No arguments - all buffers (root + scopes), reactive via storeBuffers
+  // Case 2: String argument - that scope's buffers (guard against a buffer
+  //         stored under the same name), reactive via storeBuffers
+  // Case 3: Creator function - the entries registered above
+  let buffers: BufferRecordType | (BufferRecordType & Record<string, BufferRecordType>) = created
+  if (creatorOrScope === undefined) {
+    buffers = storeBuffers as BufferRecordType & Record<string, BufferRecordType>
+  } else if (typeof creatorOrScope === 'string') {
+    const scopeData = storeBuffers[creatorOrScope]
+    buffers = scopeData && !isBufferLike(scopeData) ? (scopeData as BufferRecordType) : {}
+  }
 
   // Return buffers with utils
   return { ...buffers, removeBuffers, clearBuffers, rebuildBuffers, disposeBuffers } as BuffersWithUtils<T>
@@ -333,30 +232,17 @@ export function useBuffers<T extends Record<string, BufferLike>>(
 
 /**
  * Global rebuildBuffers function for HMR integration.
- * Clears cached buffers and increments _hmrVersion to trigger re-creation.
+ * Invalidates cached buffers and increments _hmrVersion to trigger re-creation.
  * Call this when HMR is detected to refresh all buffer creators.
+ *
+ * Resolves to the primary store so shared TSL resources rebuild on the
+ * authoritative store.
  *
  * @param store - The R3F store (from useStore or context)
  * @param scope - Optional scope to rebuild ('root' for root only, string for specific scope, undefined for all)
  */
 export function rebuildAllBuffers(store: ReturnType<typeof useStore>, scope?: string) {
-  // Resolve to the primary store so shared TSL resources rebuild on the authoritative store
-  store = store.getState().primaryStore ?? store
-  store.setState((state) => {
-    let newBuffers = state.buffers
-    if (scope && scope !== 'root') {
-      const { [scope]: _, ...rest } = state.buffers
-      newBuffers = rest
-    } else if (scope === 'root') {
-      newBuffers = {}
-      for (const [key, value] of Object.entries(state.buffers)) {
-        if (!isBufferLike(value)) newBuffers[key] = value
-      }
-    } else {
-      newBuffers = {}
-    }
-    return { buffers: newBuffers, _hmrVersion: state._hmrVersion + 1 }
-  })
+  rebuildResource(store, 'buffers', scope)
 }
 
 export default useBuffers

--- a/packages/fiber/src/webgpu/hooks/useGPUStorage.tsx
+++ b/packages/fiber/src/webgpu/hooks/useGPUStorage.tsx
@@ -1,8 +1,10 @@
 // EXPERIMENTAL (A3): API may change before stable. Reactive GPU storage registry for TSL.
-import { useCallback, useMemo } from 'react'
+import { useCallback } from 'react'
 import { useStore } from '../../core/hooks'
 import { usePrimaryStore, usePrimaryThree } from '../../core/hooks/usePrimaryStore'
+import { clearResourceEntries, rebuildResource, removeResourceEntries } from '../../core/utils/resourceRegistry'
 import { createLazyCreatorState, type CreatorState } from './ScopedStore'
+import { useScopedResource } from './useScopedResource'
 import type { StorageLike, StorageRecord } from '#types'
 
 //* Types ==============================
@@ -139,68 +141,20 @@ export function useGPUStorage<T extends Record<string, StorageLike>>(
 
   /** Remove storage by name from root or a scope */
   const removeStorage = useCallback<RemoveStorageFn>(
-    (names, targetScope) => {
-      const nameArray = Array.isArray(names) ? names : [names]
-      store.setState((state) => {
-        if (targetScope) {
-          // Remove from scoped storage
-          const currentScope = { ...(state.gpuStorage[targetScope] as StorageRecord) }
-          for (const name of nameArray) delete currentScope[name]
-          return { gpuStorage: { ...state.gpuStorage, [targetScope]: currentScope } }
-        }
-        // Remove from root level
-        const gpuStorage = { ...state.gpuStorage }
-        for (const name of nameArray) if (isStorageLike(gpuStorage[name])) delete gpuStorage[name]
-        return { gpuStorage }
-      })
-    },
+    (names, targetScope) =>
+      removeResourceEntries(store, 'gpuStorage', Array.isArray(names) ? names : [names], targetScope, isStorageLike),
     [store],
   )
 
   /** Clear storage - scope name, 'root' for root only, or undefined for all */
   const clearStorage = useCallback<ClearStorageFn>(
-    (targetScope) => {
-      store.setState((state) => {
-        // Clear specific scope
-        if (targetScope && targetScope !== 'root') {
-          const { [targetScope]: _, ...rest } = state.gpuStorage
-          return { gpuStorage: rest }
-        }
-        // Clear root only (preserve scopes)
-        if (targetScope === 'root') {
-          const gpuStorage: typeof state.gpuStorage = {}
-          for (const [key, value] of Object.entries(state.gpuStorage)) {
-            if (!isStorageLike(value)) gpuStorage[key] = value
-          }
-          return { gpuStorage }
-        }
-        // Clear everything
-        return { gpuStorage: {} }
-      })
-    },
+    (targetScope) => clearResourceEntries(store, 'gpuStorage', targetScope, isStorageLike),
     [store],
   )
 
-  /** Rebuild storage - clears cache and increments HMR version to trigger re-creation */
+  /** Rebuild storage - invalidates the cache and increments HMR version to trigger re-creation */
   const rebuildStorage = useCallback<RebuildStorageFn>(
-    (targetScope) => {
-      store.setState((state) => {
-        // Clear the specified scope (or all) and bump version
-        let newStorage = state.gpuStorage
-        if (targetScope && targetScope !== 'root') {
-          const { [targetScope]: _, ...rest } = state.gpuStorage
-          newStorage = rest
-        } else if (targetScope === 'root') {
-          newStorage = {}
-          for (const [key, value] of Object.entries(state.gpuStorage)) {
-            if (!isStorageLike(value)) newStorage[key] = value
-          }
-        } else {
-          newStorage = {}
-        }
-        return { gpuStorage: newStorage, _hmrVersion: state._hmrVersion + 1 }
-      })
-    },
+    (targetScope) => rebuildResource(store, 'gpuStorage', targetScope),
     [store],
   )
 
@@ -237,102 +191,44 @@ export function useGPUStorage<T extends Record<string, StorageLike>>(
   // For creator mode, we intentionally don't use this value to avoid re-running the creator
   const storeStorage = usePrimaryThree((s) => s.gpuStorage)
 
-  // Subscribe to HMR version for creator modes
-  // This allows rebuildStorage() to bust the memoization cache and force re-creation
-  const hmrVersion = usePrimaryThree((s) => s._hmrVersion)
-
-  // Extracted deps to avoid complex expressions in useMemo dependency array
-  const scopeDep = typeof creatorOrScope === 'string' ? creatorOrScope : scope
-  const readerDep = isReader ? storeStorage : null
-  const creatorDep = isReader ? null : hmrVersion
-
-  const gpuStorage = useMemo(() => {
-    // Case 1: No arguments - return all storage (root + scopes)
-    // Uses subscribed storeStorage for reactivity
-    if (creatorOrScope === undefined) {
-      return storeStorage as StorageRecordType & Record<string, StorageRecordType>
-    }
-
-    // Case 2: String argument - return storage from that scope
-    // Uses subscribed storeStorage for reactivity
-    if (typeof creatorOrScope === 'string') {
-      const scopeData = storeStorage[creatorOrScope]
-      // Make sure we're returning a scope object, not a storage item
-      if (scopeData && !isStorageLike(scopeData)) return scopeData as StorageRecordType
-      return {}
-    }
-
-    // Case 3: Creator function - create if not exists
-    // Uses store.getState() snapshot to avoid re-running creator on unrelated storage changes
-    const state = store.getState()
-    const set = store.setState
-    const creator = creatorOrScope
-
-    // Lazy ScopedStore wrapping - Proxies only created if uniforms/nodes/buffers/storage accessed
-    const wrappedState = createLazyCreatorState(state)
-    const created = creator(wrappedState)
-    const result: Record<string, StorageLike> = {}
-    let hasNewStorage = false
-
-    // Scoped storage ---------------------------------
-    if (scope) {
-      const currentScope = (state.gpuStorage[scope] as StorageRecord) ?? {}
-
-      for (const [name, storage] of Object.entries(created)) {
-        if (currentScope[name]) {
-          result[name] = currentScope[name]
-        } else {
-          // Apply label for debugging if it's a TSL node
-          if ('setName' in storage && typeof storage.setName === 'function') {
-            storage.setName(`${scope}.${name}`)
-          }
-          // Apply name to textures if they have a name property
-          if ('name' in storage && typeof storage.name === 'string') {
-            ;(storage as any).name = `${scope}.${name}`
-          }
-          result[name] = storage
-          hasNewStorage = true
-        }
+  // Creator mode: run the creator and register the result through the shared
+  // staged-registration mechanism (render-phase creation, commit-phase store
+  // write). In reader mode this stages nothing and returns {}.
+  const created = useScopedResource<StorageLike>({
+    store,
+    kind: 'gpuStorage',
+    scope: isReader ? undefined : scope,
+    isLeaf: isStorageLike,
+    create: () => {
+      if (isReader) return {}
+      // Lazy ScopedStore wrapping - Proxies only created if uniforms/nodes/buffers/storage accessed
+      return (creatorOrScope as StorageCreator<T>)(createLazyCreatorState(store.getState(), store))
+    },
+    prepare: (name, storage) => {
+      const label = scope ? `${scope}.${name}` : name
+      // Apply label for debugging if it's a TSL node
+      if ('setName' in storage && typeof storage.setName === 'function') {
+        storage.setName(label)
       }
-
-      if (hasNewStorage) {
-        set((s) => ({
-          gpuStorage: {
-            ...s.gpuStorage,
-            [scope]: { ...(s.gpuStorage[scope] as StorageRecord), ...result },
-          },
-        }))
+      // Apply name to textures if they have a name property
+      if ('name' in storage && typeof storage.name === 'string') {
+        ;(storage as any).name = label
       }
+      return storage
+    },
+  })
 
-      return result as T
-    }
-
-    // Root-level storage ---------------------------------
-    for (const [name, storage] of Object.entries(created)) {
-      const existing = state.gpuStorage[name]
-      if (existing && isStorageLike(existing)) {
-        result[name] = existing
-      } else {
-        // Apply label for debugging if it's a TSL node
-        if ('setName' in storage && typeof storage.setName === 'function') {
-          storage.setName(name)
-        }
-        // Apply name to textures if they have a name property
-        if ('name' in storage && typeof storage.name === 'string') {
-          ;(storage as any).name = name
-        }
-        result[name] = storage
-        hasNewStorage = true
-      }
-    }
-
-    if (hasNewStorage) {
-      set((s) => ({ gpuStorage: { ...s.gpuStorage, ...result } }))
-    }
-
-    return result as T
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [store, scopeDep, readerDep, creatorDep])
+  // Case 1: No arguments - all storage (root + scopes), reactive via storeStorage
+  // Case 2: String argument - that scope's storage (guard against a storage
+  //         item stored under the same name), reactive via storeStorage
+  // Case 3: Creator function - the entries registered above
+  let gpuStorage: StorageRecordType | (StorageRecordType & Record<string, StorageRecordType>) = created
+  if (creatorOrScope === undefined) {
+    gpuStorage = storeStorage as StorageRecordType & Record<string, StorageRecordType>
+  } else if (typeof creatorOrScope === 'string') {
+    const scopeData = storeStorage[creatorOrScope]
+    gpuStorage = scopeData && !isStorageLike(scopeData) ? (scopeData as StorageRecordType) : {}
+  }
 
   // Return storage with utils
   return {
@@ -349,30 +245,17 @@ export function useGPUStorage<T extends Record<string, StorageLike>>(
 
 /**
  * Global rebuildStorage function for HMR integration.
- * Clears cached storage and increments _hmrVersion to trigger re-creation.
+ * Invalidates cached storage and increments _hmrVersion to trigger re-creation.
  * Call this when HMR is detected to refresh all storage creators.
+ *
+ * Resolves to the primary store so shared TSL resources rebuild on the
+ * authoritative store.
  *
  * @param store - The R3F store (from useStore or context)
  * @param scope - Optional scope to rebuild ('root' for root only, string for specific scope, undefined for all)
  */
 export function rebuildAllStorage(store: ReturnType<typeof useStore>, scope?: string) {
-  // Resolve to the primary store so shared TSL resources rebuild on the authoritative store
-  store = store.getState().primaryStore ?? store
-  store.setState((state) => {
-    let newStorage = state.gpuStorage
-    if (scope && scope !== 'root') {
-      const { [scope]: _, ...rest } = state.gpuStorage
-      newStorage = rest
-    } else if (scope === 'root') {
-      newStorage = {}
-      for (const [key, value] of Object.entries(state.gpuStorage)) {
-        if (!isStorageLike(value)) newStorage[key] = value
-      }
-    } else {
-      newStorage = {}
-    }
-    return { gpuStorage: newStorage, _hmrVersion: state._hmrVersion + 1 }
-  })
+  rebuildResource(store, 'gpuStorage', scope)
 }
 
 export default useGPUStorage

--- a/packages/fiber/src/webgpu/hooks/useNodes.tsx
+++ b/packages/fiber/src/webgpu/hooks/useNodes.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useMemo } from 'react'
 import { useStore } from '../../core/hooks'
 import { usePrimaryStore, usePrimaryThree } from '../../core/hooks/usePrimaryStore'
+import { clearResourceEntries, rebuildResource, removeResourceEntries } from '../../core/utils/resourceRegistry'
 import { createLazyCreatorState, type CreatorState } from './ScopedStore'
+import { useScopedResource } from './useScopedResource'
 
 //* Types ==============================
 
@@ -121,68 +123,20 @@ export function useNodes<T extends Record<string, TSLNodeLike>>(
 
   /** Remove nodes by name from root or a scope */
   const removeNodes = useCallback<RemoveNodesFn>(
-    (names, targetScope) => {
-      const nameArray = Array.isArray(names) ? names : [names]
-      store.setState((state) => {
-        if (targetScope) {
-          // Remove from scoped nodes
-          const currentScope = { ...(state.nodes[targetScope] as NodeRecord) }
-          for (const name of nameArray) delete currentScope[name]
-          return { nodes: { ...state.nodes, [targetScope]: currentScope } }
-        }
-        // Remove from root level
-        const nodes = { ...state.nodes }
-        for (const name of nameArray) if (isTSLNode(nodes[name])) delete nodes[name]
-        return { nodes }
-      })
-    },
+    (names, targetScope) =>
+      removeResourceEntries(store, 'nodes', Array.isArray(names) ? names : [names], targetScope, isTSLNode),
     [store],
   )
 
   /** Clear nodes - scope name, 'root' for root only, or undefined for all */
   const clearNodes = useCallback<ClearNodesFn>(
-    (targetScope) => {
-      store.setState((state) => {
-        // Clear specific scope
-        if (targetScope && targetScope !== 'root') {
-          const { [targetScope]: _, ...rest } = state.nodes
-          return { nodes: rest }
-        }
-        // Clear root only (preserve scopes)
-        if (targetScope === 'root') {
-          const nodes: typeof state.nodes = {}
-          for (const [key, value] of Object.entries(state.nodes)) {
-            if (!isTSLNode(value)) nodes[key] = value
-          }
-          return { nodes }
-        }
-        // Clear everything
-        return { nodes: {} }
-      })
-    },
+    (targetScope) => clearResourceEntries(store, 'nodes', targetScope, isTSLNode),
     [store],
   )
 
-  /** Rebuild nodes - clears cache and increments HMR version to trigger re-creation */
+  /** Rebuild nodes - invalidates the cache and increments HMR version to trigger re-creation */
   const rebuildNodes = useCallback<RebuildNodesFn>(
-    (targetScope) => {
-      store.setState((state) => {
-        // Clear the specified scope (or all) and bump version
-        let newNodes = state.nodes
-        if (targetScope && targetScope !== 'root') {
-          const { [targetScope]: _, ...rest } = state.nodes
-          newNodes = rest
-        } else if (targetScope === 'root') {
-          newNodes = {}
-          for (const [key, value] of Object.entries(state.nodes)) {
-            if (!isTSLNode(value)) newNodes[key] = value
-          }
-        } else {
-          newNodes = {}
-        }
-        return { nodes: newNodes, _hmrVersion: state._hmrVersion + 1 }
-      })
-    },
+    (targetScope) => rebuildResource(store, 'nodes', targetScope),
     [store],
   )
 
@@ -196,90 +150,37 @@ export function useNodes<T extends Record<string, TSLNodeLike>>(
   // For creator mode, we intentionally don't use this value to avoid re-running the creator
   const storeNodes = usePrimaryThree((s) => s.nodes)
 
-  // Subscribe to HMR version for creator modes
-  // This allows rebuildNodes() to bust the memoization cache and force re-creation
-  const hmrVersion = usePrimaryThree((s) => s._hmrVersion)
+  // Creator mode: run the creator and register the result through the shared
+  // staged-registration mechanism (render-phase creation, commit-phase store
+  // write). In reader mode this stages nothing and returns {}.
+  const created = useScopedResource<TSLNodeLike>({
+    store,
+    kind: 'nodes',
+    scope: isReader ? undefined : scope,
+    isLeaf: isTSLNode,
+    create: () => {
+      if (isReader) return {}
+      // Lazy ScopedStore wrapping - Proxies only created if uniforms/nodes accessed
+      return (creatorOrScope as NodeCreator<T>)(createLazyCreatorState(store.getState(), store))
+    },
+    prepare: (name, node) => {
+      // Apply label for debugging
+      node.setName?.(scope ? `${scope}.${name}` : name)
+      return node
+    },
+  })
 
-  // Extracted deps to avoid complex expressions in useMemo dependency array
-  const scopeDep = typeof creatorOrScope === 'string' ? creatorOrScope : scope
-  const readerDep = isReader ? storeNodes : null
-  const creatorDep = isReader ? null : hmrVersion
-
-  const nodes = useMemo(() => {
-    // Case 1: No arguments - return all nodes (root + scopes)
-    // Uses subscribed storeNodes for reactivity
-    if (creatorOrScope === undefined) {
-      return storeNodes as NodeRecord & Record<string, NodeRecord>
-    }
-
-    // Case 2: String argument - return nodes from that scope
-    // Uses subscribed storeNodes for reactivity
-    if (typeof creatorOrScope === 'string') {
-      const scopeData = storeNodes[creatorOrScope]
-      // Make sure we're returning a scope object, not a TSL node
-      if (scopeData && !isTSLNode(scopeData)) return scopeData as NodeRecord
-      return {}
-    }
-
-    // Case 3: Creator function - create if not exists
-    // Uses store.getState() snapshot to avoid re-running creator on unrelated node changes
-    const state = store.getState()
-    const set = store.setState
-    const creator = creatorOrScope
-
-    // Lazy ScopedStore wrapping - Proxies only created if uniforms/nodes accessed
-    const wrappedState = createLazyCreatorState(state)
-    const created = creator(wrappedState)
-    const result: Record<string, TSLNodeLike> = {}
-    let hasNewNodes = false
-
-    // Scoped nodes ---------------------------------
-    if (scope) {
-      const currentScope = (state.nodes[scope] as NodeRecord) ?? {}
-
-      for (const [name, node] of Object.entries(created)) {
-        if (currentScope[name]) {
-          result[name] = currentScope[name]
-        } else {
-          // Apply label for debugging
-          node.setName?.(`${scope}.${name}`)
-          result[name] = node
-          hasNewNodes = true
-        }
-      }
-
-      if (hasNewNodes) {
-        set((s) => ({
-          nodes: {
-            ...s.nodes,
-            [scope]: { ...(s.nodes[scope] as NodeRecord), ...result },
-          },
-        }))
-      }
-
-      return result as T
-    }
-
-    // Root-level nodes ---------------------------------
-    for (const [name, node] of Object.entries(created)) {
-      const existing = state.nodes[name]
-      if (existing && isTSLNode(existing)) {
-        result[name] = existing
-      } else {
-        // Apply label for debugging
-        node.setName?.(name)
-        result[name] = node
-        hasNewNodes = true
-      }
-    }
-
-    if (hasNewNodes) {
-      set((s) => ({ nodes: { ...s.nodes, ...result } }))
-    }
-
-    return result as T
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [store, scopeDep, readerDep, creatorDep])
+  // Case 1: No arguments - all nodes (root + scopes), reactive via storeNodes
+  // Case 2: String argument - that scope's nodes (guard against a TSL node
+  //         stored under the same name), reactive via storeNodes
+  // Case 3: Creator function - the entries registered above
+  let nodes: NodeRecord | (NodeRecord & Record<string, NodeRecord>) = created
+  if (creatorOrScope === undefined) {
+    nodes = storeNodes as NodeRecord & Record<string, NodeRecord>
+  } else if (typeof creatorOrScope === 'string') {
+    const scopeData = storeNodes[creatorOrScope]
+    nodes = scopeData && !isTSLNode(scopeData) ? (scopeData as NodeRecord) : {}
+  }
 
   // Return nodes with utils
   return { ...nodes, removeNodes, clearNodes, rebuildNodes } as NodesWithUtils<T>
@@ -290,30 +191,17 @@ export function useNodes<T extends Record<string, TSLNodeLike>>(
 
 /**
  * Global rebuildNodes function for HMR integration.
- * Clears cached nodes and increments _hmrVersion to trigger re-creation.
+ * Invalidates cached nodes and increments _hmrVersion to trigger re-creation.
  * Call this when HMR is detected to refresh all node creators.
+ *
+ * Resolves to the primary store so shared TSL resources rebuild on the
+ * authoritative store.
  *
  * @param store - The R3F store (from useStore or context)
  * @param scope - Optional scope to rebuild ('root' for root only, string for specific scope, undefined for all)
  */
 export function rebuildAllNodes(store: ReturnType<typeof useStore>, scope?: string) {
-  // Resolve to the primary store so shared TSL resources rebuild on the authoritative store
-  store = store.getState().primaryStore ?? store
-  store.setState((state) => {
-    let newNodes = state.nodes
-    if (scope && scope !== 'root') {
-      const { [scope]: _, ...rest } = state.nodes
-      newNodes = rest
-    } else if (scope === 'root') {
-      newNodes = {}
-      for (const [key, value] of Object.entries(state.nodes)) {
-        if (!isTSLNode(value)) newNodes[key] = value
-      }
-    } else {
-      newNodes = {}
-    }
-    return { nodes: newNodes, _hmrVersion: state._hmrVersion + 1 }
-  })
+  rebuildResource(store, 'nodes', scope)
 }
 
 //* Standalone Utils (Deprecated) ==============================
@@ -405,8 +293,10 @@ export function useLocalNodes<T extends Record<string, unknown>>(creator: LocalN
   const hmrVersion = usePrimaryThree((s) => s._hmrVersion)
 
   return useMemo(() => {
-    // Lazy ScopedStore wrapping - Proxies only created if uniforms/nodes accessed
-    const wrappedState = createLazyCreatorState(store.getState())
+    // Lazy ScopedStore wrapping - Proxies only created if uniforms/nodes accessed.
+    // The store is passed so entries staged (not yet committed) by creator hooks
+    // earlier in this render pass are visible here too.
+    const wrappedState = createLazyCreatorState(store.getState(), store)
     return creator(wrappedState)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [store, creator, uniforms, nodes, textures, hmrVersion]) // hmrVersion triggers rebuild on HMR

--- a/packages/fiber/src/webgpu/hooks/useScopedResource.ts
+++ b/packages/fiber/src/webgpu/hooks/useScopedResource.ts
@@ -1,0 +1,118 @@
+import { useMemo } from 'react'
+import { useIsomorphicLayoutEffect } from '../../core/utils'
+import {
+  ROOT_SCOPE,
+  flushStagedScope,
+  isScopeValid,
+  peekStaged,
+  readCommittedScope,
+  stageEntries,
+  type LeafGuard,
+  type ResourceKind,
+} from '../../core/utils/resourceRegistry'
+import type { RootStore } from '#types'
+
+/**
+ * @template C candidate type — what the creator produces (raw uniform inputs, TSL nodes, …)
+ * @template V value type — what is stored on the map (UniformNode, TSL node, buffer, …)
+ */
+export interface ScopedResourceOptions<C, V> {
+  /** The store the resource lives on (already primary-resolved by the caller). */
+  store: RootStore
+  kind: ResourceKind
+  /** Scope name, or `undefined` for root-level entries. */
+  scope: string | undefined
+  /** Distinguishes leaf entries from scope sub-objects on this kind's map. */
+  isLeaf: LeafGuard
+  /**
+   * Produces the candidate entries. Runs inside the memo — only when `store`,
+   * `scope`, `_hmrVersion`, or `input` change, NOT on every render. Must be
+   * pure apart from resource construction: registration is handled here.
+   * Return an empty record in reader mode.
+   */
+  create: () => Record<string, C>
+  /**
+   * Turns a candidate into the stored value for entries being registered for
+   * the first time this generation (wrap in `uniform()`, apply debug labels…).
+   * Defaults to the identity — only valid when `C` and `V` coincide.
+   */
+  prepare?: (name: string, candidate: C) => V
+  /**
+   * Reconciles an existing entry with a fresh candidate when the entry is
+   * reused (e.g. sync a changed uniform value onto the live node — GPU-only,
+   * no store write).
+   */
+  reconcile?: (existing: V, candidate: C) => void
+  /** Extra memo dependency (deep-compared input, uniform name, …). */
+  input?: unknown
+}
+
+/**
+ * The one registration mechanism shared by every TSL resource hook
+ * (`useNodes`, `useUniforms`, `useBuffers`, `useGPUStorage`, `useUniform`).
+ *
+ * Render phase (the memo) is pure computation: candidates are created, reused
+ * against the current generation, and freshly created values are STAGED in the
+ * resource registry — never written to the store, so already-mounted readers
+ * are never notified mid-render. Commit phase (the layout effect) flushes the
+ * staged entries in one immutable `setState` per scope; readers observe a
+ * single old-complete → new-complete transition.
+ *
+ * Reuse resolution order, per entry name:
+ *  1. staged this render pass (same-generation sharing, StrictMode dedup)
+ *  2. committed on the store — only while the scope is VALID; after an HMR or
+ *     `rebuild*` invalidation nothing committed is reusable, so a stale entry
+ *     can never be resurrected into the new generation.
+ *
+ * Returns exactly the caller's entries (created + reused), not the whole scope.
+ */
+export function useScopedResource<C, V = C>(options: ScopedResourceOptions<C, V>): Record<string, V> {
+  const { store, kind, scope, isLeaf, create, prepare, reconcile, input } = options
+  const scopeKey = scope ?? ROOT_SCOPE
+
+  // Re-run creators when a rebuild/HMR invalidation bumps the version. The
+  // subscription is against the SAME store the registry is keyed by.
+  const version = store((s) => s._hmrVersion)
+
+  const entries = useMemo(() => {
+    const staged = peekStaged(store, kind, scopeKey)
+    const reusable = isScopeValid(store, kind, scopeKey)
+    const map = store.getState()[kind] as Record<string, unknown>
+    const committed = reusable ? readCommittedScope(map, scopeKey, isLeaf) : undefined
+
+    const result: Record<string, V> = {}
+    let fresh: Record<string, V> | null = null
+
+    for (const [name, candidate] of Object.entries(create())) {
+      const existing = (staged?.[name] ?? committed?.[name]) as V | undefined
+      if (existing !== undefined) {
+        result[name] = existing
+        reconcile?.(existing, candidate)
+      } else {
+        const value = prepare ? prepare(name, candidate) : (candidate as unknown as V)
+        result[name] = value
+        ;(fresh ??= {})[name] = value
+      }
+    }
+
+    // Staging is render-phase but registry-only; React may discard this render
+    // (StrictMode, interrupted work) — a staged entry then simply gets
+    // committed by the next flush of this scope, which is harmless for
+    // create-if-not-exists resources and exactly what the reuse path expects.
+    if (fresh) stageEntries(store, kind, scopeKey, fresh)
+    return result
+    // create/prepare/reconcile are intentionally not dependencies: creator
+    // identity changes every render (inline closures) and must not bust the
+    // cache — `input` carries the hook-specific trigger instead.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [store, kind, scopeKey, version, input])
+
+  // Commit phase: land this scope's staged entries on the store. Runs every
+  // commit on purpose — the first contributor to flush commits the whole
+  // scope's staging atomically and the rest become no-ops.
+  useIsomorphicLayoutEffect(() => {
+    flushStagedScope(store, kind, scopeKey, isLeaf)
+  })
+
+  return entries
+}

--- a/packages/fiber/src/webgpu/hooks/useUniform.tsx
+++ b/packages/fiber/src/webgpu/hooks/useUniform.tsx
@@ -1,9 +1,10 @@
-import { useMemo } from 'react'
 import { uniform } from '#three/tsl'
 import { Color as ThreeColor, Node } from '#three'
 
 import type { Vector2, Vector3, Vector4, Color, Matrix3, Matrix4 } from '#three'
-import { useStore, useThree } from '../../core/hooks'
+import { useStore } from '../../core/hooks'
+import { ROOT_SCOPE, peekStaged } from '../../core/utils/resourceRegistry'
+import { useScopedResource } from './useScopedResource'
 
 /**
  * `uniform()` typed to its documented runtime contract.
@@ -106,73 +107,62 @@ export function useUniform<T extends UniformValue>(name: string, value: T): Unif
 export function useUniform<T extends UniformValue>(name: string, value?: T): UniformNode<Widen<T>> {
   const store = useStore()
 
-  // Subscribe to HMR version - when it changes, uniforms get re-created
-  const hmrVersion = useThree((s) => s._hmrVersion)
-
-  return useMemo(() => {
-    const state = store.getState()
-    const set = store.setState
-    const existing = state.uniforms[name]
-
-    // Case 1: Uniform exists in store ---------------------------------
-    if (existing && isUniformNode(existing)) {
+  // Create mode: register through the shared staged mechanism (render-phase
+  // creation, commit-phase store write, generation-aware reuse). In get-only
+  // mode this stages nothing and returns {}.
+  // Note: `value` is intentionally not a memo trigger - updates happen
+  // imperatively via `node.value`.
+  const registered = useScopedResource<UniformValue, UniformNode>({
+    store,
+    kind: 'uniforms',
+    scope: undefined,
+    isLeaf: isUniformNode,
+    input: name,
+    create: () => (value === undefined ? {} : { [name]: value }),
+    prepare: createNamedUniform,
+    reconcile: (existing) => {
       // Update value if provided (but not for TSL nodes - those are immutable)
       if (value !== undefined && !isTSLNode(value) && !isUniformNode(value)) {
         existing.value = typeof value === 'string' ? new ThreeColor(value) : value
       }
-      return existing as UniformNode<Widen<T>>
-    }
+    },
+  })
+  if (registered[name]) return registered[name] as UniformNode<Widen<T>>
 
-    // Case 2: Get-only mode but uniform doesn't exist ---------------------------------
-    if (value === undefined) {
-      throw new Error(
-        `[useUniform] Uniform "${name}" not found. ` + `Create it first with: useUniform('${name}', initialValue)`,
-      )
-    }
+  // Get-only mode: return the uniform another hook registered — committed, or
+  // staged earlier in this same render pass (not yet flushed).
+  const existing = peekStaged(store, 'uniforms', ROOT_SCOPE)?.[name] ?? store.getState().uniforms[name]
+  if (existing && isUniformNode(existing)) return existing as UniformNode<Widen<T>>
 
-    // Case 3: Value is already a UniformNode ---------------------------------
-    // Just register it to the store (e.g., from external library)
-    if (isUniformNode(value)) {
-      const node = value as unknown as UniformNode<Widen<T>>
-      if (typeof node.setName === 'function') {
-        node.setName(name)
-      }
-      set((s) => ({
-        uniforms: { ...s.uniforms, [name]: node },
-      }))
-      return node
-    }
+  throw new Error(
+    `[useUniform] Uniform "${name}" not found. ` + `Create it first with: useUniform('${name}', initialValue)`,
+  )
+}
 
-    // Case 4: Create new uniform ---------------------------------
-    let node: UniformNode<Widen<T>>
+/** Build the stored UniformNode for a fresh registration (see useUniform cases). */
+function createNamedUniform(name: string, value: UniformValue): UniformNode {
+  let node: UniformNode
 
-    if (isTSLNode(value)) {
-      // TSL nodes (color(), vec3(), float()) - pass directly for type casting
-      node = uniformOf(value) as unknown as UniformNode<Widen<T>>
-    } else if (typeof value === 'string') {
-      // String colors - convert to Three.js Color (matches three's `(value: Color)` overload)
-      node = uniform(new ThreeColor(value)) as unknown as UniformNode<Widen<T>>
-    } else {
-      // Raw values (number, Vector3, Color, etc.)
-      node = uniformOf(value) as unknown as UniformNode<Widen<T>>
-    }
+  if (isUniformNode(value)) {
+    // Already a UniformNode - register it to the store as-is (e.g., from external library)
+    node = value
+  } else if (isTSLNode(value)) {
+    // TSL nodes (color(), vec3(), float()) - pass directly for type casting
+    node = uniformOf(value)
+  } else if (typeof value === 'string') {
+    // String colors - convert to Three.js Color (matches three's `(value: Color)` overload)
+    node = uniform(new ThreeColor(value)) as unknown as UniformNode
+  } else {
+    // Raw values (number, Vector3, Color, etc.)
+    node = uniformOf(value)
+  }
 
-    // Label for debugging
-    if (typeof node.setName === 'function') {
-      node.setName(name)
-    }
+  // Label for debugging
+  if (typeof node.setName === 'function') {
+    node.setName(name)
+  }
 
-    // Register to store
-    set((s) => ({
-      uniforms: {
-        ...s.uniforms,
-        [name]: node,
-      },
-    }))
-
-    return node
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [store, name, hmrVersion]) // Note: value intentionally excluded - updates happen imperatively
+  return node
 }
 
 export default useUniform

--- a/packages/fiber/src/webgpu/hooks/useUniforms.tsx
+++ b/packages/fiber/src/webgpu/hooks/useUniforms.tsx
@@ -6,7 +6,9 @@ import { uniform } from '#three/tsl'
 import { vectorize } from './utils'
 import { useCompareMemoize } from './useCompareMemoize'
 import { is } from '../../core/utils'
+import { clearResourceEntries, rebuildResource, removeResourceEntries } from '../../core/utils/resourceRegistry'
 import { createLazyCreatorState, type CreatorState } from './ScopedStore'
+import { useScopedResource } from './useScopedResource'
 
 //* Types ==============================
 
@@ -144,66 +146,20 @@ export function useUniforms<T extends UniformInputRecord = UniformInputRecord>(
 
   /** Remove uniforms by name from root or a scope */
   const removeUniforms = useCallback<RemoveUniformsFn>(
-    (names, targetScope) => {
-      const nameArray = Array.isArray(names) ? names : [names]
-      store.setState((state) => {
-        if (targetScope) {
-          // Remove from scoped uniforms
-          const currentScope = { ...(state.uniforms[targetScope] as UniformRecord) }
-          for (const name of nameArray) delete currentScope[name]
-          return { uniforms: { ...state.uniforms, [targetScope]: currentScope } }
-        }
-        // Remove from root level
-        const uniforms = { ...state.uniforms }
-        for (const name of nameArray) if (isUniformNode(uniforms[name])) delete uniforms[name]
-        return { uniforms }
-      })
-    },
+    (names, targetScope) =>
+      removeResourceEntries(store, 'uniforms', Array.isArray(names) ? names : [names], targetScope, isUniformNode),
     [store],
   )
 
   /** Clear uniforms - scope name, 'root' for root only, or undefined for all */
   const clearUniforms = useCallback<ClearUniformsFn>(
-    (targetScope) => {
-      store.setState((state) => {
-        // Clear specific scope
-        if (targetScope && targetScope !== 'root') {
-          const { [targetScope]: _, ...rest } = state.uniforms
-          return { uniforms: rest }
-        }
-        // Clear root only (preserve scopes)
-        if (targetScope === 'root') {
-          const uniforms: typeof state.uniforms = {}
-          for (const [key, value] of Object.entries(state.uniforms)) {
-            if (!isUniformNode(value)) uniforms[key] = value
-          }
-          return { uniforms }
-        }
-        // Clear everything
-        return { uniforms: {} }
-      })
-    },
+    (targetScope) => clearResourceEntries(store, 'uniforms', targetScope, isUniformNode),
     [store],
   )
 
-  /** Rebuild uniforms - clears cache and increments HMR version to trigger re-creation */
+  /** Rebuild uniforms - invalidates the cache and increments HMR version to trigger re-creation */
   const rebuildUniforms = useCallback<RebuildUniformsFn>(
-    (targetScope) => {
-      store.setState((state) => {
-        // Clear the specified scope (or all) and bump version
-        let newUniforms: typeof state.uniforms = {}
-        if (targetScope && targetScope !== 'root') {
-          const { [targetScope]: _, ...rest } = state.uniforms
-          newUniforms = rest
-        } else if (targetScope === 'root') {
-          for (const [key, value] of Object.entries(state.uniforms)) {
-            if (!isUniformNode(value)) newUniforms[key] = value
-          }
-        }
-        // else: stays as {} (clear all)
-        return { uniforms: newUniforms, _hmrVersion: state._hmrVersion + 1 }
-      })
-    },
+    (targetScope) => rebuildResource(store, 'uniforms', targetScope),
     [store],
   )
 
@@ -222,8 +178,10 @@ export function useUniforms<T extends UniformInputRecord = UniformInputRecord>(
 
     // If a function, execute it and get what it returns
     if (is.fun(creatorOrScope)) {
-      // Lazy ScopedStore wrapping - Proxies only created if uniforms/nodes accessed
-      const wrappedState = createLazyCreatorState(store.getState())
+      // Lazy ScopedStore wrapping - Proxies only created if uniforms/nodes accessed.
+      // The store is passed so entries staged by creator hooks earlier in this
+      // render pass are visible here too.
+      const wrappedState = createLazyCreatorState(store.getState(), store)
       raw = creatorOrScope(wrappedState)
     }
 
@@ -253,101 +211,55 @@ export function useUniforms<T extends UniformInputRecord = UniformInputRecord>(
   // This ensures useUniforms() and useUniforms('scope') reactively update when store changes
   const storeUniforms = usePrimaryThree((s) => s.uniforms)
 
-  // Subscribe to HMR version for creator modes
-  // This ensures rebuildUniforms() triggers re-creation
-  const hmrVersion = usePrimaryThree((s) => s._hmrVersion)
-
-  // Extracted deps to avoid complex expressions in useMemo dependency array
-  const readerDep = isReader ? storeUniforms : null
-  const creatorDep = isReader ? null : hmrVersion
-
   //* Main Logic ==============================
-  const uniforms = useMemo(() => {
-    // Read-only: Return all uniforms
-    // Uses subscribed storeUniforms for reactivity
-    // ex: const { uDelay, uColor } = useUniforms()
-    if (memoizedInput === undefined) {
-      return storeUniforms as UniformRecord & Record<string, UniformRecord>
-    }
 
-    // Read-only: Return uniforms from specific scope
-    // Uses subscribed storeUniforms for reactivity
-    // ex: const { uTuPower } = useUniforms('player')
-    if (typeof memoizedInput === 'string') {
-      const scopeData = storeUniforms[memoizedInput]
-      if (scopeData && !isUniformNode(scopeData)) return scopeData as UniformRecord
-      return {}
-    }
+  // Creator mode: register the (normalized, deep-compared) definitions through
+  // the shared staged-registration mechanism — new uniforms are created
+  // render-phase but only land on the store in the commit-phase flush. Value
+  // changes on reused uniforms are reconciled in place (GPU-only, no store
+  // write). In reader mode this stages nothing and returns {}.
+  const created = useScopedResource<unknown, UniformNode>({
+    store,
+    kind: 'uniforms',
+    scope: isReader ? undefined : scope,
+    isLeaf: isUniformNode,
+    input: memoizedInput,
+    create: () => {
+      if (isReader) return {}
+      if (typeof memoizedInput !== 'object' || memoizedInput === null) throw new Error('Invalid uniform input')
+      return memoizedInput as Record<string, unknown>
+    },
+    prepare: (name, candidate) => createUniform(name, candidate, scope),
+    reconcile: (existing, candidate) => {
+      const existingVal = existing.value
+      const newVal = vectorize(candidate)
 
-    //* CREATOR MODE ==============================
-    // here we are adding/creating NEW uniforms
-
-    // Get a clean state snapshot of the store
-    const state = store.getState()
-    const set = store.setState
-
-    // Create/update: Process uniform definitions
-    if (typeof memoizedInput !== 'object' || memoizedInput === null) {
-      throw new Error('Invalid uniform input')
-    }
-
-    const created = memoizedInput as UniformRecord
-    const result: Record<string, UniformNode> = {}
-    let hasNewUniforms = false
-
-    // Determine target location (root or scope)
-    let targetRecord: UniformRecord = state.uniforms as UniformRecord
-    if (scope) {
-      if (!state.uniforms[scope]) state.uniforms[scope] = {}
-      targetRecord = state.uniforms[scope] as UniformRecord
-    }
-
-    // Process each uniform definition
-    for (const [name, node] of Object.entries(created)) {
-      if (targetRecord[name]) {
-        // Uniform exists - reuse it but check if value changed
-        result[name] = targetRecord[name]
-        const existingVal = result[name].value
-        const newVal = vectorize(node)
-
-        // Second Phase Efficient equality checking
-        let equals = newVal === existingVal // Fast path: primitives and same references
-        if (!equals && hasEqualsMethod(existingVal) && hasEqualsMethod(newVal)) {
-          // Three.js types: use native .equals() methods
-          if (isThreeVector(existingVal) && isThreeVector(newVal)) {
-            equals = vectorEquals(existingVal, newVal)
-          } else if (isSameThreeType(existingVal, newVal)) {
-            equals = (existingVal as any).equals(newVal)
-          }
+      // Efficient equality checking
+      let equals = newVal === existingVal // Fast path: primitives and same references
+      if (!equals && hasEqualsMethod(existingVal) && hasEqualsMethod(newVal)) {
+        // Three.js types: use native .equals() methods
+        if (isThreeVector(existingVal) && isThreeVector(newVal)) {
+          equals = vectorEquals(existingVal, newVal)
+        } else if (isSameThreeType(existingVal, newVal)) {
+          equals = (existingVal as any).equals(newVal)
         }
-
-        // Only update GPU if value actually changed
-        if (!equals) result[name].value = newVal
-      } else {
-        // New uniform - create it
-        result[name] = createUniform(name, node, scope)
-        hasNewUniforms = true
       }
-    }
 
-    // Only update React state if new uniforms were created
-    // Value changes don't trigger state updates (GPU-only)
-    if (hasNewUniforms) {
-      if (scope) {
-        set((s) => ({
-          uniforms: {
-            ...s.uniforms,
-            [scope]: { ...(s.uniforms[scope] as UniformRecord), ...result },
-          },
-        }))
-      } else {
-        set((s) => ({ uniforms: { ...s.uniforms, ...result } }))
-      }
-    }
+      // Only update GPU if value actually changed
+      if (!equals) existing.value = newVal
+    },
+  })
 
-    return result as UniformRecord
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [store, memoizedInput, scope, readerDep, creatorDep])
+  // Read-only: all uniforms / a specific scope (guard against a uniform stored
+  // under the requested name), reactive via storeUniforms. Creator mode returns
+  // the entries registered above.
+  let uniforms: UniformRecord | (UniformRecord & Record<string, UniformRecord>) = created
+  if (memoizedInput === undefined) {
+    uniforms = storeUniforms as UniformRecord & Record<string, UniformRecord>
+  } else if (typeof memoizedInput === 'string') {
+    const scopeData = storeUniforms[memoizedInput]
+    uniforms = scopeData && !isUniformNode(scopeData) ? (scopeData as UniformRecord) : {}
+  }
 
   // Return uniforms with utils
   return { ...uniforms, removeUniforms, clearUniforms, rebuildUniforms } as UniformsWithUtils<UniformRecord>
@@ -358,28 +270,17 @@ export function useUniforms<T extends UniformInputRecord = UniformInputRecord>(
 
 /**
  * Global rebuildUniforms function for HMR integration.
- * Clears cached uniforms and increments _hmrVersion to trigger re-creation.
+ * Invalidates cached uniforms and increments _hmrVersion to trigger re-creation.
  * Call this when HMR is detected to refresh all uniform creators.
+ *
+ * Resolves to the primary store so shared TSL resources rebuild on the
+ * authoritative store.
  *
  * @param store - The R3F store (from useStore or context)
  * @param scope - Optional scope to rebuild ('root' for root only, string for specific scope, undefined for all)
  */
 export function rebuildAllUniforms(store: ReturnType<typeof useStore>, scope?: string) {
-  // Resolve to the primary store so shared TSL resources rebuild on the authoritative store
-  store = store.getState().primaryStore ?? store
-  store.setState((state) => {
-    let newUniforms: typeof state.uniforms = {}
-    if (scope && scope !== 'root') {
-      const { [scope]: _, ...rest } = state.uniforms
-      newUniforms = rest
-    } else if (scope === 'root') {
-      for (const [key, value] of Object.entries(state.uniforms)) {
-        if (!isUniformNode(value)) newUniforms[key] = value
-      }
-    }
-    // else: stays as {} (clear all)
-    return { uniforms: newUniforms, _hmrVersion: state._hmrVersion + 1 }
-  })
+  rebuildResource(store, 'uniforms', scope)
 }
 
 //* Standalone Utils (Deprecated) ==============================

--- a/packages/fiber/tests/hmr.test.ts
+++ b/packages/fiber/tests/hmr.test.ts
@@ -1,31 +1,57 @@
 import { createStore } from '../src/core/store'
 import { clearHmrCaches } from '../src/core/utils/hmr'
+import {
+  RESOURCE_KINDS,
+  ROOT_SCOPE,
+  flushStagedScope,
+  isScopeValid,
+  stageEntries,
+} from '../src/core/utils/resourceRegistry'
+
+const noop = () => {}
+const isLeaf = () => true
 
 describe('clearHmrCaches', () => {
-  // Regression for Bug #4: the HMR handler cleared only nodes/uniforms, leaving
-  // buffers/gpuStorage stale after a hot reload. It must clear all four maps.
-  it('clears all four TSL resource maps and bumps _hmrVersion', () => {
-    const store = createStore(
-      () => {},
-      () => {},
-    )
+  // Regression for Bug #4: the HMR handler invalidated only nodes/uniforms,
+  // leaving buffers/gpuStorage reusable after a hot reload. All four kinds
+  // must go stale. Since the C16 fix that means INVALIDATION, not wiping:
+  // wiping notified readers with empty scopes mid-rebuild and stripped the
+  // material *Node props (see tests/webgpu/hmr-rebuild.test.tsx).
+  it('invalidates all four TSL resource kinds, keeps entries visible to readers, and bumps _hmrVersion', () => {
+    const store = createStore(noop, noop)
 
-    store.setState({
-      nodes: { n: 1 } as any,
-      uniforms: { u: 2 } as any,
-      buffers: { b: 3 } as any,
-      gpuStorage: { g: 4 } as any,
-    })
-
+    // Register one committed entry per kind through the real staged flush path
+    for (const kind of RESOURCE_KINDS) {
+      stageEntries(store, kind, ROOT_SCOPE, { entry: kind })
+      flushStagedScope(store, kind, ROOT_SCOPE, isLeaf)
+      expect(isScopeValid(store, kind, ROOT_SCOPE)).toBe(true)
+    }
     const before = store.getState()._hmrVersion
 
     clearHmrCaches(store)
 
     const state = store.getState()
-    expect(state.nodes).toEqual({})
-    expect(state.uniforms).toEqual({})
-    expect(state.buffers).toEqual({})
-    expect(state.gpuStorage).toEqual({})
+    for (const kind of RESOURCE_KINDS) {
+      // Stale for creators: nothing committed may be reused into the new generation…
+      expect(isScopeValid(store, kind, ROOT_SCOPE)).toBe(false)
+      // …but still visible to readers until the rebuilt generation lands atomically
+      expect((state[kind] as Record<string, unknown>).entry).toBe(kind)
+    }
     expect(state._hmrVersion).toBe(before + 1)
+  })
+
+  it('resolves primaryStore so a secondary canvas invalidates the shared store', () => {
+    const primary = createStore(noop, noop)
+    const secondary = createStore(noop, noop)
+    secondary.setState({ primaryStore: primary })
+
+    stageEntries(primary, 'nodes', ROOT_SCOPE, { n: 1 })
+    flushStagedScope(primary, 'nodes', ROOT_SCOPE, isLeaf)
+    const before = primary.getState()._hmrVersion
+
+    clearHmrCaches(secondary)
+
+    expect(isScopeValid(primary, 'nodes', ROOT_SCOPE)).toBe(false)
+    expect(primary.getState()._hmrVersion).toBe(before + 1)
   })
 })

--- a/packages/fiber/tests/webgpu/hmr-rebuild.test.tsx
+++ b/packages/fiber/tests/webgpu/hmr-rebuild.test.tsx
@@ -1,0 +1,283 @@
+/**
+ * @fileoverview HMR rebuild correctness for the TSL resource hooks (C16).
+ *
+ * Browser validation C16 found that Vite hot updates corrupt TSL state: the
+ * rebuilt scene reuses stale scoped nodes and React reports setState-during-
+ * render from the creator hooks. Full audit ("the plan" below):
+ * https://app.notion.com/p/3aa0baf6021681829f5ddb5129d40430
+ *
+ * These tests pin the INTENDED semantics (plan §5) and are written red-first
+ * against the defects (plan §3):
+ *   D1 — creator hooks must not write to the store during render
+ *   D2 — `useUniforms` must not mutate store state in place
+ *   D3 — cache reuse must not resurrect entries from a previous generation
+ *
+ * "HMR" here is simulated exactly as the Canvas listener performs it
+ * (`core/Canvas.tsx`): `clearHmrCaches(store)` — wipe all four maps and bump
+ * `_hmrVersion`. jsdom cannot run Vite, but the store transition is identical,
+ * so everything except the vite event plumbing is covered at this tier.
+ * The browser protocol in plan §6 covers the rest.
+ */
+import * as React from 'react'
+import { act } from 'react'
+import { render } from '@testing-library/react'
+import { color, float } from 'three/tsl'
+import { createStore, context } from '../../src/core/store'
+import { clearHmrCaches } from '../../src/core/utils/hmr'
+import { useNodes, useUniforms } from '../../src/webgpu'
+import type { RootStore } from '../../src'
+
+const noop = () => {}
+const makeStore = () => createStore(noop, noop)
+
+/** Render `children` with `useStore()` resolving to the given store. */
+function withStore(store: RootStore, children: React.ReactNode) {
+  return render(<context.Provider value={store}>{children}</context.Provider>)
+}
+
+/**
+ * A creator component + a separately-mounted reader component, the shape that
+ * broke in the browser (RagingSea's `Experience` + `SeaSurface`). The reader
+ * records every value it COMMITS (post-render effect), not just renders —
+ * intermediate renders React throws away are legal; committed corruption is not.
+ */
+function makeCreatorReaderPair(scope: string) {
+  const committed: Array<Record<string, unknown>> = []
+
+  function Creator({ make }: { make: () => Record<string, any> }) {
+    useNodes(make, scope)
+    return null
+  }
+
+  function Reader() {
+    const nodes = useNodes(scope)
+    // Strip the attached utils so assertions see only the node entries
+    const { removeNodes, clearNodes, rebuildNodes, ...entries } = nodes
+    React.useEffect(() => {
+      committed.push(entries)
+    })
+    return null
+  }
+
+  return { Creator, Reader, committed }
+}
+
+let errorSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(noop)
+})
+
+afterEach(() => {
+  errorSpy.mockRestore()
+})
+
+/** React logs cross-component render-phase setState through console.error. */
+function renderPhaseViolations() {
+  return errorSpy.mock.calls.filter((args) => String(args[0]).includes('Cannot update a component'))
+}
+
+describe('TSL HMR rebuild (C16) — creator + mounted reader', () => {
+  it('T1: never triggers setState-during-render, on mount or across a simulated hot update', async () => {
+    const store = makeStore()
+    const { Creator, Reader } = makeCreatorReaderPair('sea')
+    const make = () => ({ tint: color('#ff0a81') })
+
+    // Reader first, creator second — the order that guarantees a subscribed
+    // reader exists while the creator's registration runs (RagingSea's shape).
+    await act(async () => {
+      withStore(
+        store,
+        <>
+          <Reader />
+          <Creator make={make} />
+        </>,
+      )
+    })
+
+    await act(async () => clearHmrCaches(store))
+
+    expect(renderPhaseViolations()).toEqual([])
+  })
+
+  it('T2: a committed reader value is never empty once the scope has been populated (atomic rebuild)', async () => {
+    const store = makeStore()
+    const { Creator, Reader, committed } = makeCreatorReaderPair('sea')
+    const make = () => ({ tint: color('#ff0a81') })
+
+    await act(async () => {
+      withStore(
+        store,
+        <>
+          <Reader />
+          <Creator make={make} />
+        </>,
+      )
+    })
+
+    await act(async () => clearHmrCaches(store))
+
+    // The reader must land on the rebuilt generation…
+    const final = committed.at(-1)!
+    expect(Object.keys(final)).toEqual(['tint'])
+    // …and once populated, no later COMMIT may observe the scope empty.
+    // (old-complete → new-complete is the only legal transition, plan §5.3)
+    const firstPopulated = committed.findIndex((c) => Object.keys(c).length > 0)
+    const emptyAfterPopulated = committed.slice(firstPopulated).filter((c) => Object.keys(c).length === 0)
+    expect(emptyAfterPopulated).toEqual([])
+  })
+
+  it('T3: after a hot update, nodes are rebuilt against the SAME generation of uniforms (no stale capture)', async () => {
+    const store = makeStore()
+
+    // RagingSea's dependency shape: a uniform creator plus a node creator that
+    // derives from the uniform via the CreatorState proxy.
+    function Experience() {
+      useUniforms({ uEmissive: color('#ff0a81') }, 'sea')
+      useNodes(({ uniforms }) => ({ emissive: (uniforms as any).sea.uEmissive }), 'sea')
+      return null
+    }
+    let seen: Record<string, any> = {}
+    function Surface() {
+      seen = useNodes('sea')
+      return null
+    }
+
+    await act(async () => {
+      withStore(
+        store,
+        <>
+          <Surface />
+          <Experience />
+        </>,
+      )
+    })
+
+    await act(async () => clearHmrCaches(store))
+
+    // The node the reader received must BE the uniform currently in the store —
+    // not a captured reference to the wiped generation (plan H2/D3).
+    const current = (store.getState().uniforms.sea as any).uEmissive
+    expect(current).toBeDefined()
+    expect(seen.emissive).toBe(current)
+  })
+
+  it('T4: scoped uniform creation does not mutate a previous state snapshot in place', async () => {
+    const store = makeStore()
+    const before = store.getState().uniforms
+
+    function Comp() {
+      useUniforms({ uHealth: float(100) }, 'player')
+      return null
+    }
+    await act(async () => withStore(store, <Comp />))
+
+    // The pre-mount uniforms object must be untouched: new scopes arrive via
+    // an immutable state transition, never by writing into the old object (D2).
+    expect(Object.keys(before)).toEqual([])
+    expect(store.getState().uniforms).not.toBe(before)
+    expect((store.getState().uniforms.player as any).uHealth).toBeDefined()
+  })
+
+  it('T5: StrictMode double-render registers one generation, no duplicates and no violations', async () => {
+    const store = makeStore()
+    const { Creator, Reader } = makeCreatorReaderPair('fx')
+    const make = () => ({ pulse: float(1) })
+
+    await act(async () => {
+      withStore(
+        store,
+        <React.StrictMode>
+          <Reader />
+          <Creator make={make} />
+        </React.StrictMode>,
+      )
+    })
+
+    const scope = store.getState().nodes.fx as Record<string, unknown>
+    expect(Object.keys(scope)).toEqual(['pulse'])
+    expect(renderPhaseViolations()).toEqual([])
+  })
+
+  it('T6: with a shared primaryStore, a hot update on the primary rebuilds atomically for the secondary reader', async () => {
+    const primary = makeStore()
+    const secondary = makeStore()
+    secondary.setState({ primaryStore: primary })
+
+    // Creator lives on the primary canvas, reader on the secondary (A6 shape).
+    function Creator() {
+      useNodes(() => ({ shared: float(42) }), 'sea')
+      return null
+    }
+    let seen: Record<string, any> = {}
+    function Reader() {
+      seen = useNodes('sea')
+      return null
+    }
+
+    await act(async () => {
+      withStore(secondary, <Reader />)
+      withStore(primary, <Creator />)
+    })
+    expect(seen.shared).toBeDefined()
+
+    await act(async () => clearHmrCaches(primary))
+
+    // Secondary's reader must see the primary's rebuilt generation.
+    expect(seen.shared).toBe((primary.getState().nodes.sea as any).shared)
+    expect(renderPhaseViolations()).toEqual([])
+  })
+
+  it('T7: rebuildNodes(scope) re-creates only that scope, leaving others untouched (existing semantics)', async () => {
+    const store = makeStore()
+    let utils!: ReturnType<typeof useNodes>
+
+    function Comp() {
+      useNodes(() => ({ a: float(1) }), 'alpha')
+      utils = useNodes(() => ({ b: float(2) }), 'beta')
+      return null
+    }
+    await act(async () => withStore(store, <Comp />))
+
+    const alphaBefore = store.getState().nodes.alpha
+    const betaBefore = store.getState().nodes.beta
+
+    await act(async () => utils.rebuildNodes('beta'))
+
+    expect(store.getState().nodes.alpha).toBe(alphaBefore)
+    expect(store.getState().nodes.beta).toBeDefined()
+    expect(store.getState().nodes.beta).not.toBe(betaBefore)
+  })
+
+  it('T8: when the creator function itself changes across a hot update, the new creator wins', async () => {
+    const store = makeStore()
+    const { Creator, Reader } = makeCreatorReaderPair('sea')
+
+    const oldTint = color('#ff0a81')
+    const newTint = color('#00d5ff')
+
+    const { rerender } = withStore(
+      store,
+      <>
+        <Reader />
+        <Creator make={() => ({ tint: oldTint })} />
+      </>,
+    )
+    await act(async () => {})
+    expect((store.getState().nodes.sea as any).tint).toBe(oldTint)
+
+    // A hot update swaps the module: new creator closure + cache wipe. The
+    // edited creator's output must replace the cached entry (C16's trigger).
+    await act(async () => {
+      clearHmrCaches(store)
+      rerender(
+        <context.Provider value={store}>
+          <Reader />
+          <Creator make={() => ({ tint: newTint })} />
+        </context.Provider>,
+      )
+    })
+
+    expect((store.getState().nodes.sea as any).tint).toBe(newTint)
+  })
+})

--- a/packages/fiber/tests/webgpu/hmr-rebuild.test.tsx
+++ b/packages/fiber/tests/webgpu/hmr-rebuild.test.tsx
@@ -74,7 +74,7 @@ afterEach(() => {
 
 /** React logs cross-component render-phase setState through console.error. */
 function renderPhaseViolations() {
-  return errorSpy.mock.calls.filter((args) => String(args[0]).includes('Cannot update a component'))
+  return errorSpy.mock.calls.filter((args: unknown[]) => String(args[0]).includes('Cannot update a component'))
 }
 
 describe('TSL HMR rebuild (C16) — creator + mounted reader', () => {


### PR DESCRIPTION
Closes #3792.

TSL hot reloads corrupted shared resource state: React "Cannot update a component while rendering" on every hot update, stale colors and lost lighting after the first edit, black scene after the second. Full audit and fix plan: [TSL HMR — Audit & Fix Plan](https://app.notion.com/p/3aa0baf6021681829f5ddb5129d40430).

## Root causes

- **D1** — all five resource hooks (`useNodes`/`useUniforms`/`useBuffers`/`useGPUStorage`/`useUniform`) called `store.setState` from inside render-phase `useMemo`, notifying mounted readers mid-render.
- **D2** — `useUniforms` mutated `state.uniforms[scope]` in place.
- **D3** — create-if-not-exists reuse was generation-blind, so creator re-runs could resurrect entries from a wiped generation.
- The HMR wipe itself notified readers with empty scopes before creators re-ran; the reconciler then removed the material's `*Node` props (the black scene).

## Fix — one shared registration mechanism

- `core/utils/resourceRegistry.ts`: per-store staging + per-scope validity. Fresh entries are staged during render (registry only — no store write) and flushed in a commit-phase effect, one immutable `setState` per scope. Readers observe a single old-complete → new-complete transition.
- `webgpu/hooks/useScopedResource.ts`: internal hook all five resource hooks delegate to. Committed entries are only reusable while their scope is valid; HMR/`rebuild*` invalidate + bump `_hmrVersion` instead of wiping.
- `CreatorState` overlays staged entries so a creator sees resources a sibling hook created earlier in the same render pass.
- Public APIs, overloads, and returned utils unchanged. Net −407 lines in the hooks.

## Verification

- Red-first baseline (0584b534, in-history): T1/T2/T4 red on the old code, all 8 green after the fix **without altering any test's intent** (sole diff: a type annotation for strict typecheck) — the issue's acceptance criteria.
- Full suite green: 36 files / 483 tests, `pnpm run ci`, `verify-bundles`.
- Browser (real Vite + Chrome WebGPU): zero React errors across hot updates; post-HMR store/material state verified current-generation; maintainer-verified three consecutive HMR edits on RagingSea rendering correctly.
- `tests/hmr.test.ts` re-pinned: its old assertions pinned the physical wipe, which is the defect mechanism; the Bug #4 intent (all four kinds go stale + version bump) is preserved and extended with no-wipe + primaryStore-resolution guarantees.

Also included:
- `fix(example)`: RagingSea's `TerrainGeometry` rotated its geometry in an unguarded effect — Fast Refresh re-runs effects, so each hot update added −90° until the sea was backface-culled (an independent co-factor in C16's symptom).
- `docs(webgpu)`: the TSL HMR page now documents the atomic rebuild guarantees, the two user-facing consequences (removed creators leave last-good data; captured references go stale), and the effect-idempotency gotcha.

Note: stacked on #3790 (shares its scheduler-test commit); merging that first collapses this PR to the four HMR commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)