### PR TITLE
fix: Pierced prop reset

### DIFF
--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -376,13 +376,14 @@ export function diffProps<T = any>(instance: Instance<T>, newProps: Instance<T>[
     // has no means to do this. Hence we curate a small collection of value-classes
     // with their respective constructor/set arguments
     // For removed props, try to set default values, if possible
+    // NOTE: changes are keyed by the full (pierced) prop so applyProps resolves the same target
     if (root.constructor && root.constructor.length === 0) {
       // create a blank slate of the instance and copy the particular parameter.
       const ctor = getMemoizedPrototype(root)
-      if (!is.und(ctor)) changedProps[key] = ctor[key]
+      if (!is.und(ctor)) changedProps[prop] = ctor[key]
     } else {
       // instance does not have constructor, just set it to 0
-      changedProps[key] = 0
+      changedProps[prop] = 0
     }
   }
 

--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -376,7 +376,6 @@ export function diffProps<T = any>(instance: Instance<T>, newProps: Instance<T>[
     // has no means to do this. Hence we curate a small collection of value-classes
     // with their respective constructor/set arguments
     // For removed props, try to set default values, if possible
-    // NOTE: changes are keyed by the full (pierced) prop so applyProps resolves the same target
     if (root.constructor && root.constructor.length === 0) {
       // create a blank slate of the instance and copy the particular parameter.
       const ctor = getMemoizedPrototype(root)

--- a/packages/fiber/tests/renderer.test.tsx
+++ b/packages/fiber/tests/renderer.test.tsx
@@ -880,4 +880,25 @@ describe('renderer', () => {
     await act(async () => root.render(<TestComponent />))
     await act(async () => updateSynchronously(1))
   })
+
+  it('should reset removed pierced props on the pierced target', async () => {
+    const ref = React.createRef<THREE.Mesh>()
+
+    function Test(props: any) {
+      return (
+        <mesh ref={ref} {...props}>
+          <boxGeometry />
+          <meshBasicMaterial />
+        </mesh>
+      )
+    }
+
+    await act(async () => root.render(<Test position-x={5} />))
+    expect(ref.current!.position.x).toBe(5)
+
+    await act(async () => root.render(<Test />))
+    expect(ref.current!.position.x).toBe(0)
+    // The reset must not leak a stray leaf-key property onto the object root
+    expect((ref.current as any).x).toBeUndefined()
+  })
 })


### PR DESCRIPTION
We had a bug where if a pierce prop was unset, the reconciler would try to reset it to a default value. However, it would set it to the base object instead of the pierced prop.

```js
// Initial render
<mesh position-x={5} />

// Later render: prop removed
<mesh />

// bug: would set it to the base object
mesh.x = 0 // !!!
```

This is now fixed and properly sets `mesh.position.x`.