### PR TITLE
fix: keep interaction state continuous across instance reconstruction

### DIFF
--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -61,6 +61,73 @@ function releaseInternalPointerCapture(internal: RootState['internal'], obj: THR
   }
 }
 
+/**
+ * Moves every trace of interactivity from one object to its replacement, for reconstruction.
+ *
+ * When `args` or a `primitive`'s `object` changes, R3F builds a new three object and keeps the same
+ * instance. Removing the old object from the interaction state and registering the new one from
+ * scratch makes events *work* again (#3778), but it forgets what was in flight: a pointer resting on
+ * the object fires a second `onPointerEnter` without ever having left, and an active pointer capture
+ * is dropped mid-drag. Rewriting the references instead keeps the interaction continuous across a
+ * swap the user never asked to see (#3744).
+ *
+ * Captures are re-keyed rather than released, so the DOM-level capture on `captureData.target` is
+ * left alone — releasing and re-acquiring it is precisely the glitch being avoided.
+ *
+ * Visibility handlers are deliberately not transferred: that registry is keyed by `object.uuid`, so
+ * the replacement re-registers itself through `applyProps`. The old entry is dropped here so it
+ * cannot outlive the object it described.
+ */
+export function swapInteractivity(store: RootStore, object: THREE.Object3D, newObject: THREE.Object3D) {
+  const { internal } = store.getState()
+
+  // Replaced in place: an object's position in the interaction list feeds hit ordering, so the
+  // replacement should inherit it rather than being appended at the end.
+  for (let i = 0; i < internal.interaction.length; i++) {
+    if (internal.interaction[i] === object) internal.interaction[i] = newObject
+  }
+
+  for (const pointerState of internal.pointerMap.values()) {
+    for (let i = 0; i < pointerState.initialHits.length; i++) {
+      if (pointerState.initialHits[i] === object) pointerState.initialHits[i] = newObject
+    }
+
+    // Hover entries are keyed by uuid, so a swap needs a new key as well as new references —
+    // rewriting the value alone would strand the entry under the old object's id.
+    pointerState.hovered.forEach((value, key) => {
+      if (value.eventObject === object || value.object === object) {
+        pointerState.hovered.delete(key)
+        const next = {
+          ...value,
+          eventObject: value.eventObject === object ? newObject : value.eventObject,
+          object: value.object === object ? newObject : value.object,
+        }
+        pointerState.hovered.set(makeId(next), next)
+      }
+    })
+
+    // Captures need more than a re-key. The stored `intersection` is replayed into the hit list on
+    // every subsequent event, and it holds its own `object`/`eventObject` references — leave those
+    // pointing at the discarded object and the replay resolves to a corpse whose `__r3f` link has
+    // already been severed, so the drag goes silent even though the capture "survived".
+    const captureData = pointerState.captured.get(object)
+    if (captureData) {
+      pointerState.captured.delete(object)
+      pointerState.captured.set(newObject, {
+        ...captureData,
+        intersection: {
+          ...captureData.intersection,
+          object: captureData.intersection.object === object ? newObject : captureData.intersection.object,
+          eventObject:
+            captureData.intersection.eventObject === object ? newObject : captureData.intersection.eventObject,
+        },
+      })
+    }
+  }
+
+  unregisterVisibility(store, object)
+}
+
 export function removeInteractivity(store: RootStore, object: THREE.Object3D) {
   const { internal } = store.getState()
   // Removes every trace of an object from the data store

--- a/packages/fiber/src/core/reconciler.tsx
+++ b/packages/fiber/src/core/reconciler.tsx
@@ -31,7 +31,7 @@ import {
   isFromRef,
   FROM_REF,
 } from './utils'
-import { removeInteractivity } from './events'
+import { removeInteractivity, swapInteractivity } from './events'
 import type { ThreeElement } from '../../types/three'
 
 //* Type Imports ==============================
@@ -381,9 +381,14 @@ function swapReconstructedInstances(): void {
     // So, we manually check if an instance was hidden and unhide it.
     if (instance.isHidden) unhideInstance(instance)
 
-    // The old object is being discarded. Scrub it from the interaction manager so it isn't
-    // left behind as a dead raycast target (and doesn't leak) after reconstruction (#3778).
-    if (isObject3D(instance.object)) removeInteractivity(findInitialRoot(instance), instance.object)
+    // The old object must not survive in the interaction manager as a dead raycast target (#3778).
+    // How it leaves depends on whether a replacement is coming: the second loop hands its state to
+    // the new object via swapInteractivity, and scrubbing it here would destroy exactly what that
+    // transfer needs. Only orphans — instances with no parent, which the second loop skips — are
+    // removed outright.
+    if (isObject3D(instance.object) && !instance.parent) {
+      removeInteractivity(findInitialRoot(instance), instance.object)
+    }
     // Dispose of old object if able
     if (instance.object.__r3f) delete instance.object.__r3f
     if (instance.type !== 'primitive') disposeOnIdle(instance.object)
@@ -399,9 +404,18 @@ function swapReconstructedInstances(): void {
       const target = catalogue[toPascalCase(instance.type)]
 
       // Create object
+      const prevObject = instance.object
       instance.object = instance.props.object ?? new target(...(instance.props.args ?? []))
       instance.object.__r3f = instance
       setFiberRef(fiber, instance.object)
+
+      // Hand the outgoing object's interaction state to its replacement before anything reads it,
+      // so a hover or an in-flight pointer capture survives the swap rather than being torn down
+      // and rebuilt (#3744). This also retires the old object as a raycast target, which is the
+      // job the first loop skipped for exactly this reason.
+      if (isObject3D(prevObject) && isObject3D(instance.object)) {
+        swapInteractivity(findInitialRoot(instance), prevObject, instance.object)
+      }
 
       // Clear appliedOnce so once() props can be reapplied to the new object
       delete instance.appliedOnce

--- a/packages/fiber/tests/default/__snapshots__/index.test.tsx.snap
+++ b/packages/fiber/tests/default/__snapshots__/index.test.tsx.snap
@@ -109,6 +109,7 @@ exports[`exports > matches public API 1`] = `
   "registerPrimary",
   "removeInteractivity",
   "resolve",
+  "swapInteractivity",
   "unmountComponentAtNode",
   "unregisterPrimary",
   "updateCamera",

--- a/packages/fiber/tests/events.test.tsx
+++ b/packages/fiber/tests/events.test.tsx
@@ -464,6 +464,80 @@ describe('events', () => {
     expect(handleClickRear).not.toHaveBeenCalled()
   })
 
+  describe('interactivity across reconstruction', () => {
+    const geometry = new THREE.BoxGeometry(2, 2)
+
+    function SwapApp({ material, ...handlers }: { material: THREE.Material } & Record<string, unknown>) {
+      return (
+        <Canvas>
+          <mesh args={[geometry, material]} {...handlers} />
+        </Canvas>
+      )
+    }
+
+    it('keeps firing events after an args change reconstructs the instance', async () => {
+      const handleClick = vi.fn()
+      const materialA = new THREE.MeshBasicMaterial()
+      const materialB = new THREE.MeshBasicMaterial()
+
+      let result: RenderResult = null!
+      await act(async () => {
+        result = render(<SwapApp material={materialA} onClick={handleClick} />)
+      })
+      await act(async () => {
+        result.rerender(<SwapApp material={materialB} onClick={handleClick} />)
+      })
+
+      const canvas = getContainer()
+      fireEvent(canvas, createPointerEvent('pointerdown'))
+      fireEvent(canvas, createPointerEvent('pointerup'))
+      fireEvent(canvas, createPointerEvent('click'))
+
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not re-enter a hovered object when the instance is swapped underneath it', async () => {
+      const handlePointerEnter = vi.fn()
+      const handlePointerLeave = vi.fn()
+      const materialA = new THREE.MeshBasicMaterial()
+      const materialB = new THREE.MeshBasicMaterial()
+      const handlers = { onPointerEnter: handlePointerEnter, onPointerLeave: handlePointerLeave }
+
+      let result: RenderResult = null!
+      await act(async () => {
+        result = render(<SwapApp material={materialA} {...handlers} />)
+      })
+
+      const canvas = getContainer()
+      await act(async () => {
+        canvas.dispatchEvent(createPointerEvent('pointermove'))
+      })
+      expect(handlePointerEnter).toHaveBeenCalledTimes(1)
+
+      // The pointer has not moved. Reconstructing the object beneath it is an implementation
+      // detail, and must not surface as the pointer leaving and re-entering. Before
+      // swapInteractivity the hover entry was discarded here, so the next move re-fired enter --
+      // without a matching leave, leaving the pair unbalanced.
+      await act(async () => {
+        result.rerender(<SwapApp material={materialB} {...handlers} />)
+      })
+      await act(async () => {
+        canvas.dispatchEvent(createPointerEvent('pointermove'))
+      })
+
+      expect(handlePointerEnter).toHaveBeenCalledTimes(1)
+      expect(handlePointerLeave).not.toHaveBeenCalled()
+    })
+
+    // KNOWN GAP, deliberately not asserted as passing: an active pointer capture does not survive
+    // reconstruction. swapInteractivity re-keys `pointerState.captured` and rewrites the stored
+    // intersection, and both are verifiably correct at replay time (the captured hit resolves to
+    // the new object with its handlers intact) -- but the deferred pointer-move path never reaches
+    // `onIntersect` afterwards, so a drag in progress goes silent. That is a frame-timed raycast
+    // interaction rather than a state-transfer problem, and it needs its own fix.
+    it.todo('keeps an active pointer capture alive across reconstruction')
+  })
+
   describe('web pointer capture', () => {
     const handlePointerMove = vi.fn()
     const handlePointerDown = vi.fn((ev) => (ev.target as any).setPointerCapture(ev.pointerId))


### PR DESCRIPTION
Ports #3744 to v10 — but only after checking it was actually needed. v10 already has its own fix in this area (#3778), and porting for symmetry would have been wrong.

## The probe came first

Three cases against **clean `v10`**, before writing any fix:

| | | |
|---|---|---|
| **A** | events still fire after an args swap | ✅ **passes** — #3778 works |
| **B** | hover survives the swap | ❌ `onPointerEnter` fires **twice**, pointer never moved |
| **C** | pointer capture survives the swap | ❌ capture **dropped** |

So the two fixes solve different halves. v10 restores *events working*; this restores *what was in flight*. B is the interesting failure: there's no matching `onPointerLeave`, so enter/leave come out **unbalanced** — worse than a symmetric glitch, because a component tracking hover state gets stuck.

## What it does

`swapInteractivity()` rewrites references instead of discarding them:

- interaction-list entries **in place** — position feeds hit ordering, so the replacement inherits it rather than being appended
- per-pointer `initialHits`
- `hovered` entries **re-keyed by uuid** — those are keyed on `object.uuid`, so rewriting the value alone would strand the entry under the old id
- captures re-keyed **without touching the DOM-level capture** on `captureData.target` — releasing and re-acquiring is precisely the glitch being avoided

Visibility handlers are deliberately *not* transferred: that registry is keyed by uuid and `applyProps` re-registers the replacement. The old entry is dropped so it can't outlive its object.

This is a rewrite rather than a copy, because v10 restructured interaction state to be **per-pointer** (`internal.pointerMap`). v9's version references flat `internal.hovered` / `internal.capturedMap`, which no longer exist.

## One structural gotcha

`swapReconstructedInstances` runs two loops. The first scrubbed interactivity from the old object before the second had a replacement to hand it to — destroying exactly what the transfer needs. `removeInteractivity` now runs there only for **orphans** (instances with no parent), which the second loop skips anyway, so #3778's guarantee still holds.

## What is NOT fixed

**C is left as `it.todo`, not asserted as passing.** I want to be precise about why, because the transfer itself is correct: instrumented, the captured hit replays with the new object, `__r3f` intact, `eventCount: 2`. The problem is downstream — the deferred pointer-move path never reaches `onIntersect` afterwards, so a drag in progress goes silent.

That's a frame-timed raycast interaction, not a state-transfer problem, and it deserves its own fix rather than being bundled in here. v9's version doesn't address it either. Happy to file it.

## Note for the API review

`swapInteractivity` lands on the **public surface** — `core/index.tsx` does `export * from './events'`, and `removeInteractivity` is already exported that way. Snapshot updated deliberately. If the intent is to keep reconciler internals private, that's a conversation about the barrel, and it applies to both functions.

Test for B verified to fail against the previous code. Full suite: **566 passed, 0 failed, 7 todo.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)