### PR TITLE
fix: preserve instance children during keyed reorders

### DIFF
--- a/packages/fiber/src/core/reconciler.tsx
+++ b/packages/fiber/src/core/reconciler.tsx
@@ -272,6 +272,8 @@ function appendChild(parent: HostConfig['instance'], child: HostConfig['instance
 
   // Link instances
   child.parent = parent
+  const childIndex = parent.children.indexOf(child)
+  if (childIndex !== -1) parent.children.splice(childIndex, 1)
   parent.children.push(child)
 
   // Attach tree once complete
@@ -287,6 +289,8 @@ function insertBefore(
 
   // Link instances
   child.parent = parent
+  const existingIndex = parent.children.indexOf(child)
+  if (existingIndex !== -1) parent.children.splice(existingIndex, 1)
   const childIndex = parent.children.indexOf(beforeChild)
   if (childIndex !== -1) parent.children.splice(childIndex, 0, child)
   else parent.children.push(child)

--- a/packages/fiber/tests/renderer.test.tsx
+++ b/packages/fiber/tests/renderer.test.tsx
@@ -1,6 +1,16 @@
 import * as React from 'react'
 import * as THREE from 'three'
-import { ReconcilerRoot, createRoot, act, extend, ThreeElement, ThreeElements, flushSync, useThree } from '../src/index'
+import {
+  ReconcilerRoot,
+  createRoot,
+  act,
+  extend,
+  ThreeElement,
+  ThreeElements,
+  flushSync,
+  useThree,
+  type Instance,
+} from '../src/index'
 import { suspend } from 'suspend-react'
 
 extend(THREE as any)
@@ -506,6 +516,30 @@ describe('renderer', () => {
     const mixedArray = [b, a, d, c]
     await act(async () => root.render(<Test array={mixedArray} />))
     expect(scene.children.map((o) => o.name)).toStrictEqual(mixedArray.map((o) => o.name))
+  })
+
+  it('keeps instance children unique when keyed children are reordered', async () => {
+    const Test = ({ names }: { names: string[] }) => (
+      <group>
+        {names.map((name) => (
+          <mesh key={name} name={name} />
+        ))}
+      </group>
+    )
+
+    const store = await act(async () => root.render(<Test names={['A', 'B', 'C']} />))
+    const group = store.getState().scene.children[0] as Instance<THREE.Group>['object']
+    const instance = group.__r3f!
+    const children = () => instance.children.map((child) => child.object.name)
+
+    expect(children()).toStrictEqual(['A', 'B', 'C'])
+
+    await act(async () => root.render(<Test names={['B', 'A', 'C']} />))
+    expect(children()).toStrictEqual(['B', 'A', 'C'])
+
+    await act(async () => root.render(<Test names={['B', 'C', 'A']} />))
+    expect(children()).toStrictEqual(['B', 'C', 'A'])
+    expect(new Set(instance.children).size).toBe(3)
   })
 
   // https://github.com/pmndrs/react-three-fiber/issues/3125


### PR DESCRIPTION
## Summary

- remove an existing host instance from its previous position before appending or inserting it during keyed moves
- keep internal `Instance.children` ordering aligned with the Three.js scene graph without stale duplicates
- add regression coverage for both insert-before and append-to-end reorder paths

## Testing

- `yarn test --runInBand --no-watchman`
- `yarn typecheck`
- `yarn eslint`
- `yarn prettier --check packages/fiber/src/core/reconciler.tsx packages/fiber/tests/renderer.test.tsx`
- `yarn build`
- `yarn validate`

Fixes #3804