### PR TITLE
fix(test-renderer): return objects from mock GL object factories

### DIFF
--- a/packages/test-renderer/src/WebGL2RenderingContext.ts
+++ b/packages/test-renderer/src/WebGL2RenderingContext.ts
@@ -722,7 +722,10 @@ export class WebGL2RenderingContext {
     this.drawingBufferHeight = canvas.height
 
     for (const method of functions) {
-      this[method] ??= () => {}
+      // Object factories hand back a fresh object rather than undefined: three keys per-object
+      // render state in WeakMaps (WebGLState.drawBuffers keys on the framebuffer), which throws
+      // on an undefined key the first time a render target is bound.
+      this[method] ??= method.startsWith('create') ? () => ({}) : () => {}
     }
 
     Object.assign(this, enums)

--- a/packages/test-renderer/src/__tests__/RTTR.webgl2.test.ts
+++ b/packages/test-renderer/src/__tests__/RTTR.webgl2.test.ts
@@ -1,0 +1,56 @@
+import * as THREE from 'three'
+
+import { WebGL2RenderingContext } from '../WebGL2RenderingContext'
+
+const objectFactories = [
+  'createBuffer',
+  'createFramebuffer',
+  'createProgram',
+  'createQuery',
+  'createRenderbuffer',
+  'createSampler',
+  'createShader',
+  'createTexture',
+  'createTransformFeedback',
+  'createVertexArray',
+]
+
+describe('WebGL2RenderingContext object factories', () => {
+  const createContext = () => new WebGL2RenderingContext({ width: 1280, height: 800 } as HTMLCanvasElement) as any
+
+  // three tracks per-object render state in WeakMaps — WebGLState.drawBuffers keys on the
+  // framebuffer handed back by createFramebuffer — so a factory returning undefined throws
+  // the first time a render target is bound.
+  it('return values that can key a WeakMap', () => {
+    const gl = createContext()
+
+    for (const factory of objectFactories) {
+      expect(() => new WeakMap().set(gl[factory](), true)).not.toThrow()
+    }
+  })
+
+  it('return a distinct object per call', () => {
+    const gl = createContext()
+
+    expect(gl.createFramebuffer()).not.toBe(gl.createFramebuffer())
+  })
+
+  it('let three render an equirectangular background', () => {
+    const canvas = document.createElement('canvas')
+    canvas.width = 1280
+    canvas.height = 800
+
+    const renderer = new THREE.WebGLRenderer({ canvas })
+    const scene = new THREE.Scene()
+    const camera = new THREE.PerspectiveCamera()
+
+    const texture = new THREE.DataTexture(new Uint8Array([0, 0, 0, 255]), 1, 1)
+    texture.mapping = THREE.EquirectangularReflectionMapping
+    texture.needsUpdate = true
+    scene.background = texture
+
+    // Equirect backgrounds go through PMREMGenerator, which binds a framebuffer-backed
+    // render target — the path that fails when createFramebuffer returns undefined.
+    expect(() => renderer.render(scene, camera)).not.toThrow()
+  })
+})


### PR DESCRIPTION
The mock GL context stubs every function in its list as `() => {}`, so
`createFramebuffer` and the other nine object factories return `undefined`. three
keys per-object render state in WeakMaps, and `WebGLState.drawBuffers` keys on the
framebuffer, so the first framebuffer-backed `setRenderTarget` calls
`currentDrawbuffers.set(undefined, [])` and throws `Invalid value used as weak map
key`. The only place the suite hits that path is the equirect background test,
which reaches it through `PMREMGenerator`, so that test fails intermittently and
nothing else does.

The fix is one line: the `create*` entries return a fresh object instead of
`undefined`. It has to be a new object per call, not a shared one, or framebuffer
state collides across render targets.

One correction to what I wrote in the issue: `--coverage` is not a reliable
trigger. I had it at 10/10 there, but on another machine it was 1/8 with coverage
and 1/7 without, and once the machine was idle it stopped reproducing entirely. So
the added test does not depend on the race. It renders an equirect background
through the mock directly, which forces the PMREM path synchronously. All three
added tests fail before the change and pass after. Full suite is green (45 files,
567 passed).

I left `createVertexArrayOES` on the `getExtension` object alone. Same underlying
problem, different code path, and nothing in the suite reaches it.

Fixes #3820
