### PR TITLE
feat: Support reconciler microtasks

### DIFF
--- a/packages/fiber/src/core/reconciler.tsx
+++ b/packages/fiber/src/core/reconciler.tsx
@@ -28,6 +28,7 @@ import {
   findInitialRoot,
   getInstanceProps,
   IsAllOptional,
+  scheduleMicrotask,
 } from './utils'
 import type { RootStore } from './store'
 import { swapInteractivity, removeInteractivity, type EventHandlers } from './events'
@@ -674,6 +675,9 @@ export const reconciler = /* @__PURE__ */ createReconciler<
   createTextInstance: handleTextInstance,
   hideTextInstance: handleTextInstance,
   unhideTextInstance: handleTextInstance,
+  // Mirrors react-dom, which flushes discrete work in microtasks
+  supportsMicrotasks: true,
+  scheduleMicrotask,
   scheduleTimeout: (typeof setTimeout === 'function' ? setTimeout : undefined) as any,
   cancelTimeout: (typeof clearTimeout === 'function' ? clearTimeout : undefined) as any,
   noTimeout: -1,

--- a/packages/fiber/src/core/reconciler.tsx
+++ b/packages/fiber/src/core/reconciler.tsx
@@ -28,7 +28,6 @@ import {
   findInitialRoot,
   getInstanceProps,
   IsAllOptional,
-  scheduleMicrotask,
 } from './utils'
 import type { RootStore } from './store'
 import { swapInteractivity, removeInteractivity, type EventHandlers } from './events'
@@ -575,6 +574,22 @@ function getEventPriority(type: string): number {
     }
     default:
       return DefaultEventPriority
+  }
+}
+
+function scheduleMicrotask(callback: () => void): void {
+  if (typeof queueMicrotask === 'function') {
+    queueMicrotask(callback)
+  } else if (typeof Promise !== 'undefined') {
+    Promise.resolve()
+      .then(callback)
+      .catch((error: unknown) => {
+        setTimeout(() => {
+          throw error
+        })
+      })
+  } else {
+    setTimeout(callback)
   }
 }
 

--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -16,22 +16,6 @@ export type IsAllOptional<T extends any[]> = T extends [infer First, ...infer Re
     : false
   : true
 
-export function scheduleMicrotask(callback: () => void): void {
-  if (typeof queueMicrotask === 'function') {
-    queueMicrotask(callback)
-  } else if (typeof Promise !== 'undefined') {
-    Promise.resolve()
-      .then(callback)
-      .catch((error: unknown) => {
-        setTimeout(() => {
-          throw error
-        })
-      })
-  } else {
-    setTimeout(callback)
-  }
-}
-
 /**
  * Returns the instance's initial (outmost) root.
  */

--- a/packages/fiber/src/core/utils.tsx
+++ b/packages/fiber/src/core/utils.tsx
@@ -16,6 +16,22 @@ export type IsAllOptional<T extends any[]> = T extends [infer First, ...infer Re
     : false
   : true
 
+export function scheduleMicrotask(callback: () => void): void {
+  if (typeof queueMicrotask === 'function') {
+    queueMicrotask(callback)
+  } else if (typeof Promise !== 'undefined') {
+    Promise.resolve()
+      .then(callback)
+      .catch((error: unknown) => {
+        setTimeout(() => {
+          throw error
+        })
+      })
+  } else {
+    setTimeout(callback)
+  }
+}
+
 /**
  * Returns the instance's initial (outmost) root.
  */


### PR DESCRIPTION
This PR turns on support for microtasks in the reconciler. This gives React some control over deciding to defer events over painting and takes full advantage of the event priorities. 