### PR TITLE
chore(ci): verify v10 after merge, and verify canaries before publishing

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -34,6 +34,16 @@ jobs:
       - name: Build
         run: pnpm build
 
+      # Verify before publishing, not after. This job fires on every push to v10 and pushes straight
+      # to npm, where a version can never be withdrawn -- so it is the last place a bad artifact can
+      # be stopped. These are the checks that catch the self-import leak, a stub shipped as a build,
+      # and absolute local paths in declarations; none of them ran here before.
+      - name: Verify bundles
+        run: pnpm verify-bundles
+
+      - name: Verify types
+        run: pnpm verify-types
+
       # Every published package gets a canary, not just fiber -- test-renderer has had a real build
       # since it gained one, and a canary of fiber alone cannot be integration-tested against it.
       #

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,12 @@
 name: Test
 on:
   push:
+    # Both active release lines. `v10` matters as much as `master`: PR checks verify a PR's *head*,
+    # not the result of merging it, and a PR head can lag behind the branch it points at -- so a
+    # merge can land content no run ever saw. Verifying the branch after the merge catches that.
     branches:
       - 'master'
+      - 'v10'
   pull_request: {}
 jobs:
   build:


### PR DESCRIPTION
Two gaps that let unverified content through. **One has already bitten.**

## `test.yml` never ran on `v10`

Triggers were `push: [master]` + `pull_request`. PR checks verify a PR's **head**, not the result of merging it — and a PR head can lag behind the branch it points at, so a merge can land content **no run ever saw**.

That is exactly what happened today. #3823 and #3824 each merged **one commit short**: the final push reached the branch, GitHub's PR head never updated, and the merge took the stale head. Verified against `v10@0f8db175`:

```
8b921fdd in v10?  *** NO — MISSING ***
2ccdafa0 in v10?  *** NO — MISSING ***
```

Nothing downstream noticed, because there is no post-merge run on `v10`. Recovered in #3833; this stops the next one.

## `canary.yml` publishes without verifying

It fires on every push to `v10` and pushes straight to npm — where **a version can never be withdrawn**. It ran neither `verify-bundles` nor `verify-types`, making the one job with irreversible consequences the one job with no checks.

Both now run before publish. That is what catches the self-import leak, a stub shipped as a build, and absolute local paths in declarations (#3830) — a direct push could still have shipped a canary with none of that checked.

Items 12 and 13 from the pre-publish audit.