### PR TITLE
fix(events): recover two fixes lost when #3823/#3824 merged at a stale head

### DIFF
--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -57,7 +57,23 @@ function releaseInternalPointerCapture(internal: RootState['internal'], obj: THR
   const captureData = pointerState.captured.get(obj)
   if (captureData) {
     pointerState.captured.delete(obj)
-    captureData.target.releasePointerCapture(pointerId)
+
+    // Our own bookkeeping is done; the DOM release is best-effort on top of it.
+    //
+    // This runs from `removeInteractivity` during unmount, and the browser may well have released
+    // the capture already -- on pointerup, on pointercancel, or when the element was detached. In
+    // that case `releasePointerCapture` throws `NotFoundError` for an id it no longer considers
+    // captured. Letting that escape means a component that was mid-drag when it unmounted takes
+    // the whole teardown down with it.
+    //
+    // Unlike the swallowed errors removed elsewhere in v10, there is nothing here worth surfacing:
+    // the release we wanted has happened either way, and warning on every such unmount would be
+    // noise for a non-event.
+    try {
+      captureData.target.releasePointerCapture?.(pointerId)
+    } catch {
+      // Already released, or the target is gone. Either way the capture is not held.
+    }
   }
 }
 

--- a/packages/fiber/src/core/events.ts
+++ b/packages/fiber/src/core/events.ts
@@ -228,8 +228,22 @@ export function createEvents(store: RootStore) {
         if (state.raycaster.camera === undefined) state.raycaster.camera = null!
       }
 
+      if (!state.raycaster.camera) return []
+
+      // Bring world matrices up to date before intersecting. three's raycaster reads `matrixWorld`
+      // and never refreshes it -- it assumes the render loop already has. That assumption breaks for
+      // any event arriving between a React commit and the next rendered frame: the object has its
+      // new `position`, its `matrixWorld` still says otherwise, and the hit is computed against
+      // where it used to be. Two objects that have not been rendered yet both report the origin, so
+      // their distances tie and "nearest first" silently degrades into scene order.
+      //
+      // `updateWorldMatrix(true, true)` walks ancestors first, then descendants, so a nested object
+      // is correct even when its parent is what moved. Cheap in the common case -- three skips the
+      // maths for anything not flagged dirty.
+      obj.updateWorldMatrix(true, true)
+
       // Intersect object by object
-      return state.raycaster.camera ? state.raycaster.intersectObject(obj, true) : []
+      return state.raycaster.intersectObject(obj, true)
     }
 
     // Collect events

--- a/packages/fiber/tests/events-priority-xr.test.tsx
+++ b/packages/fiber/tests/events-priority-xr.test.tsx
@@ -1,18 +1,7 @@
 import { vi } from 'vitest'
 import * as React from 'react'
 import { render, fireEvent } from '@testing-library/react'
-// NOTE: this file deliberately keeps a local frame-settling helper instead of the shared
-// act() in ./utils/act. Wrapping these cases in React's real act changes the raycast the
-// pointer events see -- 'falls back to distance ordering' starts reporting the far mesh
-// first, i.e. declaration order, which is what a distance tie would produce. That points at
-// world matrices not being current at dispatch time under a real act scope, and it needs its
-// own investigation rather than being papered over here. Tracked separately; the act(...)
-// warnings from this file stay until then.
-async function act<T>(fn: () => Promise<T>) {
-  const value = await fn()
-  await new Promise((res) => requestAnimationFrame(() => requestAnimationFrame(() => res(null))))
-  return value
-}
+import { act } from './utils/act'
 import { Canvas, extend } from '../src'
 import * as THREE from '#three'
 import type { RootState } from '#types'

--- a/packages/fiber/tests/events.test.tsx
+++ b/packages/fiber/tests/events.test.tsx
@@ -524,13 +524,42 @@ describe('events', () => {
       expect(handlePointerLeave).not.toHaveBeenCalled()
     })
 
-    // KNOWN GAP, deliberately not asserted as passing: an active pointer capture does not survive
-    // reconstruction. swapInteractivity re-keys `pointerState.captured` and rewrites the stored
-    // intersection, and both are verifiably correct at replay time (the captured hit resolves to
-    // the new object with its handlers intact) -- but the deferred pointer-move path never reaches
-    // `onIntersect` afterwards, so a drag in progress goes silent. That is a frame-timed raycast
-    // interaction rather than a state-transfer problem, and it needs its own fix.
-    it.todo('keeps an active pointer capture alive across reconstruction')
+    it('keeps an active pointer capture alive across reconstruction', async () => {
+      const handlePointerDown = vi.fn((ev: any) => ev.target.setPointerCapture(ev.pointerId))
+      const handlePointerMove = vi.fn()
+      const materialA = new THREE.MeshBasicMaterial()
+      const materialB = new THREE.MeshBasicMaterial()
+      const handlers = { onPointerDown: handlePointerDown, onPointerMove: handlePointerMove }
+
+      let result: RenderResult = null!
+      await act(async () => {
+        result = render(<SwapApp material={materialA} {...handlers} />)
+      })
+
+      const canvas = getContainer()
+      await act(async () => {
+        canvas.dispatchEvent(createPointerEvent('pointerdown'))
+      })
+      expect(handlePointerDown).toHaveBeenCalledTimes(1)
+
+      // Reconstruct mid-drag, then move well off the mesh. Only a live capture keeps delivering
+      // there -- without one the pointer misses everything and the drag dies silently.
+      //
+      // Re-keying `captured` is not enough on its own: `PointerCaptureTarget` carries its own
+      // `intersection`, and that is what gets replayed into the hit list on every later event. Left
+      // pointing at the discarded object, the replayed hit resolves to something whose `__r3f` link
+      // has been severed.
+      await act(async () => {
+        result.rerender(<SwapApp material={materialB} {...handlers} />)
+      })
+
+      handlePointerMove.mockClear()
+      await act(async () => {
+        canvas.dispatchEvent(createPointerEvent('pointermove', { offsetX: 5, offsetY: 5, clientX: 5, clientY: 5 }))
+      })
+
+      expect(handlePointerMove).toHaveBeenCalled()
+    })
   })
 
   describe('web pointer capture', () => {

--- a/packages/fiber/tests/setupTests.ts
+++ b/packages/fiber/tests/setupTests.ts
@@ -123,3 +123,33 @@ Object.defineProperties(HTMLCanvasElement.prototype, {
   clientWidth: { get: () => 1280 },
   clientHeight: { get: () => 800 },
 })
+
+//* Pointer Capture Polyfill ==============================
+// jsdom implements PointerEvent poorly and the capture API not at all, so `setPointerCapture` is
+// simply absent from elements. R3F's pointer-capture path calls straight through to it, which means
+// any test that captures a pointer dies on the DOM call rather than on the behaviour it is testing.
+//
+// Modelled on the real contract rather than stubbed to no-ops, because the failure modes are the
+// interesting part: releasing an id that is not captured throws `NotFoundError` in browsers, and
+// code that unmounts mid-drag has to survive that.
+const capturedPointers = new WeakMap<Element, Set<number>>()
+
+if (!Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = function (pointerId: number) {
+    let ids = capturedPointers.get(this)
+    if (!ids) capturedPointers.set(this, (ids = new Set()))
+    ids.add(pointerId)
+  }
+
+  Element.prototype.hasPointerCapture = function (pointerId: number) {
+    return capturedPointers.get(this)?.has(pointerId) ?? false
+  }
+
+  Element.prototype.releasePointerCapture = function (pointerId: number) {
+    const ids = capturedPointers.get(this)
+    if (!ids?.has(pointerId)) {
+      throw new DOMException(`Failed to release pointer capture for pointerId ${pointerId}`, 'NotFoundError')
+    }
+    ids.delete(pointerId)
+  }
+}


### PR DESCRIPTION
⚠️ **These two commits were meant to be in #3823 and #3824. They were pushed to those branches before merge, but GitHub's PR head lagged and never picked them up — so both PRs merged one commit short.**

Verified against current `v10` (`0f8db175`):

```
8b921fdd in v10?  *** NO — MISSING ***
2ccdafa0 in v10?  *** NO — MISSING ***

updateWorldMatrix in events.ts:   0
guarded releasePointerCapture:    0
setupTests capture polyfill:      0
```

#3826 and #3827 are correctly still open, because the code that closes them never landed. This restores both, cherry-picked onto current `v10`.

## `fix(events): keep pointer captures alive across reconstruction` — closes #3826

Re-keying `pointerState.captured` is not enough. `PointerCaptureTarget` carries its own `intersection`, and that is what gets replayed into the hit list on every later event. Left pointing at the discarded object, the replayed hit resolves to something whose `__r3f` link has been severed — so a drag in progress goes silent even though the capture "survived".

**Verified load-bearing**: reverting to the v9-style re-key-only fails the test. That also confirms the fix proposed for the v9 line in #3831 is the right one.

Two supporting changes, both of which were hiding this:

- **`releaseInternalPointerCapture` could take down unmount.** It called `captureData.target.releasePointerCapture` unguarded, from `removeInteractivity` during teardown — where browsers throw `NotFoundError` if the capture was already released (pointerup, pointercancel, detached element). A component that unmounted mid-drag threw out of its own teardown. Now best-effort, since our own bookkeeping is already complete at that point.
- **jsdom has no pointer-capture API at all**, so `setPointerCapture` is simply absent from elements and any test touching captures died on the DOM call rather than the behaviour. `setupTests` now polyfills it against the *real* contract — releasing an uncaptured id throws `NotFoundError` — because that failure mode is the interesting one. Also unblocks capture coverage generally (#3797).

## `fix(events): update world matrices before raycasting` — closes #3827

three's raycaster reads `matrixWorld` and never refreshes it; it assumes the render loop has. That breaks for any pointer event arriving **between a React commit and the next rendered frame**. Measured:

```
[RAY] Mesh dist= 4.5316  wpos.z= 0.000  pos.z= -2
[RAY] Mesh dist= 4.5316  wpos.z= 0.000  pos.z= 2
```

`position` correct, `matrixWorld` translation **0.000 for both** — identical distances for meshes four units apart, so the sort tied and fell through to scene order.

`updateWorldMatrix(true, true)` walks ancestors first then descendants, so a nested object is right even when the *parent* moved — which a bare `updateMatrixWorld()` on the object would not fix. Cheap when nothing is dirty.

This is what kept `events-priority-xr.test.tsx` on a fake `act`; it now uses the shared helper like every other file.

## Result on current v10

**581 passed, 0 failed, 6 todo.** Act warnings **99 → 2** — the last two are `useLoader`'s abort test, left deliberately: wrapping the abort surfaces the intentional rejection as a failure, and wrapping the cache clear re-triggers the load before the assertion that a fresh load started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)