### PR TITLE
fix: internal instance children synchronization after keyed reorder

### DIFF
--- a/packages/fiber/src/core/reconciler.tsx
+++ b/packages/fiber/src/core/reconciler.tsx
@@ -270,6 +270,12 @@ function handleContainerEffects(parent: Instance, child: Instance, beforeChild?:
 function appendChild(parent: HostConfig['instance'], child: HostConfig['instance'] | HostConfig['textInstance']) {
   if (!child) return
 
+  // Move an existing child instead of duplicating it
+  if (child.parent === parent) {
+    const childIndex = parent.children.indexOf(child)
+    if (childIndex !== -1) parent.children.splice(childIndex, 1)
+  }
+
   // Link instances
   child.parent = parent
   parent.children.push(child)
@@ -284,6 +290,12 @@ function insertBefore(
   beforeChild: HostConfig['instance'] | HostConfig['textInstance'],
 ) {
   if (!child || !beforeChild) return
+
+  // Move an existing child instead of duplicating it.
+  if (child.parent === parent) {
+    const childIndex = parent.children.indexOf(child)
+    if (childIndex !== -1) parent.children.splice(childIndex, 1)
+  }
 
   // Link instances
   child.parent = parent

--- a/packages/fiber/tests/renderer.test.tsx
+++ b/packages/fiber/tests/renderer.test.tsx
@@ -840,6 +840,21 @@ describe('renderer', () => {
     expect(finalUniqueNames.size).toBe(scene.children.length)
   })
 
+  it('should keep instance children synchronized after a keyed reorder', async () => {
+    const children = (order: string[]) => order.map((name) => <group key={name} name={name} />)
+
+    const store = await act(async () => root.render(children(['a', 'b'])))
+    const { scene } = store.getState()
+
+    await act(async () => root.render(children(['b', 'a'])))
+
+    const objectOrder = scene.children.map((child) => child.name)
+    const instanceOrder = (scene as any).__r3f.children.map((child: any) => child.object.name)
+
+    expect(objectOrder).toEqual(['b', 'a'])
+    expect(instanceOrder).toEqual(objectOrder)
+  })
+
   it('should update scene synchronously with flushSync', async () => {
     let updateSynchronously: (value: number) => void
 


### PR DESCRIPTION
R3F's internal children instances were not being synchronized React's own child moves.