### PR TITLE
fix(test-renderer): return real object handles from the mock GL create* calls

### DIFF
--- a/packages/test-renderer/src/WebGL2RenderingContext.ts
+++ b/packages/test-renderer/src/WebGL2RenderingContext.ts
@@ -713,6 +713,27 @@ const extensions: { [key: string]: any } = {
   WEBGL_compressed_texture_etc1: null,
 }
 
+/**
+ * Whether a GL entry point hands back an opaque *handle* rather than a value.
+ *
+ * Real WebGL returns objects here — `WebGLFramebuffer`, `WebGLBuffer`, `WebGLSync` and friends —
+ * and callers legitimately treat them as identities: they compare them, and they use them as map
+ * keys. The blanket `() => {}` stub returns `undefined` for all of them, which silently breaks any
+ * consumer that stores state *per handle*, because every handle is then the same value.
+ *
+ * three r185 does exactly that. `WebGLState.drawBuffers()` caches per-framebuffer draw-buffer state
+ * in a `WeakMap` keyed on the framebuffer, so the first framebuffer-backed `setRenderTarget()`
+ * evaluates `currentDrawbuffers.set(undefined, [])` and throws
+ * `TypeError: Invalid value used as weak map key`. The PMREM/equirect background path is the only
+ * thing in the suite that binds such a target today, which is why it surfaced there first — but the
+ * defect is in the mock, not in that test, and any behavioural coverage of `Environment` /
+ * `useEnvironment` will hit it routinely (see #3820, #3797).
+ *
+ * Matching on the name rather than listing the ten `create*` functions keeps this correct as the
+ * function table grows: the WebGL naming convention is the contract being honoured here.
+ */
+const returnsHandle = (method: string) => method.startsWith('create') || method === 'fenceSync'
+
 export class WebGL2RenderingContext {
   [key: string]: any
 
@@ -722,7 +743,7 @@ export class WebGL2RenderingContext {
     this.drawingBufferHeight = canvas.height
 
     for (const method of functions) {
-      this[method] ??= () => {}
+      this[method] ??= returnsHandle(method) ? () => ({}) : () => {}
     }
 
     Object.assign(this, enums)

--- a/packages/test-renderer/src/__tests__/WebGL2RenderingContext.test.ts
+++ b/packages/test-renderer/src/__tests__/WebGL2RenderingContext.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { WebGL2RenderingContext } from '../WebGL2RenderingContext'
+
+/**
+ * Guards the handle contract described on `returnsHandle` in the mock.
+ *
+ * These assertions look trivial, but the bug they cover was not: every `create*` stub returned
+ * `undefined`, so three r185's `WeakMap`-keyed draw-buffer cache threw
+ * `TypeError: Invalid value used as weak map key` the first time anything bound a
+ * framebuffer-backed render target (#3820). The symptom appeared as a flaky, unrelated-looking
+ * failure in the PMREM background test, so the useful thing to pin here is the *contract* rather
+ * than that one test's outcome.
+ */
+describe('WebGL2RenderingContext mock', () => {
+  const createContext = () => new WebGL2RenderingContext(document.createElement('canvas'))
+
+  const handleFactories = [
+    'createBuffer',
+    'createFramebuffer',
+    'createProgram',
+    'createQuery',
+    'createRenderbuffer',
+    'createSampler',
+    'createShader',
+    'createTexture',
+    'createTransformFeedback',
+    'createVertexArray',
+    'fenceSync',
+  ] as const
+
+  it.each(handleFactories)('%s returns a usable object handle', (method) => {
+    const gl = createContext()
+    const handle = gl[method]()
+
+    expect(handle).toBeTypeOf('object')
+    expect(handle).not.toBeNull()
+  })
+
+  it('hands out a distinct handle per call, so handles work as identities', () => {
+    const gl = createContext()
+
+    // Same call twice must not collapse to one identity -- three tracks state per framebuffer,
+    // and shared handles would silently merge unrelated render targets' state.
+    expect(gl.createFramebuffer()).not.toBe(gl.createFramebuffer())
+  })
+
+  it('produces handles that are valid WeakMap keys (the three r185 constraint)', () => {
+    const gl = createContext()
+    const cache = new WeakMap<object, string[]>()
+
+    // This is the exact operation three's WebGLState.drawBuffers() performs; with the old
+    // `() => {}` stub it threw "Invalid value used as weak map key".
+    expect(() => cache.set(gl.createFramebuffer(), [])).not.toThrow()
+  })
+
+  it('still stubs non-handle entry points as void', () => {
+    const gl = createContext()
+
+    // The handle rule keys off the WebGL naming convention, so a command that merely *contains*
+    // "create" in a later position must not be caught by it.
+    expect(gl.bindFramebuffer()).toBeUndefined()
+    expect(gl.drawBuffers()).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes #3820. Thanks @ShreeBohara — the diagnosis in that issue was correct, and I verified each step rather than taking it on trust.

## The defect

`WebGL2RenderingContext` stubs every entry in its 225-function table with `() => {}`:

```ts
for (const method of functions) {
  this[method] ??= () => {}
}
```

So `createFramebuffer()` and its nine siblings return `undefined`. Real WebGL returns opaque *handles* there — `WebGLFramebuffer`, `WebGLBuffer`, `WebGLSync` — and callers legitimately treat them as identities: they compare them and use them as map keys. Under the old stub every handle was the same value.

three r185 relies on that identity. Confirmed in the installed `three@0.185.1` source:

```js
function drawBuffers( renderTarget, framebuffer ) {
  ...
  drawBuffers = currentDrawbuffers.get( framebuffer );
  if ( drawBuffers === undefined ) {
    drawBuffers = [];
    currentDrawbuffers.set( framebuffer, drawBuffers );   // <-- WeakMap
  }
```

`WeakMap.set(undefined, …)` throws `TypeError: Invalid value used as weak map key`, so the first framebuffer-backed `setRenderTarget()` blows up.

## Why it looked like a flaky background test

The PMREM/equirect background path is the only thing in the suite that binds such a target today, so that is where it surfaced — intermittently, because the crash only fires if a frame actually renders while the stubbed HDR texture is assigned as `scene.background`, and coverage instrumentation changes whether that race is won.

That framing undersells it. **The defect is in the mock, not in that test**, and it blocks work already scoped: behavioural coverage of `Environment.tsx` / `useEnvironment.tsx` (#3797) renders framebuffer-backed targets routinely and would trip over this immediately.

One correction for the record: I could **not** reproduce the flake in 3 coverage runs on this machine — the exit-1 there was the *global* coverage ratchet failing on a single-file run, not the crash. So the race is machine-dependent. The mechanism is not, and it is the mechanism this fixes.

## The fix

Two lines of behaviour, plus the comment explaining the contract:

```ts
const returnsHandle = (method: string) => method.startsWith('create') || method === 'fenceSync'
...
this[method] ??= returnsHandle(method) ? () => ({}) : () => {}
```

Matching on the `create` prefix rather than listing the ten functions keeps this correct as the table grows — the WebGL naming convention *is* the contract being honoured. `fenceSync` is the one handle-returning call that does not follow it.

## Test

The regression test pins the **contract**, not the flaky test's outcome — handles are objects, distinct per call, and valid WeakMap keys (the exact three r185 operation). It also asserts non-handle stubs still return `undefined`, so the prefix rule can't quietly widen.

Verified to fail **13/14 against the previous stub**, so it discriminates.

Full suite green: **578 passed, 0 failed, 6 todo** across 45 files. Coverage unchanged (80.42% lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)