### PR TITLE
docs(changelog): make the alpha.3 record accurate, and give every package one

### DIFF
--- a/CHANGELOG-ALPHA.md
+++ b/CHANGELOG-ALPHA.md
@@ -19,6 +19,18 @@ The `three` peer range moved from `>=0.181.2` to **`>=0.185.0`**. **If you are o
 
 The floor moved because v10 now uses three's own APIs rather than shadowing them: `RenderPipeline` (renamed from `PostProcessing` in r183), `CubeRenderTarget`, and the real `UniformNode` types. Keeping a fallback path for older three meant maintaining a parallel implementation of types three already ships.
 
+#### `act` is no longer re-exported
+
+R3F's `act` was a re-export of React's own, deprecated in favour of importing it directly. It is now
+removed from the public surface.
+
+```diff
+- import { act } from '@react-three/fiber'
++ import { act } from 'react'
+```
+
+It is the same function, so this is an import change and nothing more.
+
 ### Features
 
 #### Interactive Priority (userData.interactivePriority)
@@ -310,6 +322,29 @@ constraints, per-callback fps throttling and the single shared RAF all behave as
 - Fixed `ShaderMaterial` uniforms losing their target reference across prop updates.
 - Added a custom `cacheKey` argument to `useLoader` / `.preload` / `.clear` for assets fetched
   from URLs that change per request.
+- Fixed visibility handlers (`onFramed`/`onOccluded`/`onVisible`) keeping a stale closure. Handler
+  registration sat behind a check comparing the handler _count_, so swapping `onOccluded` for a
+  different function left the count unchanged and the registry kept a snapshot of the old closure.
+  Inline handlers (`onFramed={() => …}`) produce a new function every render, which is the common
+  case — so an updated callback would simply never fire. Registration now runs on every prop update
+  and updates in place, preserving the last-known visibility state instead of re-firing events for
+  transitions that did not happen.
+- **Fixed TSL hot module replacement rebuilding against stale scoped state.** Vite would hot-update
+  a WebGPU scene without a full reload, but the remounted scene reused the previous module's TSL
+  nodes: the first edit lost environment lighting, the second lost the mesh entirely, while a cold
+  reload of the same code was correct. Two causes in `webgpu/hooks/useNodes.tsx` — creator mode
+  called `store.setState` inside `useMemo` during render (producing a React "Cannot update … while
+  rendering" error on every HMR remount), and the creator-mode cache returned the old module's
+  nodes because nothing invoked the existing `rebuildNodes`/`_hmrVersion` bust on the HMR path.
+  Registration is now atomic and generation-aware. Verified live over three consecutive edits on a
+  real GPU.
+- Ported the reconciler hardening released in `@react-three/fiber@9.7.0`: removed pierced props
+  reset on their pierced target rather than the object root; `instance.props` synced wholesale in
+  `commitUpdate` so removed props do not linger, changed reserved props take effect, and imperative
+  mutations are not stomped by re-applied defaults; reconstructed instances flushed in
+  `resetAfterCommit` so `args`/`primitive` changes apply even when the last updated sibling bailed
+  out. Also aligned update scheduling — `resolveUpdatePriority` now mirrors react-dom's
+  `getEventPriority`, and the reconciler uses microtask scheduling.
 
 ### Examples
 
@@ -327,22 +362,17 @@ constraints, per-callback fps throttling and the single shared RAF all behave as
 
 - `@react-three/test-renderer` now has a real build. It previously had no build script and no
   `dist`, while `main`/`module`/`types` all pointed into `dist/` — it would have published broken.
-- Removed dead `Instance.deferredRefs` and `updateVisibilityHandlers`.
+- Removed dead `Instance.deferredRefs`.
 - Renamed the last internal `PostProcessing`/`pp` identifiers to `RenderPipeline`/`pipeline`.
 - Dropped the dangling `heroes` entry from `pnpm-workspace.yaml`.
 - Corrected `pnpm ci` to `pnpm run ci` in CLAUDE.md and docs — pnpm reserves `ci` as a built-in,
   so the documented command always errored instead of running the gate.
 - Stubbed the HDR loader in the background-preset test, which previously made a live network
   request to raw.githack.com and failed offline.
-
-### Files Changed
-
-- `packages/fiber/src/core/utils/fromRef.ts` - **NEW** Deferred ref resolution utility
-- `packages/fiber/src/core/utils/once.ts` - **NEW** Mount-only method call utility
-- `packages/fiber/src/core/utils/props.ts` - Integration of fromRef and once in applyProps
-- `packages/fiber/src/core/renderer.tsx` - Camera scene parenting logic, Portal support
-- `example/src/demos/default/NestedCamera.tsx` - **NEW** Camera headlights demo
-- `docs/v10-features.md` - Camera parenting, Portal, fromRef, once documentation
+- Documentation consolidated into a single canonical home under `docs/`, with stale v9 API
+  references corrected and a CI link check added. Readmes beside source are now thin pointers.
+- The docs link check no longer fails on third-party hosts that are merely slow, and the
+  cc0textures links it kept tripping over now point at ambientCG, which is where that site moved.
 
 ---
 

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @react-three/eslint-plugin
 
+## 1.0.0-alpha.3
+
+### Patch Changes
+
+- No rule changes. Released alongside `@react-three/fiber@10.0.0-alpha.3` to keep the alpha line in
+  step; see [that package's changelog](../fiber/CHANGELOG.md) for what changed, and
+  [`CHANGELOG-ALPHA.md`](../../CHANGELOG-ALPHA.md#1000-alpha3) for full detail.
+
+  Note this package is versioned on its **own 1.x line**, not fiber's 10.x — matching alpha numbers
+  denote the same release train, not the same version.
+
+- Changelog restructured: the alpha.2 entries had been collapsed into a single run-on bullet.
+
 ## 1.0.0-alpha.2
 
 ### Major Changes

--- a/packages/fiber/CHANGELOG.md
+++ b/packages/fiber/CHANGELOG.md
@@ -1,5 +1,44 @@
 # @react-three/fiber
 
+## 10.0.0-alpha.3
+
+Full detail, with migration notes and examples, is in
+[`CHANGELOG-ALPHA.md`](../../CHANGELOG-ALPHA.md#1000-alpha3) at the repo root. This is the summary.
+
+### Breaking Changes
+
+- **`three` peer floor raised to `>=0.185.0`** (from `>=0.181.2`). If you are on r181–r184 you
+  cannot install alpha.3 — upgrade three alongside R3F. v10 now uses three's own `RenderPipeline`,
+  `CubeRenderTarget` and `UniformNode` types rather than shadowing them.
+- **`act` is no longer re-exported.** Import it from React instead — it is the same function.
+
+### Features
+
+- Interactive priority: `userData.interactivePriority` takes precedence over distance-based hit
+  testing, for UI controls that render on top via depth tricks
+- `useBuffers` and `useGPUStorage` for GPU compute (experimental)
+- `useTextures`, a reactive texture registry (experimental)
+- Multi-canvas rendering on WebGPU via `renderer={{ primaryCanvas: 'id' }}`, with shared state
+- Camera scene parenting, so children of the camera render and track it
+- `forceEven` and `background` Canvas props
+- `fromRef` and `once` prop utilities
+- The frame scheduler moved out to `@pmndrs/scheduler`
+
+### Bug Fixes
+
+- Visibility handlers (`onFramed`/`onOccluded`/`onVisible`) no longer keep a stale closure — inline
+  handlers now fire the current callback
+- TSL hot module replacement no longer rebuilds against stale scoped state
+- Multi-canvas TSL state is shared via `primaryStore`
+- Runtime `setFrameloop()` reaches the scheduler
+- `state.frustum` is current when read during the render phase
+- `createPortal` no longer leaks subscriptions; portal `size` survives parent resizes
+- Pointer events survive an `args`-triggered reconstruction
+- `ShaderMaterial` uniforms keep a stable target reference
+- Reconciler hardening from `@react-three/fiber@9.7.0` ported over, including react-dom event
+  priorities and microtask scheduling
+- `useLoader` / `.preload` / `.clear` accept a custom `cacheKey`
+
 ## 10.0.0-alpha.2
 
 ### Features

--- a/packages/test-renderer/CHANGELOG.md
+++ b/packages/test-renderer/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @react-three/test-renderer
 
+## 10.0.0-alpha.3
+
+### Major Changes
+
+- **This package now has a real build.** It previously had no build script and no `dist`, while
+  `main`, `module` and `types` all pointed into `dist/` — it would have published broken. It now
+  builds all three entries (`.`, `/legacy`, `/webgpu`) with a config mirroring `@react-three/fiber`.
+
+  If you were installing alpha.2 or earlier and hitting unresolvable imports, this is why.
+
+### Minor Changes
+
+- `@react-three/test-renderer/webgpu` no longer reaches into fiber's source, which had been leaking
+  the internal `#three` alias into the bundle as unresolvable specifiers and duplicating hooks.
+  Bundle size dropped from ~67 kB to ~44 kB as a result.
+- Export-parity tests added against `@react-three/fiber`.
+
+### Patch Changes
+
+- Tracks `@react-three/fiber@10.0.0-alpha.3`. See
+  [that package's changelog](../fiber/CHANGELOG.md) for the authoritative list, and
+  [`CHANGELOG-ALPHA.md`](../../CHANGELOG-ALPHA.md#1000-alpha3) for full detail. The headline is a
+  **breaking peer bump: `three` now requires `>=0.185.0`**, and `act` is no longer re-exported.
+
 ## 10.0.0-alpha.2
 
 ### Major Changes


### PR DESCRIPTION
Three problems, in order of how much they mattered.

## 1. One line was simply wrong

> Removed dead `Instance.deferredRefs` and `updateVisibilityHandlers`.

`deferredRefs` is gone. `updateVisibilityHandlers` is **alive and wired** — [`visibility.ts:297`](packages/fiber/src/core/visibility.ts#L297), called from [`props.ts:426`](packages/fiber/src/core/utils/props.ts#L426).

The real story is the inverse of the claim. It was found *unwired*, and wiring it is what fixed the stale handler-closure bug — registration sat behind a handler **count** check, so swapping `onOccluded` for a different function left the count unchanged and the registry kept the old closure. Inline handlers produce a new function every render, so in the common case an updated callback would simply never fire.

So the entry claimed a removal that didn't happen and omitted the fix that did. Both corrected.

## 2. Three things that landed late were missing

- **The TSL HMR fix** — the blocker the release actually waited on
- **`act` no longer re-exported** — moved to **Breaking Changes**, where it belongs. It left the public surface; it was going to ship unmentioned.
- **The v9 reconciler hardening port** (pierced prop reset, instance props sync, reconstruction flush, react-dom event priorities, microtask scheduling)

## 3. "Files Changed" listed 6 files. The release touched 134.

And one of the six (`docs/v10-features.md`) no longer exists — the docs consolidation removed it.

A partial manifest reads as a complete one, which is worse than no manifest. Removed rather than patched. alpha.2's is left alone as history.

---

## Separately: every package now has an alpha.3 section

All three per-package changelogs stopped at **alpha.2** — and those are what npm renders. Publishing alpha.3 with them untouched means anyone reading the package page sees the previous release.

Each now has one, following the convention alpha.2 set (fiber authoritative, others pointing at it):

- **fiber** — condensed summary, links to `CHANGELOG-ALPHA.md` for detail
- **test-renderer** — not a stub. It gained a **real build** this release, having previously shipped with `main`/`module`/`types` all pointing into a `dist` that was never produced. Anyone who hit unresolvable imports on alpha.2 deserves to find out why here.
- **eslint-plugin** — notes that it is versioned on its **own 1.x line**. Matching alpha numbers across a 10.x and a 1.x package invite exactly the wrong assumption, and #3828 is a live example of that assumption doing damage.

Relative links verified to resolve; anchors match GitHub's slug form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)