### PR TITLE
fix(webgpu): correct multi-canvas resize targeting

### DIFF
--- a/packages/fiber/src/core/renderer.tsx
+++ b/packages/fiber/src/core/renderer.tsx
@@ -648,6 +648,26 @@ export function createRoot<TCanvas extends HTMLCanvasElement | OffscreenCanvas>(
             if (state.internal.isMultiCanvas && state.internal.canvasTarget) {
               const renderer = state.internal.actualRenderer as WebGPURenderer
               renderer.setCanvasTarget(state.internal.canvasTarget)
+
+              // Flush a pending resize for THIS root, now that its target is the active one.
+              //
+              // The backend caches a render pass descriptor per canvas whose depth-stencil view
+              // is built once, while the colour attachment comes fresh from the swap chain each
+              // frame. They only stay in step because Renderer._onCanvasTargetResize calls
+              // backend.updateSize() -- but that listener lives on a single target at a time and
+              // setCanvasTarget moves it on every swap, so a canvas that resizes while it is not
+              // active never hears its own resize and renders a stale depth view forever
+              // (per-frame GPUValidationError about mismatched attachment sizes).
+              //
+              // This is the correct place to flush precisely because updateSize() acts on
+              // getCanvasTarget(): immediately after setCanvasTarget, that is us. See #3847.
+              if (state.internal.canvasTargetSizeDirty) {
+                state.internal.canvasTargetSizeDirty = false
+                // Backend.updateSize() exists at runtime on three's base Backend (and
+                // WebGPUBackend), but is absent from the shipped type declarations. Optional-call
+                // so a backend without it is simply a no-op rather than a crash.
+                ;(renderer.backend as Partial<{ updateSize(): void }> | undefined)?.updateSize?.()
+              }
             }
           },
           {

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -376,23 +376,40 @@ export const createStore = (
       // Update camera
       updateCamera(camera, size)
 
-      // Secondary canvases only update their CanvasTarget (renderer is shared, owned by primary)
-      // Primary canvases always update the renderer directly (owns the depth buffer/GPU resources)
-      // plus their canvas target if one exists (keeps it sized for multi-canvas mode)
+      // Size our own canvas target if we have one, otherwise the renderer.
+      //
+      // Renderer.setSize / setPixelRatio are target-IMPLICIT -- they forward to
+      // `renderer._canvasTarget`, whichever target setCanvasTarget last pointed at. In
+      // multi-canvas mode that is normally some *other* canvas, since the secondaries run after
+      // the primary in the scheduler and nothing restores the primary's target afterwards. So
+      // the primary resizing used to resize a secondary's canvas element to the primary's
+      // dimensions, before sizing its own target correctly on the next line: the renderer call
+      // was redundant for us and wrong for whoever happened to be active. See #3847.
+      //
+      // Once a canvas target exists, `isSecondary` stops mattering here -- primary and secondary
+      // both own exactly one target and should touch only that.
+      //
       // Never pass updateStyle=true to Three.js setSize — explicit pixel CSS on the canvas
       // breaks flex/percentage layouts. R3F manages canvas CSS sizing via the container divs
       // (width: 100%, height: 100%), and only the canvas buffer attributes need pixel values.
-      if (internal.isSecondary && canvasTarget) {
-        if (viewport.dpr > 0) canvasTarget.setPixelRatio(viewport.dpr)
-        canvasTarget.setSize(size.width, size.height, false)
-      } else {
-        if (viewport.dpr > 0) actualRenderer.setPixelRatio(viewport.dpr)
-        actualRenderer.setSize(size.width, size.height, false)
-        if (canvasTarget) {
-          if (viewport.dpr > 0) canvasTarget.setPixelRatio(viewport.dpr)
-          canvasTarget.setSize(size.width, size.height, false)
-        }
-      }
+      const resizeTarget = canvasTarget ?? actualRenderer
+      if (viewport.dpr > 0) resizeTarget.setPixelRatio(viewport.dpr)
+      resizeTarget.setSize(size.width, size.height, false)
+
+      // Invalidate this root's cached render pass descriptor on the next frame.
+      //
+      // WebGPUBackend caches the depth-stencil attachment view per canvas and only rebuilds it
+      // when the sample count changes, while the colour attachment is pulled fresh from the swap
+      // chain every frame. They stay in step only because Renderer._onCanvasTargetResize ->
+      // backend.updateSize() clears the cache -- but that listener is attached to one target at a
+      // time and setCanvasTarget moves it on every swap, so only the active canvas can hear its
+      // own resize. Every other one resizes silently and renders against a stale depth view
+      // forever, which surfaces as a per-frame GPUValidationError about mismatched attachment
+      // sizes. updateSize() compounds it by deleting the *active* target rather than the resized
+      // one, so it cannot be called safely from here. The flush happens in the canvas-target job
+      // (see renderer.tsx), which runs in the `start` phase where our own target is guaranteed
+      // active. See #3847.
+      internal.canvasTargetSizeDirty = true
     }
 
     // Update viewport and frustum once the camera changes

--- a/packages/fiber/tests/multicanvas-resize.test.tsx
+++ b/packages/fiber/tests/multicanvas-resize.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Multi-canvas resize correctness — Tier 1 (jsdom).
+ *
+ * Regressions for #3847. Both bugs come from the same root cause: three's
+ * `Renderer.setSize` / `setPixelRatio` and the backend's render-pass-descriptor cache are
+ * **target-implicit** — they act on whatever `renderer._canvasTarget` currently points at — and
+ * R3F is the thing swapping that pointer every frame.
+ *
+ * Bug 1: the primary's resize wrote through `actualRenderer.setSize`, which lands on whichever
+ *        canvas happens to be active (normally a *secondary*, since they run after the primary
+ *        and nothing restores the primary's target). Asserted here directly.
+ *
+ * Bug 2: a canvas that resizes while it is not the active target never hears its own resize, so
+ *        its cached depth-stencil view goes stale and every subsequent frame raises a
+ *        GPUValidationError. R3F now marks the root dirty on resize and flushes
+ *        `backend.updateSize()` from the canvas-target job, the one place this root's target is
+ *        guaranteed active. Only the store half is provable here — the flush itself needs a
+ *        device, so it is Tier 2.
+ *
+ * No GPU: `CanvasTarget` and the renderer are stubs recording calls, which is enough because the
+ * bug is about *which object gets called*, not what the GPU does with it.
+ */
+import * as THREE from 'three'
+
+import { createStore } from '../src/core/store'
+import type { RootStore } from '../src'
+
+const noop = () => {}
+
+/** Records setSize/setPixelRatio calls so we can assert who got resized. */
+function makeTargetSpy() {
+  return {
+    setSize: vi.fn(),
+    setPixelRatio: vi.fn(),
+  }
+}
+
+/**
+ * A store wired up like one canvas of a multi-canvas page.
+ * `isSecondary` distinguishes the primary from the secondaries.
+ */
+function makeCanvasStore({ isSecondary, withTarget = true }: { isSecondary: boolean; withTarget?: boolean }) {
+  const store: RootStore = createStore(noop, noop)
+  const renderer = makeTargetSpy()
+  const canvasTarget = withTarget ? makeTargetSpy() : undefined
+
+  store.setState((state) => ({
+    // The resize subscription runs updateCamera() before the sizing branch, so it needs a real one.
+    camera: new THREE.PerspectiveCamera() as any,
+    internal: {
+      ...state.internal,
+      actualRenderer: renderer as any,
+      canvasTarget: canvasTarget as any,
+      isMultiCanvas: true,
+      isSecondary,
+    },
+  }))
+
+  /** Drive a resize through the store, the way the resize observer does. */
+  const resize = (width: number, height: number) =>
+    store.setState((state) => ({ size: { ...state.size, width, height } }))
+
+  return { store, renderer, canvasTarget, resize }
+}
+
+describe('multi-canvas resize (#3847)', () => {
+  describe('bug 1: a resize only ever touches its own canvas target', () => {
+    it('primary: sizes its canvas target, never the shared renderer', async () => {
+      const { renderer, canvasTarget, resize } = makeCanvasStore({ isSecondary: false })
+
+      resize(640, 480)
+
+      expect(canvasTarget!.setSize).toHaveBeenCalledWith(640, 480, false)
+      // The stray write. `Renderer.setSize` forwards to `renderer._canvasTarget`, which in
+      // multi-canvas mode is normally some *other* canvas — so this resized a secondary's
+      // element to the primary's dimensions.
+      expect(renderer.setSize).not.toHaveBeenCalled()
+      expect(renderer.setPixelRatio).not.toHaveBeenCalled()
+    })
+
+    it('secondary: sizes its canvas target, never the shared renderer', async () => {
+      const { renderer, canvasTarget, resize } = makeCanvasStore({ isSecondary: true })
+
+      resize(320, 240)
+
+      expect(canvasTarget!.setSize).toHaveBeenCalledWith(320, 240, false)
+      expect(renderer.setSize).not.toHaveBeenCalled()
+    })
+
+    it('single-canvas (no canvas target): still sizes the renderer', async () => {
+      // The WebGL / single-WebGPU-canvas path must be unchanged — with no target to own, the
+      // renderer's own (target-implicit) sizing is the correct thing to drive.
+      const { renderer, resize } = makeCanvasStore({ isSecondary: false, withTarget: false })
+
+      resize(800, 600)
+
+      expect(renderer.setSize).toHaveBeenCalledWith(800, 600, false)
+    })
+
+    it('a dpr change routes to the canvas target too', async () => {
+      const { store, renderer, canvasTarget } = makeCanvasStore({ isSecondary: false })
+
+      store.setState((state) => ({ viewport: { ...state.viewport, dpr: 2 } }))
+
+      expect(canvasTarget!.setPixelRatio).toHaveBeenCalledWith(2)
+      expect(renderer.setPixelRatio).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('bug 2: a resized root is marked for a descriptor flush', () => {
+    it('sets canvasTargetSizeDirty so the canvas-target job can flush it', async () => {
+      const { store, resize } = makeCanvasStore({ isSecondary: true })
+      expect(store.getState().internal.canvasTargetSizeDirty).toBeFalsy()
+
+      resize(380, 149)
+
+      // The flag, not a direct backend.updateSize() call: updateSize() acts on
+      // getCanvasTarget(), so calling it here would invalidate whichever canvas is *currently*
+      // active rather than the one that just resized.
+      expect(store.getState().internal.canvasTargetSizeDirty).toBe(true)
+    })
+
+    it('is not set when nothing actually changed size', async () => {
+      const { store } = makeCanvasStore({ isSecondary: true })
+
+      // A store write that leaves width/height/dpr alone must not mark the descriptor stale.
+      store.setState((state) => ({ size: { ...state.size } }))
+
+      expect(store.getState().internal.canvasTargetSizeDirty).toBeFalsy()
+    })
+  })
+
+  // The flush itself — canvas-target job calls setCanvasTarget then backend.updateSize(), and
+  // the depth attachment stops mismatching the colour attachment — needs a real device.
+  it.todo('covered by Tier 2: a secondary resizing while inactive no longer raises GPUValidationError')
+})

--- a/packages/fiber/types/store.d.ts
+++ b/packages/fiber/types/store.d.ts
@@ -181,6 +181,18 @@ export interface InternalState {
    */
   canvasTarget?: CanvasTarget
   /**
+   * Set when this root's canvas target has been resized and the backend's cached render pass
+   * descriptor (which holds a depth-stencil view built once per canvas) is therefore stale.
+   *
+   * Flushed by the canvas-target job in the `start` phase, which is the only place this root's
+   * target is guaranteed to be the renderer's active one — `backend.updateSize()` operates on
+   * whatever `getCanvasTarget()` returns, so calling it from the resize subscription would
+   * invalidate some other canvas's descriptor instead.
+   *
+   * @see https://github.com/pmndrs/react-three-fiber/issues/3847
+   */
+  canvasTargetSizeDirty?: boolean
+  /**
    * Whether multi-canvas rendering is active.
    * True when any canvas uses `renderer={{ primaryCanvas: 'id' }}` to share a renderer.
    * When true, setCanvasTarget is called before each render.


### PR DESCRIPTION
Fixes #3847.

Two resize bugs from one root cause: three's `Renderer.setSize` / `setPixelRatio` and the backend's render-pass-descriptor cache are **target-implicit** — they act on whatever `renderer._canvasTarget` currently points at — and R3F is the thing swapping that pointer every frame.

I verified both mechanisms in `three@0.185.1` rather than taking them on trust:
- `Renderer.js:2075` — `setSize` forwards to `this._canvasTarget`
- `Renderer.js:2627-2630` — `setCanvasTarget` moves the resize listener between targets
- `WebGPUBackend.js:2608` — `updateSize()` deletes `renderer.getCanvasTarget()`, the **active** target

## Bug 1 — the primary resized someone else's canvas

`actualRenderer.setSize` forwards to `_canvasTarget`, which in multi-canvas mode is normally a *secondary* (they run after the primary in the scheduler and nothing restores the primary's target). So the primary resizing resized some other canvas's element to the primary's dimensions, then sized its own target correctly on the next line — redundant for us, wrong for whoever was active.

It's partly self-healing, which is probably why it hadn't surfaced: the clobbered secondary's own subscription usually re-fires with correct values. It doesn't heal when the secondary's measured size didn't change, and the ordering isn't guaranteed either way.

Once a canvas target exists, `isSecondary` stops mattering here — primary and secondary both own exactly one target and should touch only that — so the two branches collapse into one.

## Bug 2 — stale depth attachment

`WebGPUBackend` caches the depth-stencil view per canvas and rebuilds it only when the sample count changes, while the colour attachment comes fresh from the swap chain every frame. They stay in step only because `Renderer._onCanvasTargetResize` → `backend.updateSize()` clears the cache — but that listener lives on one target at a time, so a canvas that resizes while inactive never hears its own resize and renders a stale depth view forever. That's the per-frame `GPUValidationError` about mismatched attachment sizes.

**`updateSize()` can't be called from the resize subscription**, because it deletes `getCanvasTarget()` — the active target, not the one that resized. That's the part that makes the obvious fix wrong.

So the resize marks `internal.canvasTargetSizeDirty`, and the canvas-target job flushes it immediately after `setCanvasTarget`, in the `start` phase — the one point where this root's target is guaranteed to be the active one. This is the hook point the issue identified, and it's correct precisely because of the `getCanvasTarget()` behaviour above.

## Scope

R3F-side only, as the issue suggests. The durable fix (scoping the resize listener per canvas target, or rebuilding the depth view per frame) belongs in three — but multi-canvas is R3F's feature and three's API isn't defensive about which target is active, so owning it here is right regardless.

## Testing

New `multicanvas-resize.test.tsx`, Tier 1. The stubs record calls, which is enough because both bugs are about *which object gets called*, not what the GPU does with it.

Confirmed the three regression tests fail pre-fix:

```
× primary: sizes its canvas target, never the shared renderer
    expected "vi.fn()" to not be called at all, but actually been called 1 times
× a dpr change routes to the canvas target too
    expected "vi.fn()" to not be called at all, but actually been called 1 times
× sets canvasTargetSizeDirty so the canvas-target job can flush it
    expected undefined to be true
```

The other three pass both ways by design — they guard the single-canvas path (no target → renderer still sized, so WebGL is unaffected) and the no-op case.

The flush itself needs a device, so it's `it.todo` for Tier 2.

## Note for reviewers

three's shipped type declarations omit `Backend.updateSize` even though the base class implements it. Rather than `as any` I used a narrow local type at the call site, optional-called so a backend without it no-ops.

- `pnpm test` ✅ 587 passed (was 581), 46 files
- `pnpm typecheck` / `pnpm eslint` / `pnpm format` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)