### PR TITLE
fix(build): stop the entries importing the package by name, and gate it

### DIFF
--- a/packages/fiber/src/core/components/Environment/Environment.tsx
+++ b/packages/fiber/src/core/components/Environment/Environment.tsx
@@ -1,5 +1,15 @@
 import * as React from 'react'
-import { useThree, createPortal, useFrame, extend, Euler, applyProps, ThreeElement } from '@react-three/fiber'
+// Relative, never the package name. A self-import leaves rollup unable to resolve the specifier,
+// so it stays external and every entry ends up importing `@react-three/fiber` -- which resolves
+// back to the default entry and drags `three/webgpu` into the WebGL-only build. See verify-bundles.
+import { useThree, useFrame } from '../../hooks'
+import { createPortal } from '../../renderer'
+import { extend } from '../../reconciler'
+import { applyProps } from '../../utils'
+// `Euler` here is R3F's permissive prop type (`MathType<THREE.Euler>`, which also accepts a tuple),
+// not three's class. That is what the package-name import was resolving to, and narrowing it to
+// three's `Euler` would quietly break `backgroundRotation={[0, 0, 0]}` for every consumer.
+import type { Euler, ThreeElement } from '../../../../types/three'
 import {
   WebGLCubeRenderTarget,
   CubeRenderTarget,

--- a/packages/fiber/src/core/hooks/useEnvironment.tsx
+++ b/packages/fiber/src/core/hooks/useEnvironment.tsx
@@ -1,4 +1,7 @@
-import { useLoader, useThree } from '@react-three/fiber'
+// Relative, never the package name. A self-import leaves rollup unable to resolve the specifier,
+// so it stays external and every entry ends up importing `@react-three/fiber` -- which resolves
+// back to the default entry and drags `three/webgpu` into the WebGL-only build. See verify-bundles.
+import { useLoader, useThree } from './'
 import {
   EquirectangularReflectionMapping,
   CubeTextureLoader,

--- a/scripts/verify-bundles.js
+++ b/scripts/verify-bundles.js
@@ -42,10 +42,22 @@ const checks = [
     file: 'webgpu/index.mjs',
     // WebGPU should have three/webgpu but NOT plain three
     shouldContain: ["from 'three/webgpu'"],
-    shouldNotContain: [],
+    // This used to be empty while the note below claimed otherwise -- the invariant was documented
+    // and never enforced. Subpath imports (three/tsl, three/addons/*) are fine and are not matched
+    // by this, because the pattern includes the closing quote.
+    shouldNotContain: ["from 'three'"],
     notes: 'WebGPU entry should only have WebGPU (no plain three imports)',
   },
 ]
+
+/**
+ * Emitted JS that must not import the package by name, and the minimum size that counts as a real
+ * build. Both guard failure modes the per-entry checks structurally cannot see.
+ */
+const EMITTED_JS = ['index.mjs', 'index.cjs', 'legacy.mjs', 'legacy.cjs', 'webgpu/index.mjs', 'webgpu/index.cjs']
+
+// A stub is ~5 KB of jiti; a real entry is ~660 KB. Anything in between is not a thing we ship.
+const MIN_REAL_BUILD_BYTES = 100 * 1024
 
 //* Helpers ==============================
 
@@ -161,6 +173,69 @@ for (const check of checks) {
     isStandalone,
   })
 }
+
+//* Cross-cutting checks ==============================
+// The per-entry checks above look for `three/webgpu` in each bundle. That is one hop short of the
+// invariant we actually care about: an entry that imports `@react-three/fiber` by name pulls the
+// *default* entry at runtime, and the default entry imports `three/webgpu`. So the legacy build can
+// carry the entire WebGPU renderer while every check above passes.
+//
+// The specifier survives a build because rollup cannot resolve the package from inside itself,
+// leaves it external, and `failOnWarn: false` swallows the warning. `pnpm stub` does not reproduce
+// it -- unbuild detects the self-reference and hands jiti an explicit alias -- so stub and build
+// disagree and only the build is wrong. Hence checking the emitted files directly.
+
+console.log('\n\n📦 Cross-cutting checks')
+console.log('-'.repeat(60))
+
+let crossCuttingPassed = true
+
+console.log('\n   Package self-imports (must be none):')
+for (const file of EMITTED_JS) {
+  const filePath = path.join(FIBER_DIST, file)
+  if (!fs.existsSync(filePath)) continue
+
+  const content = fs.readFileSync(filePath, 'utf-8')
+  const selfImport = content.match(/(?:from|require\()\s*['"]@react-three\/fiber['"]/)
+
+  if (selfImport) {
+    console.log(`   ❌ dist/${file} imports '@react-three/fiber' -- use a relative import instead`)
+    console.log(`      This drags the default entry (and three/webgpu) into every bundle.`)
+    crossCuttingPassed = false
+  } else {
+    console.log(`   ✅ dist/${file}`)
+  }
+}
+
+console.log('\n   Real build, not a stub:')
+for (const file of EMITTED_JS) {
+  const filePath = path.join(FIBER_DIST, file)
+  if (!fs.existsSync(filePath)) continue
+
+  const { size } = fs.statSync(filePath)
+  if (size < MIN_REAL_BUILD_BYTES) {
+    console.log(`   ❌ dist/${file} is ${(size / 1024).toFixed(1)} KB -- this is a stub, not a build`)
+    console.log(`      Run \`pnpm build\`. \`pnpm dev\`/\`pnpm stub\` overwrite dist with jiti stubs.`)
+    crossCuttingPassed = false
+  } else {
+    console.log(`   ✅ dist/${file} (${(size / 1024).toFixed(1)} KB)`)
+  }
+}
+
+// Stub .d.ts files embed absolute paths from the machine that generated them.
+const dtsWithLocalPaths = ['index.d.ts', 'legacy.d.ts', 'webgpu/index.d.ts'].filter((file) => {
+  const filePath = path.join(FIBER_DIST, file)
+  return fs.existsSync(filePath) && /["']\/(?:Users|home)\//.test(fs.readFileSync(filePath, 'utf-8'))
+})
+
+if (dtsWithLocalPaths.length > 0) {
+  console.log(`\n   ❌ Absolute local paths in declarations: ${dtsWithLocalPaths.join(', ')}`)
+  crossCuttingPassed = false
+} else {
+  console.log('\n   ✅ No absolute local paths in declarations')
+}
+
+if (!crossCuttingPassed) allPassed = false
 
 //* Summary ==============================
 


### PR DESCRIPTION
**The WebGL-only entry was shipping the entire WebGPU renderer.**

Reported by the pre-publish audit; that report asked to confirm against a real `pnpm build` before acting, so I did. Every claim below is measured, not inferred.

## The defect

Two source files import `@react-three/fiber` **by package name** instead of relatively:

- `packages/fiber/src/core/components/Environment/Environment.tsx:2`
- `packages/fiber/src/core/hooks/useEnvironment.tsx:1`

Both are reachable from `src/core/index.tsx`, which all three entries re-export — so the specifier landed in `index`, `legacy` **and** `webgpu`.

Rollup can't resolve the package from inside itself, so it left the import external and `failOnWarn: false` swallowed the warning. Built output, before the fix:

```js
// dist/legacy.mjs:8
import { useThree as useThree$1, useLoader as useLoader$1, ... } from '@react-three/fiber';
```

At consumer runtime Node resolves that through the package's own `exports` `"."`:

```
import.meta.resolve('@react-three/fiber')
  -> file:///…/packages/fiber/dist/index.mjs
```

…and `dist/index.mjs` imports `three/webgpu`. So `@react-three/fiber/legacy` transitively pulls WebGPU — the exact thing the three-entry split exists to prevent.

**What that costs:** `three/webgpu` is **652 KB minified / 415 KB gzipped**, against **357 / 126** for plain three. Plus a second full copy of R3F entering the graph.

## Why nobody saw it

`pnpm dev` / `pnpm stub` **do not reproduce it** — unbuild detects the self-reference in stub mode and hands jiti an explicit alias, so the specifier resolves correctly there and leaks only in real builds. Stub and build disagreed, and only the build was wrong.

Not a regression: alpha.2 and every canary have it.

## One subtlety in the fix

`Euler` was coming from the package name, and it is **R3F's permissive prop type** (`MathType<THREE.Euler>`), not three's class. Importing it from `#three` typechecks as a *narrowing* — and would have silently broken `backgroundRotation={[0, 0, 0]}` for every consumer. Typecheck caught it; it now comes from `types/three` alongside `ThreeElement`.

## `verify-bundles` could not have caught this

It asserts `legacy.mjs` lacks the literal `from 'three/webgpu'` — which was **true**. The leak was one hop away, so the gate passed on a broken invariant, and even printed `✅ Legacy entry … (standalone)`.

Added, as cross-cutting checks on the emitted files (checked directly, since stub and build disagree):

- **no emitted JS may import `'@react-three/fiber'`** — the invariant that actually matters
- **a size floor**, so a stub can never pass as a build. `dist/index.mjs` is ~5 KB of jiti against a real ~660 KB; previously a stub failed only incidentally, with a confusing "MISSING import" instead of "you shipped a stub"
- **no absolute local paths in declarations** — same failure mode, stub `.d.ts` embeds the generating machine's paths
- the **WebGPU entry's `shouldNotContain` was `[]`** while its note claimed it forbade plain three. Now it does — and passes, since that entry has zero `from 'three'`.

**Gate verified in both directions**: reverted the source fix, rebuilt, and confirmed it fails with a specific message; restored, and it passes.

## Result

```
Package self-imports (must be none):
✅ dist/index.mjs   ✅ dist/index.cjs
✅ dist/legacy.mjs  ✅ dist/legacy.cjs
✅ dist/webgpu/index.mjs  ✅ dist/webgpu/index.cjs
```

`legacy.mjs` three imports are now `three` and four `three/examples/jsm/*` — no webgpu, directly or transitively. Entry sizes drop ~16 KB each from the dedupe alone; the real win is what no longer enters a legacy consumer's graph.

Full suite: **564 passed, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)