### PR TITLE
fix(webgpu): make useRenderPipeline rebuilds recompile and stop leaking the old scenePass

### DIFF
--- a/packages/fiber/src/webgpu/hooks/useRenderPipeline.tsx
+++ b/packages/fiber/src/webgpu/hooks/useRenderPipeline.tsx
@@ -20,6 +20,10 @@ import { pass } from '#three/tsl'
  * - Callbacks receive full RootState for flexibility
  * - No auto-cleanup on unmount - use reset() for explicit cleanup
  * - Scene/camera changes trigger scenePass recreation
+ * - A replaced scenePass is disposed once the new graph is installed, so rebuild() does not
+ *   strand its render target (and MRT attachments) on the GPU
+ * - Any run that changes the output node sets RenderPipeline.needsUpdate, so rebuild() actually
+ *   recompiles instead of silently keeping the first compiled graph
  *
  * @param mainCB - Main callback to configure outputNode and create effect passes
  * @param setupCB - Optional setup callback to configure MRT on scenePass
@@ -63,6 +67,12 @@ export function useRenderPipeline(
   // Recreating scenePass triggers TSL node graph rebuild which can corrupt SkinningNode refs
   const scenePassCacheRef = useRef<{ sceneUuid: string; cameraUuid: string; scenePass: any } | null>(null)
 
+  // Force scenePass recreation on the next effect run, without dropping the reference to the
+  // outgoing pass. Clearing scenePassCacheRef directly would strand it: three does not free
+  // render-target GPU memory on JS garbage collection, and once the ref is gone neither we nor
+  // the app can dispose it. Keeping the ref lets the effect dispose it after the swap. See #3854.
+  const forceScenePassRebuildRef = useRef(false)
+
   // Store callbacks in refs to avoid useEffect re-running on every render
   // (inline callbacks get new references each render)
   const mainCBRef = useRef(mainCB)
@@ -77,7 +87,10 @@ export function useRenderPipeline(
   // React preserves component identity during HMR but refs keep stale values
   useEffect(() => {
     callbacksRanRef.current = false
-    scenePassCacheRef.current = null
+    // Flag rather than clearing the cache: this runs *after* the layout effect has already
+    // created and installed a scenePass, so dropping the ref here would leak exactly the pass
+    // that is currently live. The flag makes the next run recreate and dispose it properly.
+    forceScenePassRebuildRef.current = true
   }, [])
 
   //* Cleanup Functions ==============================
@@ -91,14 +104,21 @@ export function useRenderPipeline(
       renderPipeline: null,
       passes: {},
     })
+    // Safe to dispose synchronously here: the pipeline is torn down in the same tick, so nothing
+    // is left referencing the pass. This is explicit user-requested cleanup.
+    scenePassCacheRef.current?.scenePass?.dispose?.()
     callbacksRanRef.current = false
     scenePassCacheRef.current = null
+    forceScenePassRebuildRef.current = false
   }, [store])
 
   // Force re-run of setup/main callbacks with current closure values
   const rebuild = useCallback(() => {
     callbacksRanRef.current = false // Allow callbacks to run again
-    scenePassCacheRef.current = null // Force new scenePass
+    // Deliberately NOT disposing here. The pipeline keeps rendering the current graph until the
+    // layout effect swaps it, so disposing now would leave the live graph pointing at a freed
+    // render target. The effect disposes the outgoing pass once the new one is installed.
+    forceScenePassRebuildRef.current = true // Force new scenePass
     setRebuildVersion((v) => v + 1)
   }, [])
 
@@ -132,21 +152,37 @@ export function useRenderPipeline(
       // Only recreate scenePass if scene/camera actually changed
       // Unnecessary recreation triggers TSL node graph rebuild which corrupts SkinningNode refs
       const cacheValid =
+        !forceScenePassRebuildRef.current &&
         scenePassCacheRef.current &&
         scenePassCacheRef.current.sceneUuid === scene.uuid &&
         scenePassCacheRef.current.cameraUuid === camera.uuid
+
+      // The pass being replaced, if any. Disposed at the end of this effect, once the new graph
+      // is installed -- never before, or the pipeline would render against a freed target.
+      let outgoingScenePass: any = null
 
       let scenePass
       if (cacheValid) {
         scenePass = scenePassCacheRef.current!.scenePass
       } else {
+        outgoingScenePass = scenePassCacheRef.current?.scenePass ?? null
         scenePass = pass(scene, camera)
         scenePassCacheRef.current = { sceneUuid: scene.uuid, cameraUuid: camera.uuid, scenePass }
+        forceScenePassRebuildRef.current = false
       }
       currentPasses.scenePass = scenePass
 
-      // Set default outputNode (passthrough) if not configured or if we just created the pipeline
-      if (!pipeline.outputNode || justCreatedPipeline) pipeline.outputNode = scenePass
+      // Whether the node graph changed this run and the pipeline must recompile. See #3853.
+      let outputNodeChanged = false
+
+      // Set default outputNode (passthrough) if not configured, if we just created the pipeline,
+      // or if it still points at the pass we are about to replace. That last case matters when
+      // there is no mainCB, or mainCB does not assign outputNode: the default passthrough has to
+      // follow the new scenePass, otherwise we would dispose the pass the pipeline still renders.
+      if (!pipeline.outputNode || justCreatedPipeline || pipeline.outputNode === outgoingScenePass) {
+        pipeline.outputNode = scenePass
+        outputNodeChanged = true
+      }
 
       // Update state with the pipeline and initial scenePass
       set({ renderPipeline: pipeline, passes: currentPasses })
@@ -184,9 +220,25 @@ export function useRenderPipeline(
           }
         }
 
+        // The callbacks exist to assign pipeline.outputNode (see this hook's own JSDoc examples),
+        // so treat any run as a graph change.
+        outputNodeChanged = true
+
         // Mark callbacks as run so we don't re-run on HMR
         callbacksRanRef.current = true
       }
+
+      // three's RenderPipeline only recompiles its present-quad material inside _update() when
+      // needsUpdate is true, and documents the property as "Must be set to true when the output
+      // node changes." It starts true on construction, so the FIRST graph compiled fine and every
+      // later assignment -- i.e. everything driven by rebuild() -- was silently ignored: the
+      // callbacks ran, the assignment happened, the GPU never saw it. See #3853.
+      if (outputNodeChanged) pipeline.needsUpdate = true
+
+      // Now that the new graph is installed and compiled, the replaced pass is unreachable.
+      // three does not free render-target GPU memory on GC, so without this every rebuild()
+      // stranded a full-screen target per MRT attachment. See #3854.
+      if (outgoingScenePass && outgoingScenePass !== scenePass) outgoingScenePass.dispose?.()
     } catch (error) {
       // Surfaced rather than rethrown: throwing here would take down the whole tree for what is
       // usually a recoverable pass-configuration mistake. Logged loudly so a failed pipeline

--- a/packages/fiber/tests/webgpu/webgpu-hooks-lifecycle.test.tsx
+++ b/packages/fiber/tests/webgpu/webgpu-hooks-lifecycle.test.tsx
@@ -546,8 +546,107 @@ describe('useRenderPipeline — pipeline wiring against the store', () => {
     errSpy.mockRestore()
   })
 
+  //* rebuild(): recompile + disposal ==============================
+  // Regressions for #3853 (rebuilds never reached the GPU) and #3854 (rebuilds leaked the
+  // outgoing scenePass). Both are lifecycle-observable, so they belong in Tier 1: `needsUpdate`
+  // is a plain boolean three reads in _update(), and dispose() is a plain method call.
+
+  /** Mount the hook and hand back the api + store. */
+  async function mountPipeline(mainCB: RenderPipelineMainCallback = () => {}) {
+    const store = makeStore()
+    seedRenderer(store)
+    let api!: ReturnType<typeof useRenderPipeline>
+    function Comp() {
+      api = useRenderPipeline(mainCB)
+      return null
+    }
+    await act(async () => withStore(store, <Comp />))
+    return { store, api: () => api }
+  }
+
+  it('rebuild(): sets needsUpdate so the new output node actually recompiles', async () => {
+    const { store, api } = await mountPipeline()
+    const pipeline = store.getState().renderPipeline as any
+
+    // Stand in for a frame having been rendered: three's _update() clears needsUpdate once it
+    // has compiled the present-quad material. Without the fix it stays false forever after.
+    pipeline.needsUpdate = false
+
+    await act(async () => api().rebuild())
+
+    expect(store.getState().renderPipeline).toBe(pipeline)
+    expect(pipeline.needsUpdate).toBe(true)
+  })
+
+  it('rebuild(): disposes the replaced scenePass instead of stranding its render target', async () => {
+    const { store, api } = await mountPipeline()
+    const firstPass = store.getState().passes.scenePass as any
+    const disposeSpy = vi.spyOn(firstPass, 'dispose')
+
+    await act(async () => api().rebuild())
+
+    const secondPass = store.getState().passes.scenePass as any
+    expect(secondPass).not.toBe(firstPass)
+    expect(disposeSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('rebuild(): repoints a default passthrough outputNode at the new scenePass', async () => {
+    // With no mainCB assigning outputNode, the pipeline still references the pass being
+    // replaced. Disposing it without repointing would leave the pipeline rendering a freed
+    // render target -- worse than the leak being fixed.
+    const { store, api } = await mountPipeline()
+    const pipeline = store.getState().renderPipeline as any
+    const firstPass = store.getState().passes.scenePass as any
+    expect(pipeline.outputNode).toBe(firstPass)
+
+    await act(async () => api().rebuild())
+
+    const secondPass = store.getState().passes.scenePass as any
+    expect(pipeline.outputNode).toBe(secondPass)
+    expect(pipeline.outputNode).not.toBe(firstPass)
+  })
+
+  it('does not dispose the scenePass on a re-render that reuses it', async () => {
+    const store = makeStore()
+    seedRenderer(store)
+    function Comp() {
+      useRenderPipeline(() => {})
+      return null
+    }
+    let rerender!: (ui: React.ReactElement) => void
+    await act(async () => {
+      ;({ rerender } = withStore(store, <Comp />))
+    })
+    const scenePass = store.getState().passes.scenePass as any
+    const disposeSpy = vi.spyOn(scenePass, 'dispose')
+
+    await act(async () =>
+      rerender(
+        <context.Provider value={store}>
+          <Comp />
+        </context.Provider>,
+      ),
+    )
+
+    expect(store.getState().passes.scenePass).toBe(scenePass)
+    expect(disposeSpy).not.toHaveBeenCalled()
+  })
+
+  it('reset(): disposes the scenePass it drops', async () => {
+    const { store, api } = await mountPipeline()
+    const scenePass = store.getState().passes.scenePass as any
+    const disposeSpy = vi.spyOn(scenePass, 'dispose')
+
+    await act(async () => api().reset())
+
+    expect(disposeSpy).toHaveBeenCalledTimes(1)
+    expect(store.getState().renderPipeline).toBeNull()
+  })
+
   // The render loop actually calling state.renderPipeline.render() each frame,
   // and that call producing correct post-processed output, both need a real device.
   it.todo('covered by Tier 2: default render loop delegates to state.renderPipeline.render() each frame')
   it.todo('covered by Tier 2: renderPipeline / scenePass produce correct post-processed output')
+  // Tier 1 proves needsUpdate flips; that the recompiled graph reaches the GPU needs a device.
+  it.todo('covered by Tier 2: rebuild() output node change is visible in rendered output')
 })


### PR DESCRIPTION
Fixes #3853, fixes #3854.

Combined because they're the same effect and they compound — as #3854 notes, once rebuilds actually take effect, `rebuild()`-heavy workflows become common and the leak starts to matter in practice.

## #3853 — rebuilds never reached the GPU

three's `RenderPipeline` only recompiles its present-quad material inside `_update()` when `needsUpdate` is true, and documents the property as *"Must be set to `true` when the output node changes."* It starts `true` on construction, so the **first** graph compiled fine and every later `outputNode` assignment was silently ignored — the callbacks ran, the assignment happened, the pipeline kept rendering the first graph forever.

Any UI-driven reconfiguration (leva toggles, effect on/off, quality settings) appeared to do nothing, with no error or warning. Now any run that changes the output node sets `needsUpdate`.

I verified this against `three@0.185.1` source rather than taking it on trust: `RenderPipeline.js:73` sets it true on construction, `:195` gates the recompile, `:228` clears it.

## #3854 — `rebuild()` stranded the outgoing scenePass

Each rebuild created a new `pass(scene, camera)` and dropped the previous one — render target and every MRT attachment included. three does not free render-target GPU memory on JS GC, so an app with effect toggles leaked linearly with toggle count.

## The subtle part: disposal timing

Disposing inside `rebuild()` — the literal suggestion in #3854 — would free the target **while the pipeline is still rendering the current graph**. The pipeline only swaps when the layout effect runs.

So instead of clearing `scenePassCacheRef`, the rebuild paths now set a flag, keeping the outgoing reference alive until the layout effect can dispose it *after* the new graph is installed.

The same reasoning applies to the mount-time HMR effect. It runs *after* the layout effect has already created and installed a pass, so clearing the ref there was leaking precisely the pass that was live. It sets the flag now too.

`reset()` still disposes synchronously — it nulls the pipeline in the same tick, so nothing is left referencing the pass, and it's explicit user-requested cleanup.

## A hazard the fix introduced, and the fix for it

Worth a close look in review. With **no `mainCB`**, or a `mainCB` that doesn't assign `outputNode`, the pipeline still pointed at the pass being replaced — the default passthrough assigned at creation. Disposing it would have left the pipeline rendering a *freed* render target, which is strictly worse than the leak being fixed.

The default passthrough now follows the new scenePass. There's a dedicated test for it.

## Testing

Five Tier 1 tests, matching the existing convention in this file — `needsUpdate` is a plain boolean and `dispose()` a plain method call, both observable without a device.

I confirmed the four regression tests genuinely fail on the pre-fix hook rather than passing vacuously:

```
× rebuild(): sets needsUpdate so the new output node actually recompiles
× rebuild(): disposes the replaced scenePass instead of stranding its render target
× rebuild(): repoints a default passthrough outputNode at the new scenePass
× reset(): disposes the scenePass it drops
```

The fifth (`does not dispose the scenePass on a re-render that reuses it`) passes both ways by design — it guards against over-disposal, so it should never have been failing.

Whether the recompiled graph actually reaches the GPU is Tier 2 and marked `it.todo`.

- `pnpm test` ✅ 586 passed (was 581), 45 files
- `pnpm typecheck` / `pnpm eslint` / `pnpm format` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)