### PR TITLE
fix: Batch instance reconstruction hardening

### DIFF
--- a/packages/fiber/src/core/reconciler.tsx
+++ b/packages/fiber/src/core/reconciler.tsx
@@ -389,6 +389,16 @@ function setFiberRef(fiber: Fiber, publicInstance: HostConfig['publicInstance'])
 const reconstructed: [oldInstance: HostConfig['instance'], props: HostConfig['props'], fiber: Fiber][] = []
 
 function swapInstances(): void {
+  if (reconstructed.length === 0) return
+
+  try {
+    swapInstancesImpl()
+  } finally {
+    reconstructed.length = 0
+  }
+}
+
+function swapInstancesImpl(): void {
   // Detach instance
   for (const [instance] of reconstructed) {
     const parent = instance.parent
@@ -456,8 +466,6 @@ function swapInstances(): void {
       invalidateInstance(instance)
     }
   }
-
-  reconstructed.length = 0
 }
 
 // Don't handle text instances, make it no-op
@@ -466,10 +474,6 @@ const handleTextInstance = () => {}
 const NO_CONTEXT: HostConfig['hostContext'] = {}
 
 let currentUpdatePriority: number = NoEventPriority
-
-// https://github.com/facebook/react/blob/main/packages/react-reconciler/src/ReactFiberFlags.js
-const NoFlags = 0
-const Update = 4
 
 export const reconciler = /* @__PURE__ */ createReconciler<
   HostConfig['type'],
@@ -535,7 +539,8 @@ export const reconciler = /* @__PURE__ */ createReconciler<
     // Reconstruct instance if args were changed
     else if (newProps.args?.some((value, index) => value !== oldProps.args?.[index])) reconstruct = true
 
-    // Reconstruct when args or <primitive object={...} have changes
+    // Reconstruct when args or <primitive object={...} have changes.
+    // Instances are swapped at the end of the mutation phase (resetAfterCommit)
     if (reconstruct) {
       reconstructed.push([instance, getInstanceProps(newProps), fiber])
     } else {
@@ -551,17 +556,15 @@ export const reconciler = /* @__PURE__ */ createReconciler<
 
       if (Object.keys(changedProps).length) applyProps(instance.object, changedProps)
     }
-
-    // Flush reconstructed siblings when we hit the last updated child in a sequence
-    const isTailSibling = fiber.sibling === null || (fiber.flags & Update) === NoFlags
-    if (isTailSibling) swapInstances()
   },
   finalizeInitialChildren: () => false,
   commitMount() {},
   getPublicInstance: (instance) => instance?.object!,
   prepareForCommit: () => null,
   preparePortalMount: (container) => prepare(container.getState().scene, container, '', {}),
-  resetAfterCommit: () => {},
+  // Reconstructed instances are swapped once all mutations are committed,
+  // before layout effects run so refs point to the new objects
+  resetAfterCommit: swapInstances,
   shouldSetTextContent: () => false,
   clearContainer: () => false,
   hideInstance,

--- a/packages/fiber/src/core/reconciler.tsx
+++ b/packages/fiber/src/core/reconciler.tsx
@@ -388,17 +388,17 @@ function setFiberRef(fiber: Fiber, publicInstance: HostConfig['publicInstance'])
 
 const reconstructed: [oldInstance: HostConfig['instance'], props: HostConfig['props'], fiber: Fiber][] = []
 
-function swapInstances(): void {
+function flushReconstructedInstances(): void {
   if (reconstructed.length === 0) return
 
   try {
-    swapInstancesImpl()
+    swapReconstructedInstances()
   } finally {
     reconstructed.length = 0
   }
 }
 
-function swapInstancesImpl(): void {
+function swapReconstructedInstances(): void {
   // Detach instance
   for (const [instance] of reconstructed) {
     const parent = instance.parent
@@ -564,7 +564,7 @@ export const reconciler = /* @__PURE__ */ createReconciler<
   preparePortalMount: (container) => prepare(container.getState().scene, container, '', {}),
   // Reconstructed instances are swapped once all mutations are committed,
   // before layout effects run so refs point to the new objects
-  resetAfterCommit: swapInstances,
+  resetAfterCommit: flushReconstructedInstances,
   shouldSetTextContent: () => false,
   clearContainer: () => false,
   hideInstance,

--- a/packages/fiber/tests/renderer.test.tsx
+++ b/packages/fiber/tests/renderer.test.tsx
@@ -955,7 +955,7 @@ describe('renderer', () => {
     expect(dispose).not.toHaveBeenCalled()
   })
 
-  it('should apply args changes when no later fiber in the commit is a tail sibling', async () => {
+  it('should apply args changes when followed by an unchanged memoized sibling', async () => {
     const ref = React.createRef<THREE.Mesh>()
     const Sibling = React.memo(() => <group name="static" />)
 

--- a/packages/fiber/tests/renderer.test.tsx
+++ b/packages/fiber/tests/renderer.test.tsx
@@ -954,4 +954,28 @@ describe('renderer', () => {
 
     expect(dispose).not.toHaveBeenCalled()
   })
+
+  it('should apply args changes when no later fiber in the commit is a tail sibling', async () => {
+    const ref = React.createRef<THREE.Mesh>()
+    const Sibling = React.memo(() => <group name="static" />)
+
+    function Test({ size }: { size: number }) {
+      const material = React.useMemo(() => <meshBasicMaterial />, [])
+      return (
+        <>
+          <mesh ref={ref}>
+            <boxGeometry args={[size, size, size]} />
+            {material}
+          </mesh>
+          <Sibling />
+        </>
+      )
+    }
+
+    await act(async () => root.render(<Test size={1} />))
+    expect((ref.current!.geometry as THREE.BoxGeometry).parameters.width).toBe(1)
+
+    await act(async () => root.render(<Test size={2} />))
+    expect((ref.current!.geometry as THREE.BoxGeometry).parameters.width).toBe(2)
+  })
 })


### PR DESCRIPTION
This one is pretty technical and a test was added to demonstrate the edge case. When args are modified, the underlying instance needs to be reconstructed. If multiple reconstructions occurred in the same commit then an internal mechanism attempted to defer and reconstruct them batched together. However, it was possible for this batching mechanism to fail, for example if a React sibling was memoized and bailed out of commits entirely.

This PR instead uses `resetAfterCommit`, React's explicit end-of-commit hook, to do the batching making it reliable.