### PR TITLE
chore(packaging): fix the exports map, drop dead files, align peers

### DIFF
--- a/packages/fiber/package.json
+++ b/packages/fiber/package.json
@@ -35,7 +35,6 @@
   "sideEffects": false,
   "files": [
     "dist",
-    "react-reconciler",
     "readme.md"
   ],
   "exports": {
@@ -53,7 +52,8 @@
       "types": "./dist/webgpu/index.d.ts",
       "import": "./dist/webgpu/index.mjs",
       "require": "./dist/webgpu/index.cjs"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "prebuild": "node -e \"require('fs').copyFileSync('../../readme.md', 'readme.md')\"",

--- a/packages/test-renderer/package.json
+++ b/packages/test-renderer/package.json
@@ -27,7 +27,8 @@
       "types": "./dist/webgpu/index.d.ts",
       "import": "./dist/webgpu/index.mjs",
       "require": "./dist/webgpu/index.cjs"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "bugs": {
     "url": "https://github.com/pmndrs/react-three-fiber/issues"
@@ -39,7 +40,7 @@
   },
   "peerDependencies": {
     "@react-three/fiber": ">=10.0.0-alpha.0",
-    "react": "^19.0.0",
+    "react": ">=19.0 <19.3",
     "three": ">=0.185.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Items 14–16 of the pre-publish audit. Each verified in both directions rather than assumed.

## `./package.json` was not exported — this one breaks builds

Vite, Jest's resolver, `pkg-dir`-style tooling and some ESLint resolvers read `package.json` directly. Under strict `exports` that throws. Confirmed against the previous manifest:

```
BEFORE  @react-three/fiber/package.json -> ERR_PACKAGE_PATH_NOT_EXPORTED
AFTER   @react-three/fiber/package.json -> .../packages/fiber/package.json
```

All three entry points still resolve (`.`, `/legacy`, `/webgpu`). Added to `test-renderer` too, which had the same gap.

## `react-reconciler` shipped for nothing

fiber's `files` listed it, but the patched reconciler is **bundled into `dist`** — no built file carries a bare import of it, checked across all six emitted JS files. So it was 382 KB across 4 entries that no consumer could resolve.

```
BEFORE  21 files, 5.71 MB unpacked, 1.34 MB tarball
AFTER   17 files, 5.33 MB unpacked, 1.23 MB tarball
```

## test-renderer's React peer had no ceiling

It allowed `^19.0.0` while fiber pins `>=19.0 <19.3`. A consumer on React 19.3 got a conflict from fiber alone, with no signal from test-renderer that the pair was untested. Both now state the same tested range.

Full suite: **581 passed, 0 failed.**

⚠️ Changes what ships in the tarball — should land **before** the alpha.3 tag.