### PR TITLE
feat: remove act

### DIFF
--- a/docs/API/additional-exports.mdx
+++ b/docs/API/additional-exports.mdx
@@ -18,7 +18,6 @@ nav: 9
 | `createRoot`         | Creates a root that can render three JSX into a canvas         |
 | `events`             | Dom pointer-event system                                       |
 | `applyProps`         | `applyProps(element, props)` sets element properties,          |
-| `act`                | usage with react-testing                                       |
 | `useInstanceHandle`  | Exposes react-internal local state from `instance.__r3f`       |
 | `fromRef`            | Defers a prop until a ref is populated (e.g. `target`)          |
 | `once`               | Marks a method prop to run only on mount                        |

--- a/packages/fiber/src/core/utils/react.tsx
+++ b/packages/fiber/src/core/utils/react.tsx
@@ -6,14 +6,6 @@ import type { Bridge, UnblockProps } from '#types'
 // React-specific hooks, components, and utilities for R3F
 
 /**
- * Safely flush async effects when testing, simulating a legacy root.
- * @deprecated Import from React instead. import { act } from 'react'
- */
-// Reference with computed key to break Webpack static analysis
-// https://github.com/webpack/webpack/issues/14814
-export const act: typeof React.act = React[('act' + '') as 'act']
-
-/**
  * An SSR-friendly useLayoutEffect.
  *
  * React currently throws a warning when using useLayoutEffect on the server.

--- a/packages/fiber/tests/default/__snapshots__/index.test.tsx.snap
+++ b/packages/fiber/tests/default/__snapshots__/index.test.tsx.snap
@@ -59,7 +59,6 @@ exports[`exports > matches public API 1`] = `
   "Vector4",
   "VectorRepresentation",
   "_roots",
-  "act",
   "addAfterEffect",
   "addEffect",
   "addTail",


### PR DESCRIPTION
This PR is partly a conversation. I think we want to just remove all of the dead APIs in v10 so the migration is simple and happens once and we can add deprecation warning to v9. What do you think?