### PR TITLE
fix(webgpu): make the three Inspector a lazy import to break the Turbopack cycle

### DIFF
--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -1,14 +1,7 @@
-import {
-  WebGLRenderer,
-  WebGPURenderer,
-  Scene,
-  Raycaster,
-  Vector2,
-  Vector3,
-  Inspector,
-  Frustum,
-  SRGBColorSpace,
-} from '#three'
+import { WebGLRenderer, WebGPURenderer, Scene, Raycaster, Vector2, Vector3, Frustum, SRGBColorSpace } from '#three'
+// Type-only: a value import would pull the Inspector into the eager module graph
+// and reintroduce the Turbopack import cycle. See src/three/webgpu.ts (#3846).
+import type { Inspector } from '#three'
 import * as React from 'react'
 import { createWithEqualityFn } from 'zustand/traditional'
 

--- a/packages/fiber/src/three/index.ts
+++ b/packages/fiber/src/three/index.ts
@@ -46,4 +46,14 @@ export { CubeRenderTarget as CubeRenderTargetCompat } from 'three/webgpu'
 export { RenderTarget as RenderTargetCompat } from 'three/webgpu'
 
 //* Addons ==============================
-export { Inspector } from 'three/addons/inspector/Inspector.js'
+// Type-only export plus a lazy loader — a static re-export creates an import
+// cycle (Inspector.js -> three/webgpu -> here) that throws under Turbopack.
+// See https://github.com/pmndrs/react-three-fiber/issues/3846 and the longer
+// note in ./webgpu.ts.
+export type { Inspector } from 'three/addons/inspector/Inspector.js'
+
+/** Lazily load the three Inspector. Keeps it out of the eager module graph — see note above. */
+export async function loadInspector() {
+  const { Inspector } = await import('three/addons/inspector/Inspector.js')
+  return Inspector
+}

--- a/packages/fiber/src/three/legacy.ts
+++ b/packages/fiber/src/three/legacy.ts
@@ -19,11 +19,13 @@ export * from 'three'
 // These prevent type/runtime errors in shared code
 // They should never actually be used in legacy builds
 
-// Inspector doesn't exist in legacy - stub it
-export const Inspector = class Inspector {
-  constructor() {
-    throw new Error('Inspector is not available in legacy builds. Use @react-three/fiber/webgpu instead.')
-  }
+// Inspector doesn't exist in legacy - stub it.
+// Shape must match the other #three barrels: a type plus a lazy loader.
+export type Inspector = never
+
+/** Not available on the legacy (WebGL-only) entry. */
+export async function loadInspector(): Promise<never> {
+  throw new Error('Inspector is not available in legacy builds. Use @react-three/fiber/webgpu instead.')
 }
 
 // WebGPURenderer stub - throws if someone tries to use it

--- a/packages/fiber/src/three/webgpu.ts
+++ b/packages/fiber/src/three/webgpu.ts
@@ -17,7 +17,25 @@ export const R3F_BUILD_WEBGPU = true
 export * from 'three/webgpu'
 
 //* Addons ==============================
-export { Inspector } from 'three/addons/inspector/Inspector.js'
+// Inspector is exported as a TYPE ONLY, plus a lazy loader.
+//
+// A static re-export here would poison the module graph of every consumer:
+// three/addons/inspector/Inspector.js imports { REVISION } from 'three/webgpu',
+// which this file is itself mid-evaluation of. Under Turbopack (the Next.js 16
+// default) that cycle resolves the namespace to undefined and throws
+// "Cannot read properties of undefined (reading 'REVISION')" on import.
+// See https://github.com/pmndrs/react-three-fiber/issues/3846
+//
+// The inspector is opt-in devtooling (state.inspector defaults to null), so it
+// has no business in the eager graph. Anything that wants it must await
+// loadInspector(), which keeps the cycle inside a dynamic import.
+export type { Inspector } from 'three/addons/inspector/Inspector.js'
+
+/** Lazily load the three Inspector. Keeps it out of the eager module graph — see note above. */
+export async function loadInspector() {
+  const { Inspector } = await import('three/addons/inspector/Inspector.js')
+  return Inspector
+}
 
 //* Stubs for legacy-only features ==============================
 // WebGLRenderer stub - throws if someone tries to use it in webgpu-only build

--- a/scripts/verify-bundles.js
+++ b/scripts/verify-bundles.js
@@ -222,6 +222,29 @@ for (const file of EMITTED_JS) {
   }
 }
 
+// A *static* import of the three Inspector creates a cycle that no amount of version-bumping fixes:
+// three/addons/inspector/Inspector.js imports { REVISION } from 'three/webgpu', which is the module
+// our own entry is mid-evaluation of. Turbopack (the Next.js 16 default) resolves the namespace to
+// undefined and the entry throws on import for every consumer, inspector user or not. See #3846.
+//
+// A dynamic `import('three/addons/inspector/Inspector.js')` is fine and is what loadInspector() uses
+// -- this pattern only matches the static forms, so the two stay distinguishable.
+console.log('\n   Static Inspector imports (must be none -- see #3846):')
+for (const file of EMITTED_JS) {
+  const filePath = path.join(FIBER_DIST, file)
+  if (!fs.existsSync(filePath)) continue
+
+  const content = fs.readFileSync(filePath, 'utf-8')
+  const staticInspector = content.match(/(?:from|require\()\s*['"]three\/addons\/inspector\/[^'"]*['"]/)
+  if (staticInspector) {
+    console.log(`   ❌ dist/${file} statically imports ${staticInspector[0]}`)
+    console.log(`      This reintroduces the Turbopack REVISION cycle. Use loadInspector() instead.`)
+    crossCuttingPassed = false
+  } else {
+    console.log(`   ✅ dist/${file}`)
+  }
+}
+
 // Stub .d.ts files embed absolute paths from the machine that generated them.
 const dtsWithLocalPaths = ['index.d.ts', 'legacy.d.ts', 'webgpu/index.d.ts'].filter((file) => {
   const filePath = path.join(FIBER_DIST, file)


### PR DESCRIPTION
Fixes #3846 — **alpha 4 blocker.**

## The problem

`@react-three/fiber/webgpu` could not be imported *at all* under Turbopack (the Next.js 16 default). Every consumer got this at module evaluation, before anything rendered:

```
Cannot read properties of undefined (reading 'REVISION')
```

`src/three/webgpu.ts` statically re-exported the Inspector, and `three/addons/inspector/Inspector.js` imports `{ REVISION }` straight back from `three/webgpu` — the module our own entry is mid-evaluation of. Turbopack resolves the namespace to `undefined` at that point and the read throws. Because it was a top-level re-export, the cycle ran for *everyone*, whether or not they ever touched the inspector. No three version fixes this; `0.185.1` still has it.

## The fix

The Inspector turns out to be pure dead weight in the eager graph:

- it is **not** publicly exported from any package entry (`#three` is internal),
- its only consumer was a **type** position — `store.ts:104`, `null as unknown as Inspector`, and `RootState.inspector` is already declared `any`,
- the sole runtime construction site, `renderer.tsx:326`, is commented out.

So it's exported as a type only, with a `loadInspector()` helper for the eventual wiring — a dynamic `import()` keeps the cycle contained. All three `#three` barrels keep a consistent shape (legacy's loader throws, as its class stub did).

I added the loader rather than just deleting the export so the next person wiring up the inspector has an obvious correct path, instead of re-adding the static import that caused this.

## Verification

No unit test can catch a bundler cycle, so the guard went into `verify-bundles.js` alongside the existing self-import check. It matches only the **static** forms (`from '…'` / `require('…')`), so the dynamic import in `loadInspector()` stays legal.

I confirmed the guard actually fires rather than just passing vacuously — the pre-fix `dist/webgpu/index.mjs` at v10 HEAD contains `from 'three/addons/inspector/Inspector.js'` and the regex matches it.

- `pnpm typecheck` ✅
- `pnpm build` + `pnpm verify-bundles` ✅ (new guard green on all 6 emitted files)
- `pnpm test` ✅ 581 passed, 45 files
- `pnpm eslint` / `pnpm format` ✅

**Side effect:** the WebGPU bundle drops **710.2 KB → 693.6 KB**, since the Inspector was being bundled into every consumer.

## Note for reviewers

This does not wire the inspector up — `state.inspector` still defaults to `null`, exactly as before. It only moves it out of the eager module graph. If you want it functional for alpha 4 that's a separate change, and `loadInspector()` is the hook for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)