### PR TITLE
chore(release): derive the dist-tag from the version instead of defaulting to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,14 +32,15 @@
     "test": "vitest run --coverage",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false --strict",
-    "release": "pnpm build && pnpm -r publish --filter './packages/*'",
+    "release": "pnpm build && node scripts/release.js",
     "codegen:eslint": "cd packages/eslint-plugin && pnpm codegen",
     "analyze-fiber": "cd packages/fiber && npm publish --dry-run",
     "analyze-test": "cd packages/test-renderer && npm publish --dry-run",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
     "verify-bundles": "node scripts/verify-bundles.js",
-    "verify-types": "node scripts/verify-types.js"
+    "verify-types": "node scripts/verify-types.js",
+    "release:dry": "node scripts/release.js --dry-run"
   },
   "devDependencies": {
     "@babel/core": "^7.28.6",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * Publish the workspace packages under the dist-tag their own versions imply.
+ *
+ * The tag is derived, never passed in. `pnpm publish` defaults to `latest` when `--tag` is omitted,
+ * so the previous one-line release script would have moved `latest` from the 9.x line onto a v10
+ * prerelease -- every `npm install @react-three/fiber` in the world, from a command whose danger was
+ * invisible at the call site. Hardcoding `--tag alpha` fixes today and breaks at beta, so instead
+ * the channel comes from the version string and stays correct through beta, rc and stable.
+ *
+ *   10.0.0-alpha.3  -> alpha
+ *   10.0.0-beta.1   -> beta
+ *   10.0.0-rc.2     -> rc
+ *   10.0.0          -> latest
+ *
+ * Guards, in order of how much damage they prevent:
+ *
+ *   - every package must agree on the channel. A stray `latest` alongside prereleases is how
+ *     `latest` moves by accident, and the versions are edited by hand.
+ *   - publishing to `latest` requires --allow-latest. Reaching stable should be a deliberate act,
+ *     not something a script does because the version happened to lose its suffix.
+ *   - --dry-run prints the plan and publishes nothing.
+ *
+ * Usage:  node scripts/release.js [--dry-run] [--allow-latest]
+ */
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+// fiber first: the others declare a peer on it, so a partial run leaves the tree resolvable.
+const PACKAGES = ['fiber', 'test-renderer', 'eslint-plugin']
+
+const argv = new Set(process.argv.slice(2))
+const dryRun = argv.has('--dry-run')
+const allowLatest = argv.has('--allow-latest')
+
+const die = (msg) => {
+  console.error(`\n✖ ${msg}\n`)
+  process.exit(1)
+}
+
+/** `10.0.0-alpha.3` -> `alpha`; `10.0.0` -> `latest`. */
+const channelOf = (version) => {
+  const [, prerelease] = version.split('-', 2)
+  if (!prerelease) return 'latest'
+
+  const id = prerelease.split('.')[0]
+  if (!/^[a-z][a-z0-9]*$/.test(id)) die(`Cannot read a dist-tag from version "${version}".`)
+  return id
+}
+
+const manifests = PACKAGES.map((dir) => {
+  const path = join(root, 'packages', dir, 'package.json')
+  const { name, version } = JSON.parse(readFileSync(path, 'utf8'))
+  return { dir, name, version, channel: channelOf(version) }
+})
+
+const channels = [...new Set(manifests.map((m) => m.channel))]
+if (channels.length > 1) {
+  die(
+    `Packages disagree on the release channel, so publishing would tag them inconsistently:\n\n` +
+      manifests.map((m) => `    ${m.name.padEnd(30)} ${m.version.padEnd(20)} -> ${m.channel}`).join('\n') +
+      `\n\n  Align the versions, then re-run.`,
+  )
+}
+
+const [tag] = channels
+
+if (tag === 'latest' && !allowLatest) {
+  die(
+    `Refusing to publish to "latest".\n\n` +
+      `  These versions carry no prerelease suffix, so this would move the "latest" dist-tag —\n` +
+      `  the version every plain \`npm install\` resolves to.\n\n` +
+      manifests.map((m) => `    ${m.name.padEnd(30)} ${m.version}`).join('\n') +
+      `\n\n  If that is genuinely the intent, re-run with --allow-latest.`,
+  )
+}
+
+console.log(`\nPublishing under dist-tag: ${tag}${dryRun ? '  (dry run)' : ''}\n`)
+for (const m of manifests) console.log(`    ${m.name.padEnd(30)} ${m.version}`)
+console.log()
+
+if (dryRun) {
+  console.log('Dry run — nothing published.\n')
+  process.exit(0)
+}
+
+for (const m of manifests) {
+  console.log(`→ ${m.name}`)
+  execFileSync('pnpm', ['--filter', m.name, 'publish', '--tag', tag, '--access', 'public', '--no-git-checks'], {
+    stdio: 'inherit',
+    cwd: root,
+  })
+}
+
+console.log(`\n✔ Published ${manifests.length} packages under "${tag}".`)
+console.log(`  Verify: ${manifests.map((m) => `npm dist-tag ls ${m.name}`).join(' && ')}\n`)


### PR DESCRIPTION
`pnpm release` was:

```
pnpm build && pnpm -r publish --filter './packages/*'
```

No `--tag`. **pnpm defaults to `latest`** — so running it during the alpha would move `latest` off `9.7.0` onto a v10 prerelease, handing an alpha to every plain `npm install @react-three/fiber`. And the version cannot be unpublished.

None of that was visible at the call site. That is what makes it worth fixing rather than documenting.

## Derived, not hardcoded

`--tag alpha` would fix today and break at beta. The channel now comes from the version string:

| version | dist-tag |
| --- | --- |
| `10.0.0-alpha.3` | `alpha` |
| `10.0.0-beta.1` | `beta` |
| `10.0.0-rc.2` | `rc` |
| `10.0.0` | `latest` |

## Guards, verified by running them

**All-stable versions** — the 9.7.0-clobbering scenario:

```
✖ Refusing to publish to "latest".
    @react-three/fiber             10.0.0
    @react-three/test-renderer     10.0.0
    @react-three/eslint-plugin     1.0.0
  If that is genuinely the intent, re-run with --allow-latest.
  exit=1
```

**Mixed channels** — how `latest` moves by accident, since versions are hand-edited:

```
✖ Packages disagree on the release channel...
    @react-three/fiber             10.0.0-alpha.3       -> alpha
    @react-three/test-renderer     10.0.0               -> latest
  exit=1
```

And `pnpm release:dry` prints the plan and publishes nothing:

```
Publishing under dist-tag: alpha  (dry run)
    @react-three/fiber             10.0.0-alpha.3
    @react-three/test-renderer     10.0.0-alpha.3
    @react-three/eslint-plugin     1.0.0-alpha.3
```

fiber publishes first, since the other two declare a peer on it — a partial run then leaves a resolvable tree.

Full suite: **581 passed, 0 failed.**