### PR TITLE
docs: record the breaking changes alpha.3 actually ships

### DIFF
--- a/CHANGELOG-ALPHA.md
+++ b/CHANGELOG-ALPHA.md
@@ -31,6 +31,104 @@ removed from the public surface.
 
 It is the same function, so this is an import change and nothing more.
 
+#### React peer range is `>=19.0 <19.3`
+
+v10 requires React 19, with an upper bound. The ceiling is deliberate and follows the same rule as
+the three range: we state the versions we have tested. It moves when a newer React is verified, not
+before.
+
+```json
+"react": ">=19.0 <19.3",
+"react-dom": ">=19.0 <19.3"
+```
+
+#### Removed Renderer Props
+
+> **These shipped in alpha.3, not alpha.2.** The alpha.2 notes described them, but the entries were
+> written after `v10.0.0-alpha.2` was tagged — "Removed Renderer Props" four days after, the shadow
+> default nineteen days after — so anyone reading the published alpha.2 notes was told this had
+> already happened when it had not. Moved here, where an alpha.2 → alpha.3 upgrader will meet them.
+
+Removed redundant renderer props that can be passed via `gl` or `renderer` props directly:
+
+**Removed from Canvas/RenderProps:**
+
+- `legacy` - `THREE.ColorManagement.enabled` is now always `true`
+- `linear` (deprecated) - Use `gl={{ outputColorSpace: THREE.LinearSRGBColorSpace }}`
+- `flat` (deprecated) - Use `gl={{ toneMapping: THREE.NoToneMapping }}`
+- `colorSpace` - Use `gl={{ outputColorSpace: ... }}`
+- `toneMapping` - Use `gl={{ toneMapping: ... }}`
+
+**Removed from RootState (useThree):**
+
+- `legacy`, `linear`, `flat`, `colorSpace`, `toneMapping`
+- Access via `state.renderer.outputColorSpace` and `state.renderer.toneMapping` instead
+
+**Migration:**
+
+```diff
+- <Canvas colorSpace={THREE.LinearSRGBColorSpace} toneMapping={THREE.NoToneMapping} />
++ <Canvas gl={{ outputColorSpace: THREE.LinearSRGBColorSpace, toneMapping: THREE.NoToneMapping }} />
+
+- const { colorSpace, toneMapping } = useThree()
++ const { renderer } = useThree()
++ const colorSpace = renderer.outputColorSpace
++ const toneMapping = renderer.toneMapping
+```
+
+**Note:** `textureColorSpace` survives, but **not as a Canvas prop**. It moved into
+`ColorManagementConfig`, which is intersected into `GLProps` and `RendererProps` — so it goes inside
+the config bag, not at the top level:
+
+```diff
+- <Canvas textureColorSpace="srgb" />
++ <Canvas gl={{ textureColorSpace: 'srgb' }} />
++ <Canvas renderer={{ textureColorSpace: 'srgb' }} />
+```
+
+#### Default shadow type is now `PCFShadowMap`
+
+Changed from `PCFSoftShadowMap` to match three r182 defaults. three deprecated `PCFSoftShadowMap` and
+improved the standard `PCFShadowMap`, so R3F aligns with upstream. The legacy `shadows` aliases
+`percentage` and `soft` still work, mapping to `PCFShadowMap` with a console warning.
+
+_(Also written into the alpha.2 notes after that tag — see the box above.)_
+
+#### `usePostProcessing` → `useRenderPipeline`
+
+three renamed `PostProcessing` to `RenderPipeline` in r183. `usePostProcessing` was a **public export**
+of `@react-three/fiber/webgpu` at alpha.2 and no longer exists, and the store key moved with it.
+
+```diff
+- import { usePostProcessing } from '@react-three/fiber/webgpu'
++ import { useRenderPipeline } from '@react-three/fiber/webgpu'
+
+- const { postProcessing } = useThree()
++ const { renderPipeline } = useThree()
+```
+
+#### Smaller breaking changes
+
+Individually minor, collectively enough to break a build — none of these were listed before.
+
+- **`useTexture({ cache })` now defaults to `true`.** Every URL-loaded texture enrols in the global
+  registry and persists until disposed. If you were relying on textures being collected, this reads
+  like a leak. Opt out per call with `{ cache: false }`.
+- **`useTextures()` return shape changed.** `textures` is now `all`; `addMultiple`, `remove`,
+  `removeMultiple` and `disposeMultiple` are gone; `dispose()` returns a boolean and is refcount-gated,
+  so it no longer disposes a texture another consumer still holds.
+- **Pointer-move raycasts are deferred to frame start by default** (`events.frameTimedRaycasts: true`).
+  Moves are now processed once per frame rather than per DOM event.
+- **The default camera is a child of `scene`.** This shifts every index in `scene.children` by one —
+  code doing `scene.children[0]` to reach the first rendered object now gets the camera.
+- **`advance()` is narrowed to `(timestamp: number)`.** Extra arguments are a type error.
+- **`Mutable<P>` now uses `-readonly`** rather than `P[K] | Readonly<P[K]>`, which affects every
+  `ThreeElement` prop type.
+- **`ObjectMap` is generic**, with `Record<>` members.
+- **Canvas CSS is `width: 100%; height: 100%`**, and `setSize(w, h, false)` is now unconditional.
+- **`TextureEntry` is no longer exported** from the default entry.
+- **`@react-three/test-renderer` entry paths and peer range changed** — see that package's changelog.
+
 ### Features
 
 #### Interactive Priority (userData.interactivePriority)
@@ -339,12 +437,16 @@ constraints, per-callback fps throttling and the single shared RAF all behave as
   Registration is now atomic and generation-aware. Verified live over three consecutive edits on a
   real GPU.
 - Ported the reconciler hardening released in `@react-three/fiber@9.7.0`: removed pierced props
-  reset on their pierced target rather than the object root; `instance.props` synced wholesale in
-  `commitUpdate` so removed props do not linger, changed reserved props take effect, and imperative
-  mutations are not stomped by re-applied defaults; reconstructed instances flushed in
+  reset on their pierced target rather than the object root; reconstructed instances flushed in
   `resetAfterCommit` so `args`/`primitive` changes apply even when the last updated sibling bailed
-  out. Also aligned update scheduling — `resolveUpdatePriority` now mirrors react-dom's
-  `getEventPriority`, and the reconciler uses microtask scheduling.
+  out.
+
+  Three parts of that port are **behaviour changes rather than fixes**, and are worth knowing about:
+  - **`commitUpdate` now syncs `instance.props` wholesale.** Removed props no longer linger, changed
+    reserved props (`onUpdate`, `dispose`) take effect — and imperative mutations survive a re-render
+    instead of being stomped by re-applied defaults. That last one is the change people will notice.
+  - **`dragenter`/`dragleave` moved from Discrete to Continuous priority**, matching react-dom.
+  - **The reconciler now schedules via microtasks.**
 
 ### Examples
 
@@ -377,47 +479,6 @@ constraints, per-callback fps throttling and the single shared RAF all behave as
 ---
 
 ## 10.0.0-alpha.2
-
-### Breaking Changes
-
-#### Removed Renderer Props
-
-Removed redundant renderer props that can be passed via `gl` or `renderer` props directly:
-
-**Removed from Canvas/RenderProps:**
-
-- `legacy` - `THREE.ColorManagement.enabled` is now always `true`
-- `linear` (deprecated) - Use `gl={{ outputColorSpace: THREE.LinearSRGBColorSpace }}`
-- `flat` (deprecated) - Use `gl={{ toneMapping: THREE.NoToneMapping }}`
-- `colorSpace` - Use `gl={{ outputColorSpace: ... }}`
-- `toneMapping` - Use `gl={{ toneMapping: ... }}`
-
-**Removed from RootState (useThree):**
-
-- `legacy`, `linear`, `flat`, `colorSpace`, `toneMapping`
-- Access via `state.renderer.outputColorSpace` and `state.renderer.toneMapping` instead
-
-**Migration:**
-
-```diff
-- <Canvas colorSpace={THREE.LinearSRGBColorSpace} toneMapping={THREE.NoToneMapping} />
-+ <Canvas gl={{ outputColorSpace: THREE.LinearSRGBColorSpace, toneMapping: THREE.NoToneMapping }} />
-
-- const { colorSpace, toneMapping } = useThree()
-+ const { renderer } = useThree()
-+ const colorSpace = renderer.outputColorSpace
-+ const toneMapping = renderer.toneMapping
-```
-
-**Note:** `textureColorSpace` remains in RenderProps as it's R3F-specific.
-
-**Files changed:**
-
-- `packages/fiber/types/renderer.d.ts` - Removed props from RenderProps
-- `packages/fiber/types/store.d.ts` - Removed props from RootState
-- `packages/fiber/src/core/Canvas.tsx` - Removed prop destructuring and passing
-- `packages/fiber/src/core/renderer.tsx` - Simplified configure() logic
-- `packages/fiber/src/core/store.ts` - Removed from initial state
 
 ### Features
 
@@ -526,10 +587,6 @@ Added automatic Hot Module Replacement (HMR) support for WebGPU TSL hooks. When 
 **Store changes:**
 
 - Added `_hmrVersion: number` to RootState for coordinating HMR rebuilds
-
-#### Default Shadow Type: PCFShadowMap
-
-Changed the default shadow map type from `PCFSoftShadowMap` to `PCFShadowMap` to match Three.js r182 defaults. Three.js deprecated `PCFSoftShadowMap` and improved the standard `PCFShadowMap`, so R3F now aligns with upstream. Legacy shadow types (`percentage`, `soft`) are mapped to `PCFShadowMap` with a console warning.
 
 ### Bug Fixes
 

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -8,8 +8,24 @@ nav: 1
 npm install three @react-three/fiber
 ```
 
+To try the v10 alpha:
+
+```bash
+npm install three@latest @react-three/fiber@alpha
+```
+
 > [!WARNING]  
-> Fiber is compatible with React v18 and v19 and works with ReactDOM and React Native. Fiber is a React renderer, it must pair with a major version of React, just like react-dom, react-native, etc. @react-three/fiber@8 pairs with react@18, @react-three/fiber@9 pairs with react@19.
+> Fiber is a React renderer, so it must pair with a major version of React, just like react-dom or
+> react-native. It works with ReactDOM and React Native.
+>
+> | Fiber                           | React          | three        |
+> | ------------------------------- | -------------- | ------------ |
+> | `@react-three/fiber@8`          | `react@18`     | —            |
+> | `@react-three/fiber@9`          | `react@19`     | —            |
+> | `@react-three/fiber@10` (alpha) | `>=19.0 <19.3` | `>=0.185.0`  |
+>
+> The v10 bounds are deliberate — they state the versions we have tested, and move when a newer one
+> is verified. Installing v10 against React 19.3 or three r184 will fail peer resolution.
 
 Getting started with React Three Fiber is not nearly as hard as you might have thought, but various frameworks may require particular attention.
 

--- a/docs/migration/v10.mdx
+++ b/docs/migration/v10.mdx
@@ -49,6 +49,31 @@ You can also pass renderer parameters or a pre-created renderer instance. R3F ha
 
 ## Breaking Changes
 
+### Dependency ranges moved
+
+The first thing you will hit, before any code change: v10 will not install alongside the versions v9
+accepted.
+
+| Peer      | v9        | v10            |
+| --------- | --------- | -------------- |
+| `three`   | `>=0.156` | `>=0.185.0`    |
+| `react`   | `>=19.0`  | `>=19.0 <19.3` |
+
+The three floor moved because v10 uses three's own `RenderPipeline` (renamed from `PostProcessing`
+in r183), `CubeRenderTarget`, and the real `UniformNode` types, rather than shadowing them. **If you
+are on r181–r184 you cannot install v10** — upgrade three alongside R3F.
+
+The React ceiling states the versions we have tested, and moves when a newer one is verified.
+
+### React Native moved to its own package
+
+`@react-three/fiber/native` is now **`@react-three/native`**, versioned independently.
+
+```diff
+- import { Canvas, useFrame } from '@react-three/fiber/native'
++ import { Canvas, useFrame } from '@react-three/native'
+```
+
 ### `gl` renamed to `renderer`
 
 The `gl` property in state has been renamed to `renderer` to be renderer-agnostic and match Three.js conventions.
@@ -175,7 +200,15 @@ The following Canvas props have been removed. Use the `gl` (WebGL LEGACY ONLY) o
 + const toneMapping = renderer.toneMapping
 ```
 
-**Note:** `textureColorSpace` remains available as an R3F-specific prop for controlling how textures are interpreted.
+**Note:** `textureColorSpace` survives, but **not as a Canvas prop**. It lives in
+`ColorManagementConfig`, intersected into `GLProps` and `RendererProps`, so it goes inside the
+config bag rather than at the top level:
+
+```diff
+- <Canvas textureColorSpace="srgb" />
++ <Canvas gl={{ textureColorSpace: 'srgb' }} />
++ <Canvas renderer={{ textureColorSpace: 'srgb' }} />
+```
 
 ### `<color attach="background">` Pattern Deprecated
 
@@ -335,7 +368,12 @@ No. WebGL remains the default and will continue to be supported. WebGPU is opt-i
 
 ### Will my drei/postprocessing code work?
 
-Yes. The ecosystem packages are compatible with v10's default import. WebGPU-specific features may require updates to ecosystem packages over time.
+Mostly, with one caveat during the alpha. v10's default import keeps the v9 surface these packages
+build on, so ordinary drei and postprocessing usage is expected to work.
+
+The caveat is peer ranges: a `@react-three/drei` release declaring support for
+`@react-three/fiber@^10` is still pending, so your package manager may warn or refuse to resolve
+until it lands. WebGPU-specific features will need ecosystem updates over time regardless.
 
 ### What if I'm using `state.gl` everywhere?
 

--- a/packages/fiber/readme.md
+++ b/packages/fiber/readme.md
@@ -143,7 +143,7 @@ Live demo: https://codesandbox.io/s/icy-tree-brnsm?file=/src/App.tsx
 <details>
   <summary>Show React Native example</summary>
 
-This example relies on react 18 and uses `expo-cli`, but you can create a bare project with their template or with the `react-native` CLI.
+This example uses `expo-cli`, but you can create a bare project with their template or with the `react-native` CLI.
 
 ```bash
 # Install expo-cli, this will create our app

--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,7 @@ Live demo: https://codesandbox.io/s/icy-tree-brnsm?file=/src/App.tsx
 <details>
   <summary>Show React Native example</summary>
 
-This example relies on react 18 and uses `expo-cli`, but you can create a bare project with their template or with the `react-native` CLI.
+This example uses `expo-cli`, but you can create a bare project with their template or with the `react-native` CLI.
 
 ```bash
 # Install expo-cli, this will create our app


### PR DESCRIPTION
Items 1–7 and 10 of the pre-publish audit. The alpha.3 notes described a subset of what changed — and in one case described it under the wrong release.

## Two sections were filed under alpha.2 but shipped in alpha.3

Checked against the tag rather than assumed. At `v10.0.0-alpha.2` (`200d9db3`, 2026-01-20) **neither existed**:

| entry | added | vs tag |
| --- | --- | --- |
| "Removed Renderer Props" | 2026-01-24 | **4 days after** |
| "Default Shadow Type: PCFShadowMap" | 2026-02-08 | **19 days after** |

So someone on published alpha.2 upgrading to alpha.3 hits the removal of `legacy`/`linear`/`flat`/`colorSpace`/`toneMapping` **and** a shadow-default flip — while the notes tell them it already happened. Both moved to alpha.3, with a note explaining the misfiling so the history stays legible.

## `usePostProcessing` was filed as an internal rename

It was a **public export** of `@react-three/fiber/webgpu` at alpha.2 and no longer exists, as did `RootState.postProcessing`. Now a breaking change with a diff.

## Ten breaking changes were in the diff and in no Breaking Changes section

Each verified in source rather than transcribed. The ones that will actually bite:

- **`useTexture({ cache })` now defaults to `true`** (`useTexture.tsx:122`) — every URL-loaded texture persists until disposed, which reads like a leak if you don't know.
- **The default camera is a child of `scene`** (`renderer.tsx:444`) — shifts every `scene.children` index by one.
- **Pointer-move raycasts defer to frame start** (`store.ts:97`, `frameTimedRaycasts: true`).

Plus `useTextures()`'s return shape, `advance()` narrowing, `Mutable<P>`, `ObjectMap`, Canvas CSS, and `TextureEntry`.

## The reconciler port was filed wholly under Bug Fixes

Three parts are behaviour changes: `commitUpdate` now syncs props wholesale (**imperative mutations survive a re-render** instead of being stomped — the one people will notice), `dragenter`/`dragleave` demoted to Continuous, and microtask scheduling.

## A statement that was simply wrong, in two places

`CHANGELOG-ALPHA.md:412` and `docs/migration/v10.mdx:178` both said `textureColorSpace` *"remains in RenderProps"*. It does not — it moved to `ColorManagementConfig`, intersected into `GLProps`/`RendererProps`. `RenderProps` has no such member, so following the old note gets you a Canvas prop that silently does nothing.

## Published docs

- **`installation.mdx`** said *"compatible with React v18 and v19"*, never mentioned v10, and gave no alpha install line — against a real peer of `>=19.0 <19.3`. Now a version table plus `npm install three@latest @react-three/fiber@alpha`.
- **`migration/v10.mdx`** omitted the three peer floor (its own headline breaking change), the React range, and the `@react-three/fiber/native` → `@react-three/native` move. All three added.
- Its FAQ answered *"Will my drei/postprocessing code work? **Yes.**"* while drei `^10` compat is still pending — softened to name the actual caveat.
- The readme's *"relies on react 18"* line is gone.

Full suite: **581 passed, 0 failed.**