### PR TITLE
fix: Internal instance props sync

### DIFF
--- a/packages/fiber/src/core/reconciler.tsx
+++ b/packages/fiber/src/core/reconciler.tsx
@@ -17,6 +17,7 @@ import {
   prepare,
   isObject3D,
   findInitialRoot,
+  getInstanceProps,
   IsAllOptional,
 } from './utils'
 import type { RootStore } from './store'
@@ -536,14 +537,21 @@ export const reconciler = /* @__PURE__ */ createReconciler<
 
     // Reconstruct when args or <primitive object={...} have changes
     if (reconstruct) {
-      reconstructed.push([instance, { ...newProps }, fiber])
+      reconstructed.push([instance, getInstanceProps(newProps), fiber])
     } else {
       // Create a diff-set, flag if there are any changes
       const changedProps = diffProps(instance, newProps)
-      if (Object.keys(changedProps).length) {
-        Object.assign(instance.props, changedProps)
-        applyProps(instance.object, changedProps)
-      }
+
+      // Sync props with the committed ones so removed props aren't diffed again
+      // and instance-level props like onUpdate and dispose stay current.
+      // attach is fixed at its mount-time (possibly inferred) value since the
+      // instance is attached with it; changing attach requires a remount via key
+      const attach = instance.props.attach
+      instance.props = getInstanceProps(newProps)
+      if (attach !== undefined) instance.props.attach = attach
+      else delete instance.props.attach
+
+      if (Object.keys(changedProps).length) applyProps(instance.object, changedProps)
     }
 
     // Flush reconstructed siblings when we hit the last updated child in a sequence

--- a/packages/fiber/src/core/reconciler.tsx
+++ b/packages/fiber/src/core/reconciler.tsx
@@ -542,10 +542,8 @@ export const reconciler = /* @__PURE__ */ createReconciler<
       // Create a diff-set, flag if there are any changes
       const changedProps = diffProps(instance, newProps)
 
-      // Sync props with the committed ones so removed props aren't diffed again
-      // and instance-level props like onUpdate and dispose stay current.
-      // attach is fixed at its mount-time (possibly inferred) value since the
-      // instance is attached with it; changing attach requires a remount via key
+      // Replace the old prop snapshot after computing the diff
+      //`attach` is preserved since it cannot be updated dynamically
       const attach = instance.props.attach
       instance.props = getInstanceProps(newProps)
       if (attach !== undefined) instance.props.attach = attach

--- a/packages/fiber/tests/renderer.test.tsx
+++ b/packages/fiber/tests/renderer.test.tsx
@@ -901,4 +901,59 @@ describe('renderer', () => {
     // The reset must not leak a stray leaf-key property onto the object root
     expect((ref.current as any).x).toBeUndefined()
   })
+
+  it('should not re-apply removed prop defaults on later unrelated updates', async () => {
+    const ref = React.createRef<THREE.Mesh>()
+
+    function Test(props: any) {
+      return (
+        <mesh ref={ref} {...props}>
+          <boxGeometry />
+          <meshBasicMaterial />
+        </mesh>
+      )
+    }
+
+    await act(async () => root.render(<Test position-x={5} />))
+    await act(async () => root.render(<Test />))
+    expect(ref.current!.position.x).toBe(0)
+
+    // User mutates the object imperatively (e.g. from an animation)
+    ref.current!.position.x = 3
+
+    // An unrelated prop update must not stomp the imperative change
+    await act(async () => root.render(<Test name="updated" />))
+    expect(ref.current!.position.x).toBe(3)
+  })
+
+  it('should keep the onUpdate prop current across updates', async () => {
+    const onUpdate1 = jest.fn()
+    const onUpdate2 = jest.fn()
+
+    await act(async () => root.render(<mesh onUpdate={onUpdate1} />))
+    onUpdate1.mockClear()
+
+    await act(async () => root.render(<mesh onUpdate={onUpdate2} position-x={1} />))
+    expect(onUpdate1).not.toHaveBeenCalled()
+    expect(onUpdate2).toHaveBeenCalled()
+  })
+
+  it('should respect dispose={null} added after mount', async () => {
+    const dispose = jest.fn()
+
+    const Test = (props: any) => (
+      <mesh
+        {...props}
+        ref={(self: any) => {
+          if (self) self.dispose = dispose
+        }}
+      />
+    )
+
+    await act(async () => root.render(<Test />))
+    await act(async () => root.render(<Test dispose={null} />))
+    await act(async () => root.render(null))
+
+    expect(dispose).not.toHaveBeenCalled()
+  })
 })

--- a/packages/fiber/tests/renderer.test.tsx
+++ b/packages/fiber/tests/renderer.test.tsx
@@ -250,6 +250,34 @@ describe('renderer', () => {
     expect(lifecycle).toStrictEqual(['attach', 'mount'])
   })
 
+  it('should keep attach fixed until the instance is remounted', async () => {
+    const ref = React.createRef<THREE.Group>()
+
+    function Test({ attach, childKey }: { attach?: string; childKey: string }) {
+      return (
+        <group>
+          <group key={childKey} ref={ref} attach={attach} />
+        </group>
+      )
+    }
+
+    const store = await act(async () => root.render(<Test childKey="one" attach="userData-one" />))
+    const parent = store.getState().scene.children[0]
+    const child = ref.current
+    expect(parent.userData.one).toBe(child)
+
+    await act(async () => root.render(<Test childKey="one" attach="userData-two" />))
+    expect(parent.userData.one).toBe(child)
+    expect(parent.userData.two).toBeUndefined()
+
+    await act(async () => root.render(<Test childKey="one" />))
+    expect(parent.userData.one).toBe(child)
+
+    await act(async () => root.render(<Test childKey="two" attach="userData-two" />))
+    expect(parent.userData.one).toBeUndefined()
+    expect(parent.userData.two).toBe(ref.current)
+  })
+
   it('should update props reactively', async () => {
     const store = await act(async () => root.render(<group />))
     const { scene } = store.getState()
@@ -900,42 +928,12 @@ describe('renderer', () => {
     expect(ref.current!.position.x).toBe(0)
     // The reset must not leak a stray leaf-key property onto the object root
     expect((ref.current as any).x).toBeUndefined()
-  })
 
-  it('should not re-apply removed prop defaults on later unrelated updates', async () => {
-    const ref = React.createRef<THREE.Mesh>()
-
-    function Test(props: any) {
-      return (
-        <mesh ref={ref} {...props}>
-          <boxGeometry />
-          <meshBasicMaterial />
-        </mesh>
-      )
-    }
-
-    await act(async () => root.render(<Test position-x={5} />))
-    await act(async () => root.render(<Test />))
-    expect(ref.current!.position.x).toBe(0)
-
-    // User mutates the object imperatively (e.g. from an animation)
+    // Imperative updates should not get overwritten by unrelated updates now
     ref.current!.position.x = 3
 
-    // An unrelated prop update must not stomp the imperative change
     await act(async () => root.render(<Test name="updated" />))
     expect(ref.current!.position.x).toBe(3)
-  })
-
-  it('should keep the onUpdate prop current across updates', async () => {
-    const onUpdate1 = jest.fn()
-    const onUpdate2 = jest.fn()
-
-    await act(async () => root.render(<mesh onUpdate={onUpdate1} />))
-    onUpdate1.mockClear()
-
-    await act(async () => root.render(<mesh onUpdate={onUpdate2} position-x={1} />))
-    expect(onUpdate1).not.toHaveBeenCalled()
-    expect(onUpdate2).toHaveBeenCalled()
   })
 
   it('should respect dispose={null} added after mount', async () => {


### PR DESCRIPTION
This fixes a number of bugs that stemmed from `commitUpdate` only updatin by the object prop diff. This skipped instance props like `onUpdate` and `dispose` (causing their values to easily become stale) and also caused edge cases where imperatively updated values could get overwritten unexpectedly.

`attach` behavior was clarified that it fixed on mount and can only be updated by remounting.