### PR TITLE
chore(ci): close workflow drift with master, and fix the canary publish set

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -23,7 +23,7 @@ jobs:
           run_install: false
 
       - name: Use Node 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: 'pnpm'
@@ -34,13 +34,27 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Set canary version
+      # Every published package gets a canary, not just fiber -- test-renderer has had a real build
+      # since it gained one, and a canary of fiber alone cannot be integration-tested against it.
+      #
+      # The version is derived per package rather than shared. fiber and test-renderer are both on
+      # the 10.x line, but eslint-plugin is on 1.x: stamping 10.0.0-canary onto it would jump it two
+      # majors ahead of its own line, and npm versions cannot be withdrawn. Reading the major from
+      # each package.json keeps that impossible to get wrong by hand.
+      - name: Set canary versions
         run: |
-          CANARY_VERSION="10.0.0-canary.$(git rev-parse --short HEAD)"
-          echo "Publishing canary version: $CANARY_VERSION"
-          cd packages/fiber && npm version $CANARY_VERSION --no-git-tag-version
+          SHA="$(git rev-parse --short HEAD)"
+          for pkg in fiber test-renderer eslint-plugin; do
+            MAJOR="$(node -p "require('./packages/$pkg/package.json').version.split('.')[0]")"
+            VERSION="$MAJOR.0.0-canary.$SHA"
+            echo "Publishing @react-three/$pkg as $VERSION"
+            (cd "packages/$pkg" && npm version "$VERSION" --no-git-tag-version)
+          done
 
       - name: Publish to npm
-        run: pnpm --filter @react-three/fiber publish --tag canary --no-git-checks --provenance
+        run: |
+          pnpm --filter @react-three/fiber publish --tag canary --no-git-checks --provenance
+          pnpm --filter @react-three/test-renderer publish --tag canary --no-git-checks --provenance
+          pnpm --filter @react-three/eslint-plugin publish --tag canary --no-git-checks --provenance
         env:
           NODE_AUTH_TOKEN: ''

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build:
-    uses: pmndrs/docs/.github/workflows/build.yml@v2
+    uses: pmndrs/docs/.github/workflows/build.yml@v3
     with:
       mdx: 'docs'
       libname: 'React Three Fiber'
@@ -38,4 +38,4 @@ jobs:
 
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -26,7 +26,7 @@ jobs:
           run_install: false
 
       - name: Use Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'pnpm'
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload coverage report
         if: ${{ matrix.react-version == 'latest' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage
           path: coverage/
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Enforce the readme-stub contract: every readme that sits next to source is a
       # thin pointer to the canonical docs, never a second copy of them (the "drift


### PR DESCRIPTION
Three things, all in `.github/workflows`.

## 1. Action pins — kills the deprecation warning on every run

v10 sat on `actions/checkout@v4`, `setup-node@v4` and `upload-artifact@v4`, so every run logged:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4

Bumped to `@v5` — the version master already proved in its own `test.yml`. `docs.yml` moves to `pmndrs/docs/.github/workflows/build.yml@v3` (identical inputs to what master runs) and `deploy-pages@v5`.

`v7` of these actions exists, but matching master's proven set is the lower-risk way to clear the warning. Left `node-version` at 22/24 — master runs 20, and there's no reason for v10 to go backwards.

## 2. Canary published fiber and nothing else

`test-renderer` has had a real build since it gained one, and a canary of fiber alone can't be integration-tested against the matching test-renderer. All three now publish.

## 3. …which surfaced a trap worth flagging

**`eslint-plugin` is on the 1.x line** (`1.0.0-alpha.3`), not 10.x.

Copying master's approach — one shared `CANARY_VERSION` stamped onto every package — would have published it as `10.0.0-canary.<sha>`, jumping it two majors past its own line. **Permanently**: npm versions can't be withdrawn, and its npm `latest` is still `0.1.2`.

So the major is read from each `package.json` instead:

```
fiber          -> 10.0.0-canary.<sha>
test-renderer  -> 10.0.0-canary.<sha>
eslint-plugin  ->  1.0.0-canary.<sha>
```

Verified against the actual manifests, not assumed.

**Heads-up for master:** it has the same latent bug pointing the other way — its shared `CANARY_VERSION` is hardcoded to `10.0.0-canary` while its packages are `9.7.0` / `9.1.1` / `0.1.2`. Worth a separate look; not touching it here.

## Verification

Workflow changes can only really be proven by running, which this PR's own CI does for `test.yml`. `docs.yml` triggers on `push` to `master` only, so it won't run here — the `@v3` bump is safe on the grounds that master runs that exact workflow with these exact inputs today. The canary job runs on push to `v10`, i.e. after merge; the version derivation is the part I could check locally, and did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)