### PR TITLE
docs(tests): point the Tier-2 markers at where the tiers are defined

### DIFF
--- a/packages/fiber/tests/textureColorSpace.test.tsx
+++ b/packages/fiber/tests/textureColorSpace.test.tsx
@@ -14,6 +14,11 @@ import { ReconcilerRoot, createRoot } from '../src/index'
  * These tests drive the WebGL (`gl={{...}}`) path end-to-end, which runs under the
  * jsdom WebGL mock. The `renderer={{...}}` config bag selects WebGPU, which cannot
  * init without a device — see the Tier-2 todo at the bottom.
+ *
+ * Tiers are defined in `docs/development/TESTING.md`. In short: Tier 1 runs on every PR and
+ * proves wiring; Tier 2 needs a real GPU and runs as a pre-release gate. An `it.todo('covered
+ * by Tier 2: …')` marks something jsdom structurally cannot prove, rather than a hollow
+ * assertion that would look like coverage.
  */
 
 // 1x1 RGBA8 texture — DataTexture defaults to RGBAFormat + UnsignedByteType,

--- a/packages/fiber/tests/webgpu/useRenderTarget.test.tsx
+++ b/packages/fiber/tests/webgpu/useRenderTarget.test.tsx
@@ -12,6 +12,11 @@
  * argument parsing, the isLegacy type split, sizing from the store, memoization,
  * and disposal are all fully provable in jsdom (Tier 1). Actually *rendering into*
  * a target is Tier 2.
+ *
+ * Tiers are defined in `docs/development/TESTING.md`. In short: Tier 1 runs on every PR and
+ * proves wiring; Tier 2 needs a real GPU and runs as a pre-release gate. An `it.todo('covered
+ * by Tier 2: …')` marks something jsdom structurally cannot prove, rather than a hollow
+ * assertion that would look like coverage.
  */
 import * as React from 'react'
 import { act } from 'react'

--- a/packages/fiber/tests/webgpu/webgpu-hooks-lifecycle.test.tsx
+++ b/packages/fiber/tests/webgpu/webgpu-hooks-lifecycle.test.tsx
@@ -19,6 +19,11 @@
  *   - that uniform/node value changes actually reach the compiled shader
  *   - that the render loop's `state.renderPipeline.render()` produces correct output
  *   These need a device; faking them in jsdom would be a hollow assertion.
+ *
+ * Tiers are defined in `docs/development/TESTING.md`. In short: Tier 1 runs on every PR and
+ * proves wiring; Tier 2 needs a real GPU and runs as a pre-release gate. An `it.todo('covered
+ * by Tier 2: …')` marks something jsdom structurally cannot prove, rather than a hollow
+ * assertion that would look like coverage.
  */
 import * as React from 'react'
 import { act } from 'react'


### PR DESCRIPTION
`docs/development/TESTING.md` defines the three test tiers and explicitly prescribes this convention:

> **Label the irreducible.** If a behavior genuinely needs a GPU, leave an `it.todo('covered by Tier 2: <check>')` rather than a hollow jsdom assertion — that keeps the gap visible.

The convention is being followed correctly. The problem is that **not one test file linked to the doc**, so "Tier 2" showed up in test output and file comments with no path to its meaning anywhere in the package. You had to already know what it meant, or go looking.

Adds the reference plus the one-sentence version to the three files that use it.

No behaviour change, no test change.