### PR TITLE
ci(docs): unblock the link check — repoint cc0textures, stop timeouts counting as rot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,12 @@ jobs:
       # 404 and 400, both still caught). The opencollective badge SVGs are
       # generated on demand and 500 under load -- the page links they wrap are
       # still checked.
+      #
+      # Timeouts count as failures, so a live-but-slow third-party host reds out
+      # every unrelated PR that happens to touch docs. `fail: true` is still what
+      # we want for real rot, so instead of accepting timeouts we give a slow host
+      # room to answer: lychee's 20s default is tight for asset sites that render
+      # a preview per request. Retries cover the single-packet-loss case.
       - name: Link check
         uses: lycheeverse/lychee-action@v2
         with:
@@ -131,6 +137,8 @@ jobs:
             --exclude 'docs\.pmnd\.rs'
             --exclude 'opencollective\.com/.*\.svg'
             --accept '200,206,403,429'
+            --timeout 30
+            --max-retries 3
             'docs/**/*.md'
             'docs/**/*.mdx'
             'packages/*/src/**/[Rr][Ee][Aa][Dd][Mm][Ee].md'

--- a/docs/tutorials/loading-textures.mdx
+++ b/docs/tutorials/loading-textures.mdx
@@ -4,13 +4,13 @@ description: Let's load some fancy textures.
 nav: 28
 ---
 
-> All textures used in this chapter were downloaded from [cc0textures](https://cc0textures.com/).
+> All textures used in this chapter were downloaded from [ambientCG](https://ambientcg.com/) (formerly cc0textures).
 
 ## Using `TextureLoader` and `useLoader`
 
 To load the textures we will use the `TextureLoader` from three.js in combination with `useLoader` that will allow us to pass the location of the texture and get the map back.
 
-It's better to explain with code, let's say you downloaded [this texture](https://cc0textures.com/view?id=PavingStones092) and placed it in the public folder of your site, to get the color map from it you could do:
+It's better to explain with code, let's say you downloaded [this texture](https://ambientcg.com/view?id=PavingStones092) and placed it in the public folder of your site, to get the color map from it you could do:
 
 ```js
 const colorMap = useLoader(TextureLoader, 'PavingStones092_1K_Color.jpg')


### PR DESCRIPTION
## What

The **Docs link check** has been failing on PRs that touch docs while reporting **0 errors**. The two entries under it were *timeouts*, both `cc0textures.com`:

```
| ✅ Successful  | 135   |
| ⏳ Timeouts    | 2     |
| 🚫 Errors      | 0     |
```

Timeouts count as failures under `fail: true`, so one slow third-party host reds out any docs-touching PR. This is currently blocking #3791 (the alpha.3 changelog corrections) for a reason that has nothing to do with #3791.

## Why two changes

The flake has two halves, and only fixing one leaves the other.

**The links were genuinely stale.** cc0textures rebranded to **ambientCG** years ago. The old host still answers, slowly and unreliably from GitHub runners. Both replacements verified `200`:

- `https://ambientcg.com/` → 200
- `https://ambientcg.com/view?id=PavingStones092` → 200

The prose keeps the former name — *"[ambientCG](https://ambientcg.com/) (formerly cc0textures)"* — so a reader following an older copy of the tutorial still recognises the source.

**And the check was too strict about slowness.** Added `--timeout 30 --max-retries 3`. The deliberate choice here is *not* to `--accept` timeouts: `fail: true` is what we want for real rot, and accepting timeouts would go blind to it. Instead we give a live-but-slow host room to answer. lychee's 20s default is tight for asset sites that render a preview per request, and retries cover single-packet-loss.

## Scope

Two files. No source, no tests, no behaviour change.

- `docs/tutorials/loading-textures.mdx` — the two links
- `.github/workflows/test.yml` — timeout/retries, plus a comment explaining why timeouts aren't simply accepted

Unblocks the Docs link check on #3791.

🤖 Generated with [Claude Code](https://claude.com/claude-code)