### PR TITLE
fix(core): stop useTexture's array/record forms looping forever

### DIFF
--- a/packages/fiber/src/core/hooks/useLoader.tsx
+++ b/packages/fiber/src/core/hooks/useLoader.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import { suspend, preload, clear } from 'suspend-react'
 import { buildGraph, is, isObject3D } from '../utils'
 
@@ -93,8 +94,30 @@ export function useLoader<I extends InputLike, L extends LoaderLike | Constructo
     suspend(() => fn(loader, inputs[index]), [loader, key], { equal: is.equ }),
   )
 
+  // Keep the array's identity stable while its contents are unchanged.
+  //
+  // `.map()` builds a fresh array every render, and callers routinely use the result as an effect
+  // dependency. Any such effect that also writes to the store becomes an infinite render loop:
+  // effect -> setState -> re-render -> new array identity -> effect. That is #3849, which
+  // useTexture hit through its registry effect.
+  //
+  // Shallow-compared rather than keyed on the cache keys, because `useLoader.clear()` can hand
+  // back new objects for the *same* keys and that invalidation still has to propagate. Comparing
+  // the resolved values means a genuine change always yields a new identity, and an incidental
+  // re-render never does.
+  //
+  // The render-phase ref write is idempotent — given equal contents it always settles on the same
+  // array — so it is safe under StrictMode's double render.
+  const stableRef = useRef<unknown[] | null>(null)
+  const previous = stableRef.current
+  const stable =
+    previous !== null && previous.length === results.length && previous.every((value, i) => value === results[i])
+      ? previous
+      : results
+  stableRef.current = stable
+
   // Return the object(s)
-  return (Array.isArray(input) ? results : results[0]) as I extends any[] ? LoaderResult<L>[] : LoaderResult<L>
+  return (Array.isArray(input) ? stable : stable[0]) as I extends any[] ? LoaderResult<L>[] : LoaderResult<L>
 }
 
 /**

--- a/packages/fiber/src/core/hooks/useLoader.tsx
+++ b/packages/fiber/src/core/hooks/useLoader.tsx
@@ -106,8 +106,23 @@ export function useLoader<I extends InputLike, L extends LoaderLike | Constructo
   // the resolved values means a genuine change always yields a new identity, and an incidental
   // re-render never does.
   //
-  // The render-phase ref write is idempotent — given equal contents it always settles on the same
-  // array — so it is safe under StrictMode's double render.
+  // Only the wrapper array is stabilised. The elements come from the suspend cache, which returns
+  // one object per key process-wide, so two components loading the same URLs still share the very
+  // same loaded assets — they just hold different arrays around them.
+  //
+  // A useMemo cannot express this: its dep array would have to be `results` itself, and React
+  // throws when a dep array changes length — which happens as soon as the URL count does.
+  //
+  // On writing a ref during render, which React discourages: this is a content-keyed cache, not
+  // state. `previous` is only ever returned when it is element-wise equal to the `results` just
+  // computed, so the value handed back is correct no matter which render populated the ref. An
+  // abandoned or interrupted concurrent render can therefore only leave behind an array that the
+  // next render replaces — it cannot produce a stale or wrong result — and StrictMode's double
+  // render settles on the same array both times. Nothing outside this call can observe the write.
+  //
+  // NOTE: this is the first hook in useLoader. `suspend()` is a cache-and-throw, not a hook, so
+  // until now useLoader could be called conditionally despite its name. That was always a
+  // rules-of-hooks violation and lint has always flagged it; it merely happened to work.
   const stableRef = useRef<unknown[] | null>(null)
   const previous = stableRef.current
   const stable =

--- a/packages/fiber/src/core/hooks/useTexture.tsx
+++ b/packages/fiber/src/core/hooks/useTexture.tsx
@@ -45,6 +45,20 @@ function getUrls(input: string | string[] | Record<string, string>): string[] {
   return Object.values(input)
 }
 
+/**
+ * A value-equal signature for any input form, used to key memos off the input's *contents*
+ * rather than its reference. The record form includes its keys: two records can share the same
+ * URLs while mapping them to different names, and those are not interchangeable.
+ */
+function inputSignature(input: string | string[] | Record<string, string>): string {
+  if (typeof input === 'string') return input
+  if (Array.isArray(input)) return input.join('\0')
+  return Object.keys(input)
+    .sort()
+    .map((key) => `${key}\0${input[key]}`)
+    .join('\u0001')
+}
+
 /** Check if all URLs exist in the texture cache */
 function allUrlsCached(urls: string[], textureCache: Map<string, any>): boolean {
   return urls.every((url) => textureCache.has(url))
@@ -128,30 +142,41 @@ export function useTexture<Url extends string[] | string | Record<string, string
   // Track which input we've already called onLoad for (prevents duplicate calls on re-render)
   const onLoadCalledForRef = useRef<string | null>(null)
 
+  //* Identity-stable view of `input` --
+  // Callers routinely pass an inline literal — useTexture(['/a.png', '/b.png']) or
+  // useTexture({ map: '/a.png' }) — so `input` is a fresh reference on every render. Everything
+  // below keys off `inputKey` (a value, so it compares by equality) and `stableInput` instead of
+  // the raw reference. Without this the registry effect re-runs every render and its setState
+  // re-renders every store subscriber, which feed each other until React bails out with
+  // "Maximum update depth exceeded" (#3849). Hoisting the argument to a module constant did not
+  // help, because the instability was never only in `input`.
+  const inputKey = useMemo(() => inputSignature(input), [input])
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on the value, not the reference
+  const stableInput = useMemo(() => input, [inputKey])
+
   //* Check the registry once at mount (non-reactive) --
   // If all requested textures are already registered, use those (preserves modifications). We read
   // the registry imperatively rather than subscribing, so a mounted useTexture never re-renders on a
   // registry change — loading texture A can't re-render a component using texture B.
-  const urls = useMemo(() => getUrls(input), [input])
+  const urls = useMemo(() => getUrls(stableInput), [stableInput])
 
   const cachedResult = useMemo(() => {
     if (!cache) return null
     const textures = store.getState().textures
     if (!allUrlsCached(urls, textures)) return null
-    return buildFromCache(input, textures)
+    return buildFromCache(stableInput, textures)
     // Intentionally not keyed on the registry contents — this is a one-time read at mount (per input).
-  }, [cache, urls, input, store])
+  }, [cache, urls, stableInput, store])
 
   //* Load via useLoader (handles suspense) --
   // This always runs to maintain hooks order, but we may not use the result
   const loadedTextures = useLoader(
     TextureLoader,
-    IsObject(input) ? Object.values(input) : input,
+    IsObject(stableInput) ? Object.values(stableInput) : stableInput,
   ) as MappedTextureType<Url>
 
   // Call onLoad when textures are ready (only on initial load, not cache hits)
-  // Use a stable key based on URLs to prevent duplicate calls on re-render
-  const inputKey = urls.join('\0')
+  // Keyed on inputKey (computed above) so repeat renders don't re-fire the callback
   useLayoutEffect(() => {
     if (cachedResult) return
     if (onLoadCalledForRef.current === inputKey) return
@@ -189,16 +214,16 @@ export function useTexture<Url extends string[] | string | Record<string, string
     // If we have cached result, it's already in the right format
     if (cachedResult) return cachedResult
 
-    if (IsObject(input)) {
+    if (IsObject(stableInput)) {
       const keyed = {} as Record<string, _Texture>
       const textureArray = loadedTextures as _Texture[]
       let i = 0
-      for (const key in input) keyed[key] = textureArray[i++]
+      for (const key in stableInput) keyed[key] = textureArray[i++]
       return keyed as TextureRecord<Url>
     } else {
       return loadedTextures
     }
-  }, [input, loadedTextures, cachedResult])
+  }, [stableInput, loadedTextures, cachedResult])
 
   //* Register in the texture cache + refcount while mounted --
   // Adds missing textures and retains them so useTextures().dispose() is safe; releases on unmount.
@@ -209,15 +234,15 @@ export function useTexture<Url extends string[] | string | Record<string, string
     // Build URL → texture mapping (works for cache hits and fresh loads; mappedTextures is final either way)
     const urlTextureMap: Array<[string, _Texture]> = []
 
-    if (typeof input === 'string') {
-      urlTextureMap.push([input, mappedTextures as _Texture])
-    } else if (Array.isArray(input)) {
+    if (typeof stableInput === 'string') {
+      urlTextureMap.push([stableInput, mappedTextures as _Texture])
+    } else if (Array.isArray(stableInput)) {
       const textureArray = mappedTextures as _Texture[]
-      input.forEach((url, i) => urlTextureMap.push([url, textureArray[i]]))
-    } else if (IsObject(input)) {
+      stableInput.forEach((url, i) => urlTextureMap.push([url, textureArray[i]]))
+    } else if (IsObject(stableInput)) {
       const textureRecord = mappedTextures as Record<string, _Texture>
-      for (const key in input) {
-        const url = input[key]
+      for (const key in stableInput) {
+        const url = stableInput[key]
         urlTextureMap.push([url, textureRecord[key]])
       }
     }
@@ -253,7 +278,7 @@ export function useTexture<Url extends string[] | string | Record<string, string
         }
         return { _textureRefs: refs }
       })
-  }, [cache, input, mappedTextures, store])
+  }, [cache, stableInput, mappedTextures, store])
 
   return mappedTextures
 }

--- a/packages/fiber/tests/useTextures.test.tsx
+++ b/packages/fiber/tests/useTextures.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { act } from 'react'
 import * as THREE from 'three'
 
-import { createRoot, useTexture, useTextures, extend } from '../src'
+import { createRoot, useTexture, useTextures, useThree, extend } from '../src'
 import type { UseTexturesReturn } from '../src'
 
 extend(THREE as any)
@@ -335,6 +335,84 @@ describe('useTextures (registry)', () => {
     expect(renders).toBe(before)
 
     vi.restoreAllMocks()
+  })
+
+  //* Render-loop regressions (#3849) ==============================
+  // The array and record forms re-ran their registry effect on every render, and the setState
+  // that effect performs re-renders every store subscriber, so the two fed each other until
+  // React bailed out with "Maximum update depth exceeded". The single-URL form was unaffected.
+  //
+  // The loop only closes when the consuming component itself subscribes broadly to the store —
+  // the very common `useThree()` with no selector. A sibling subscriber is not enough, since it
+  // re-renders itself and not the useTexture caller, so the `useThree()` calls below are load
+  // bearing: without them these tests pass even on the broken build.
+
+  /** Mount `children` under Suspense and let the mocked loader settle. */
+  async function mountAndSettle(children: React.ReactNode) {
+    await act(async () => {
+      root.render(<React.Suspense fallback={null}>{children}</React.Suspense>)
+      await new Promise((r) => setTimeout(r, 20))
+    })
+  }
+
+  it('array form settles instead of looping forever', async () => {
+    mockTextureLoad(new THREE.Texture())
+
+    let renders = 0
+    function Consumer() {
+      renders++
+      useThree() // broad subscription — closes the feedback loop
+      // Inline literal on purpose: a fresh reference every render is the common call shape,
+      // and the issue notes that hoisting it to a module constant did not help either.
+      useTexture(['/loop-a.png', '/loop-b.png'])
+      return null
+    }
+
+    await mountAndSettle(<Consumer />)
+
+    // A handful of renders is normal (suspense retry + registry commit). Hundreds means the loop.
+    expect(renders).toBeLessThan(10)
+  })
+
+  it('record form settles instead of looping forever', async () => {
+    mockTextureLoad(new THREE.Texture())
+
+    let renders = 0
+    function Consumer() {
+      renders++
+      useThree()
+      useTexture({ map: '/loop-map.png', normalMap: '/loop-normal.png' })
+      return null
+    }
+
+    await mountAndSettle(<Consumer />)
+
+    expect(renders).toBeLessThan(10)
+  })
+
+  it('array form returns a reference-stable result across re-renders', async () => {
+    // The underlying cause: useLoader built a new array every call, so the result could not be
+    // used as an effect dependency by anyone — useTexture's registry effect was just the first
+    // place it bit. Fixed in useLoader, so this holds for every consumer.
+    mockTextureLoad(new THREE.Texture())
+
+    const seen: unknown[] = []
+    let forceRender!: () => void
+    function Consumer() {
+      const [, setTick] = React.useState(0)
+      forceRender = () => setTick((t) => t + 1)
+      seen.push(useTexture(['/stable-a.png', '/stable-b.png']))
+      return null
+    }
+
+    await mountAndSettle(<Consumer />)
+    const initial = seen.length
+    expect(initial).toBeGreaterThan(0)
+
+    await act(async () => forceRender())
+
+    expect(seen.length).toBeGreaterThan(initial)
+    expect(seen[seen.length - 1]).toBe(seen[initial - 1])
   })
 
   it('selector form returns scoped derived state', async () => {


### PR DESCRIPTION
Fixes #3849.

`useTexture` with an array or record argument re-ran its registry effect on every render, and the `store.setState` that effect performs re-renders every store subscriber, so the two fed each other until React bailed out with `Maximum update depth exceeded`. The single-URL form was unaffected.

## Two instabilities, both load-bearing

Fixing either one alone still loops — I verified this by reverting each half independently.

**1. `useLoader` returned a new array every call.** `.map()` builds a fresh array each render, so the result could never be used as an effect dependency — by anyone. This is the root cause and it isn't `useTexture`-specific; `useTexture`'s registry effect was just the first place it bit.

The array is now shallow-compared and its identity preserved while the contents are unchanged. **Shallow-compared rather than keyed on the cache keys** — that alternative looks simpler but silently breaks invalidation, because `useLoader.clear()` can hand back new objects for the *same* keys and that change still has to propagate. Comparing resolved values means a genuine change always yields a new identity and an incidental re-render never does.

**2. `useTexture` keyed its memos and effect on the raw `input` reference.** Callers routinely pass an inline literal, so that reference is new every render too. Everything now keys off a value signature plus an identity-stable view of the input.

The signature includes the record's **keys**, not just its URLs — two records can share URLs while mapping them to different names, and those aren't interchangeable.

## On the render-phase ref write in `useLoader`

`useLoader` previously used no React hooks. It now uses one `useRef`. The write during render is idempotent — given equal contents it always settles on the same array — so it's safe under StrictMode's double render. Flagging it since it's the least conventional part of this change.

## Testing

Three regression tests, all confirmed failing on pre-fix source with the reported error:

```
× array form settles instead of looping forever
    Error: Maximum update depth exceeded.
× record form settles instead of looping forever
    Error: Maximum update depth exceeded.
× array form returns a reference-stable result across re-renders
    AssertionError: expected [ …(2) ] to be [ …(2) ]
```

Worth knowing if you edit these: the `useThree()` call inside each Consumer is **load-bearing**. The loop only closes when the component calling `useTexture` is itself a broad store subscriber — a sibling subscriber re-renders itself, not the `useTexture` caller. My first draft put it in a sibling and the tests passed on the broken build. The issue's own repro has it in the same component; that detail matters.

- `pnpm test` ✅ 584 passed (was 581), 45 files
- `pnpm typecheck` / `pnpm eslint` / `pnpm format` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)