### PR TITLE
fix(webgpu): give scoped TSL resources valid WGSL identifiers

### DIFF
--- a/packages/fiber/src/webgpu/hooks/useBuffers.tsx
+++ b/packages/fiber/src/webgpu/hooks/useBuffers.tsx
@@ -5,6 +5,7 @@ import { usePrimaryStore, usePrimaryThree } from '../../core/hooks/usePrimarySto
 import { clearResourceEntries, rebuildResource, removeResourceEntries } from '../../core/utils/resourceRegistry'
 import { createLazyCreatorState, type CreatorState } from './ScopedStore'
 import { useScopedResource } from './useScopedResource'
+import { scopedNodeName } from './utils'
 import type { BufferLike, BufferRecord } from '#types'
 
 //* Types ==============================
@@ -205,7 +206,7 @@ export function useBuffers<T extends Record<string, BufferLike>>(
     prepare: (name, buffer) => {
       // Apply label for debugging if it's a TSL node
       if ('setName' in buffer && typeof buffer.setName === 'function') {
-        buffer.setName(scope ? `${scope}.${name}` : name)
+        buffer.setName(scopedNodeName(scope, name))
       }
       return buffer
     },

--- a/packages/fiber/src/webgpu/hooks/useGPUStorage.tsx
+++ b/packages/fiber/src/webgpu/hooks/useGPUStorage.tsx
@@ -5,6 +5,7 @@ import { usePrimaryStore, usePrimaryThree } from '../../core/hooks/usePrimarySto
 import { clearResourceEntries, rebuildResource, removeResourceEntries } from '../../core/utils/resourceRegistry'
 import { createLazyCreatorState, type CreatorState } from './ScopedStore'
 import { useScopedResource } from './useScopedResource'
+import { scopedNodeName } from './utils'
 import type { StorageLike, StorageRecord } from '#types'
 
 //* Types ==============================
@@ -205,7 +206,7 @@ export function useGPUStorage<T extends Record<string, StorageLike>>(
       return (creatorOrScope as StorageCreator<T>)(createLazyCreatorState(store.getState(), store))
     },
     prepare: (name, storage) => {
-      const label = scope ? `${scope}.${name}` : name
+      const label = scopedNodeName(scope, name)
       // Apply label for debugging if it's a TSL node
       if ('setName' in storage && typeof storage.setName === 'function') {
         storage.setName(label)

--- a/packages/fiber/src/webgpu/hooks/useNodes.tsx
+++ b/packages/fiber/src/webgpu/hooks/useNodes.tsx
@@ -4,6 +4,7 @@ import { usePrimaryStore, usePrimaryThree } from '../../core/hooks/usePrimarySto
 import { clearResourceEntries, rebuildResource, removeResourceEntries } from '../../core/utils/resourceRegistry'
 import { createLazyCreatorState, type CreatorState } from './ScopedStore'
 import { useScopedResource } from './useScopedResource'
+import { scopedNodeName } from './utils'
 
 //* Types ==============================
 
@@ -165,7 +166,7 @@ export function useNodes<T extends Record<string, TSLNodeLike>>(
     },
     prepare: (name, node) => {
       // Apply label for debugging
-      node.setName?.(scope ? `${scope}.${name}` : name)
+      node.setName?.(scopedNodeName(scope, name))
       return node
     },
   })

--- a/packages/fiber/src/webgpu/hooks/useUniforms.tsx
+++ b/packages/fiber/src/webgpu/hooks/useUniforms.tsx
@@ -3,7 +3,7 @@ import { useStore } from '../../core/hooks'
 import { usePrimaryStore, usePrimaryThree } from '../../core/hooks/usePrimaryStore'
 import * as THREE from '#three'
 import { uniform } from '#three/tsl'
-import { vectorize } from './utils'
+import { vectorize, scopedNodeName } from './utils'
 import { useCompareMemoize } from './useCompareMemoize'
 import { is } from '../../core/utils'
 import { clearResourceEntries, rebuildResource, removeResourceEntries } from '../../core/utils/resourceRegistry'
@@ -354,11 +354,10 @@ function createUniform(inName: string, node: any, scope?: string): UniformNode {
   // overloads are a closed set that R3F's wider (already-normalised) input can't select from.
   const newUniform = (uniform as (value: unknown, type?: string) => UniformNode)(inValue)
 
-  // Set debug name for easier identification in GPU tools
-  // Use underscore instead of dot to ensure WGSL compatibility
+  // Set debug name for easier identification in GPU tools.
+  // Shares scopedNodeName with the other resource hooks so the separator cannot drift again.
   if (typeof newUniform.setName === 'function') {
-    const name = scope ? `${scope}_${inName}` : inName
-    newUniform.setName(name)
+    newUniform.setName(scopedNodeName(scope, inName))
   }
 
   return newUniform

--- a/packages/fiber/src/webgpu/hooks/utils.ts
+++ b/packages/fiber/src/webgpu/hooks/utils.ts
@@ -70,6 +70,37 @@ export function createTextureOperations(set: StoreApi<RootState>['setState']): T
   }
 }
 
+//* Scoped Node Naming ==============================
+
+/**
+ * Builds the debug/identifier name for a scoped TSL resource.
+ *
+ * This is not cosmetic. three derives WGSL struct names straight from the node name, so the
+ * name has to be a valid WGSL identifier — `[A-Za-z_][A-Za-z0-9_]*`. A scope separator of `.`
+ * lands a dot inside a declaration and every shader touching the resource fails to parse:
+ *
+ * ```wgsl
+ * struct flipGrid.tilesStruct {
+ *                ^ error: expected '{' for struct declaration
+ * ```
+ *
+ * Hence `_` as the separator, plus a sanitising pass — scope and key names can come from user
+ * data (leva labels, dynamic keys), so swapping the separator alone is not sufficient.
+ *
+ * @see https://github.com/pmndrs/react-three-fiber/issues/3848
+ *
+ * @example
+ * scopedNodeName('flipGrid', 'tiles') // => 'flipGrid_tiles'
+ * scopedNodeName(undefined, 'tiles')  // => 'tiles'
+ * scopedNodeName('my sim', 'a-b')     // => 'my_sim_a_b'
+ * scopedNodeName(undefined, '2d')     // => '_2d'   (WGSL identifiers cannot start with a digit)
+ */
+export function scopedNodeName(scope: string | undefined, name: string): string {
+  const raw = scope ? `${scope}_${name}` : name
+  const safe = raw.replace(/[^A-Za-z0-9_]/g, '_')
+  return /^[A-Za-z_]/.test(safe) ? safe : `_${safe}`
+}
+
 //* TSL Node Value Extraction ==============================
 // Extracts actual values from TSL ConstNodes (color(), vec3(), float(), etc.)
 // This mirrors what Three.js's uniform() function does internally.

--- a/packages/fiber/tests/webgpu/webgpu-hooks-lifecycle.test.tsx
+++ b/packages/fiber/tests/webgpu/webgpu-hooks-lifecycle.test.tsx
@@ -29,7 +29,7 @@ import * as React from 'react'
 import { act } from 'react'
 import { render } from '@testing-library/react'
 import * as THREE from 'three/webgpu'
-import { color, vec3, float, instancedArray } from 'three/tsl'
+import { color, vec3, float, instancedArray, uniform } from 'three/tsl'
 
 import { createStore, context } from '../../src/core/store'
 import {
@@ -428,6 +428,121 @@ describe('useGPUStorage — lifecycle against the store', () => {
     expect(store.getState().gpuStorage.heightMap).toBeDefined()
     expect(store.getState().gpuStorage.heightMap).not.toBe(tex0)
   })
+})
+
+//* Scoped resource naming ==============================
+
+describe('scoped resource names are valid WGSL identifiers', () => {
+  /**
+   * Regression for #3848. three builds WGSL struct names by concatenation --
+   * `WGSLNodeBuilder._getWGSLStructBinding` does `const structName = name + 'Struct'` and is fed
+   * the node's own name -- so a `.` separator lands inside a declaration:
+   *
+   *     struct flipGrid.tilesStruct {
+   *                    ^ error: expected '{' for struct declaration
+   *
+   * and every shader touching the resource fails to compile. jsdom cannot run the WGSL parser,
+   * so this asserts the property the parser needs: the name three will interpolate is a legal
+   * WGSL identifier. Tier 2 covers the shader actually compiling.
+   */
+  const WGSL_IDENT = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+  // Only some node classes carry a name (UniformNode, ComputeNode, StorageBufferNode, ...); the
+  // base Node has no setName, so useNodes' `setName?.()` is a deliberate no-op for e.g. ConstNodes
+  // like vec3(). These tests use node types that can actually hold a name.
+
+  it('useNodes: scoped node name has no dot', async () => {
+    const store = makeStore()
+    function Comp() {
+      useNodes(() => ({ tiles: uniform(1) }), 'flipGrid')
+      return null
+    }
+    await act(async () => withStore(store, <Comp />))
+
+    const node = (store.getState().nodes.flipGrid as any).tiles
+    expect(node.name).toBe('flipGrid_tiles')
+    expect(node.name).toMatch(WGSL_IDENT)
+  })
+
+  it('useBuffers: scoped buffer name has no dot', async () => {
+    const store = makeStore()
+    function Comp() {
+      useBuffers(() => ({ pos: instancedArray(4, 'vec2') }), 'particles')
+      return null
+    }
+    await act(async () => withStore(store, <Comp />))
+
+    const buf = (store.getState().buffers.particles as any).pos
+    expect(buf.name).toBe('particles_pos')
+    expect(buf.name).toMatch(WGSL_IDENT)
+  })
+
+  it('useGPUStorage: scoped storage name has no dot', async () => {
+    const store = makeStore()
+    function Comp() {
+      useGPUStorage(() => ({ tiles: instancedArray(16, 'vec4') }), 'flipGrid')
+      return null
+    }
+    await act(async () => withStore(store, <Comp />))
+
+    const storage = (store.getState().gpuStorage.flipGrid as any).tiles
+    expect(storage.name).toBe('flipGrid_tiles')
+    expect(storage.name).toMatch(WGSL_IDENT)
+  })
+
+  it('useUniforms: keeps its already-correct underscore form', async () => {
+    const store = makeStore()
+    function Comp() {
+      useUniforms({ uHealth: 100 }, 'player')
+      return null
+    }
+    await act(async () => withStore(store, <Comp />))
+
+    const node = (store.getState().uniforms.player as any).uHealth
+    expect(node.name).toBe('player_uHealth')
+    expect(node.name).toMatch(WGSL_IDENT)
+  })
+
+  it('sanitises characters that are legal in a JS key but not in WGSL', async () => {
+    // Scope and key names can come from user data (leva labels, dynamic keys), so swapping the
+    // separator alone is not enough to guarantee a parseable identifier.
+    const store = makeStore()
+    function Comp() {
+      useGPUStorage(() => ({ 'a-b': instancedArray(4, 'vec4') }), 'my sim')
+      return null
+    }
+    await act(async () => withStore(store, <Comp />))
+
+    const node = (store.getState().gpuStorage['my sim'] as any)['a-b']
+    expect(node.name).toBe('my_sim_a_b')
+    expect(node.name).toMatch(WGSL_IDENT)
+  })
+
+  it('prefixes a leading digit, which WGSL identifiers cannot start with', async () => {
+    const store = makeStore()
+    function Comp() {
+      useGPUStorage(() => ({ '2d': instancedArray(4, 'vec4') }))
+      return null
+    }
+    await act(async () => withStore(store, <Comp />))
+
+    const node = (store.getState().gpuStorage as any)['2d']
+    expect(node.name).toBe('_2d')
+    expect(node.name).toMatch(WGSL_IDENT)
+  })
+
+  it('leaves unscoped, already-valid names untouched', async () => {
+    const store = makeStore()
+    function Comp() {
+      useGPUStorage(() => ({ tiles: instancedArray(4, 'vec4') }))
+      return null
+    }
+    await act(async () => withStore(store, <Comp />))
+
+    expect((store.getState().gpuStorage as any).tiles.name).toBe('tiles')
+  })
+
+  it.todo('covered by Tier 2: a scoped storage buffer compiles and runs in a real WGSL shader')
 })
 
 //* useRenderPipeline ==============================


### PR DESCRIPTION
Fixes #3848.

## The bug

`useGPUStorage`, `useBuffers` and `useNodes` named scoped resources `` `${scope}.${name}` ``. three builds WGSL struct names by plain concatenation — `WGSLNodeBuilder._getWGSLStructBinding` does `const structName = name + 'Struct'` ([`WGSLNodeBuilder.js:2669`](https://github.com/mrdoob/three.js/blob/dev/src/renderers/webgpu/nodes/WGSLNodeBuilder.js), fed the node's own name at `:2166`) — so the dot landed inside a declaration:

```wgsl
struct flipGrid.tilesStruct {
               ^ error: expected '{' for struct declaration
```

Vertex, fragment and compute modules all failed the same way, so nothing using the buffer rendered at all.

`useUniforms` already used `_` and worked — the paths had simply drifted apart.

## The fix

Rather than patch three separators independently and leave them free to drift again, they now share a `scopedNodeName` helper — **including `useUniforms`**, which is why that call site changes too even though it wasn't broken.

The helper **sanitises rather than just swapping the separator**. #3848 offered either as alternatives; sanitising is the one that actually holds, because scope and key names can come from user data (leva labels, dynamic keys) and `_` alone doesn't guarantee a parseable identifier. Anything outside `[A-Za-z0-9_]` is replaced, and a leading digit gets prefixed (`'2d'` → `'_2d'`) since WGSL identifiers can't start with one.

## Scope note

The issue named `useGPUStorage` and `useBuffers`. **`useNodes` had the same bug** ([`useNodes.tsx:168`](packages/fiber/src/webgpu/hooks/useNodes.tsx#L168)) and is included here.

I also confirmed these labels are write-only — nothing parses them back apart from an unrelated file-extension split in `useEnvironment` — so changing the format is safe.

## Testing

Seven Tier 1 tests asserting the property the WGSL parser needs: the name three will interpolate is a legal identifier. jsdom can't run the parser, so shader compilation itself is marked `it.todo` for Tier 2.

Confirmed the five regression tests fail on pre-fix source, with the bug visible verbatim:

```
AssertionError: expected 'flipGrid.tiles' to be 'flipGrid_tiles'
AssertionError: expected 'particles.pos'  to be 'particles_pos'
AssertionError: expected 'my sim.a-b'     to be 'my_sim_a_b'
AssertionError: expected '2d'             to be '_2d'
```

The other two (uniforms keeping its underscore form, unscoped names untouched) pass both ways by design — they're guards against the fix overreaching.

One thing worth knowing if you extend these tests: only some node classes carry a name. The base `Node` has no `setName`, so `useNodes`' `setName?.()` is a deliberate no-op for `ConstNode`s like `vec3()`. The tests use node types that can actually hold one.

- `pnpm test` ✅ 588 passed (was 581), 45 files
- `pnpm typecheck` / `pnpm eslint` / `pnpm format` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)