### PR TITLE
chore(tests): don't pin the three version in the canvas snapshot

### DIFF
--- a/packages/fiber/tests/__snapshots__/canvas.test.tsx.snap
+++ b/packages/fiber/tests/__snapshots__/canvas.test.tsx.snap
@@ -11,7 +11,6 @@ exports[`web Canvas > should correctly mount 1`] = `
     >
       <canvas
         class="r3f-canvas"
-        data-engine="three.js r185"
         style="display: block; width: 100%; height: 100%;"
       />
     </div>

--- a/packages/fiber/tests/canvas.test.tsx
+++ b/packages/fiber/tests/canvas.test.tsx
@@ -16,6 +16,12 @@ describe('web Canvas', () => {
       ),
     )
 
+    // three stamps its revision onto the canvas (data-engine="three.js rNNN"); assert its
+    // shape, then strip it so the snapshot doesn't pin a three version (#3802)
+    const canvas = renderer.container.querySelector('canvas')
+    expect(canvas?.getAttribute('data-engine')).toMatch(/^three\.js r\d+$/)
+    canvas?.removeAttribute('data-engine')
+
     expect(renderer.container).toMatchSnapshot()
   })
 


### PR DESCRIPTION
Fixes #3802

**What was broken.** The canvas mount snapshot contained `data-engine="three.js r185"` — three stamps its revision onto the canvas element, so the snapshot fails on every future three bump regardless of whether anything actually broke. It already had to be churned from r181 to r185 in 76c50f01 when the peer floor moved.

**Repro.** Making the assertion version-agnostic and running against the stored snapshot fails on exactly the pinned attribute; nothing else in the snapshot varies with the three version.

**What changed.** The test now asserts `data-engine` matches `/^three\.js r\d+$/` and strips the attribute before `toMatchSnapshot()`; the snapshot was regenerated without it. Assert-then-strip rather than a plain strip so the test still proves three's renderer attached to the canvas — it just no longer cares which revision.

**Why not a snapshot serializer.** Normalizing `data-engine` globally would work, but the repo has no custom serializers today and this is the only snapshot that ever contained the attribute — a DOM-rewriting serializer felt disproportionate for one call site.

**Tests.** Full suite passes (564 tests, 44 files); eslint/prettier/typecheck clean. Unrelated heads-up: `background prop > should parse object form with preset` in this same file is flaky on pristine v10 (~2/10 runs, `Invalid value used as weak map key` in PMREMGenerator via the WebGL mock) — pre-existing, happy to file it separately if useful.

Disclosure: I used Claude to find, reproduce, and draft this change; I've reviewed and can explain every line.
