### PR TITLE
fix(core): keep the renderer root alive when a child suspends

### DIFF
--- a/packages/fiber/src/core/Canvas.tsx
+++ b/packages/fiber/src/core/Canvas.tsx
@@ -259,6 +259,26 @@ function CanvasImpl({
     const canvas = canvasRef.current
     if (canvas) {
       return () => {
+        // Only tear the root down once the canvas has actually left the document.
+        //
+        // This cleanup runs whenever CanvasImpl's passive effects are destroyed, which is NOT
+        // the same as CanvasImpl being unmounted. React also destroys them when a Suspense
+        // boundary hides the tree, and StrictMode exercises that path on every mount.
+        //
+        // That matters because any child suspending — a useTexture/useLoader with no <Suspense>
+        // of its own — reaches CanvasImpl through `Block`, which deliberately lifts the promise
+        // out to the boundary *outside* the Canvas so the DOM-level `fallback` can show. The
+        // blast radius was the problem, not the lift: the resource-owning root was destroyed to
+        // display a fallback for one texture, and everything created inside it went with it. For
+        // scenes that only draw that is an invisible flash; for anything accumulating state on
+        // the GPU (useGPUStorage) it is silent data loss, with `R3F.createRoot should only be
+        // called once!` as the only clue. See #3850.
+        //
+        // React detaches the host node before running these cleanups on a real unmount, so
+        // `isConnected` separates the two cases. Both directions are covered by tests — a
+        // suspension must keep the root, and a real unmount must still release it.
+        if (canvas.isConnected) return
+
         unmountComponentAtNode(canvas)
         // Clear root ref so HMR creates a fresh root
         root.current = null!

--- a/packages/fiber/tests/canvas-suspense.test.tsx
+++ b/packages/fiber/tests/canvas-suspense.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Canvas root lifetime vs. suspension — Tier 1 (jsdom).
+ *
+ * Regression for #3850: suspending inside <Canvas> destroyed and re-created the whole renderer
+ * root, silently discarding everything created inside it (useGPUStorage buffers included).
+ *
+ * The mechanism: a child suspending with no <Suspense> of its own renders `Block`, which lifts
+ * the promise out to the boundary *outside* the Canvas so the DOM-level `fallback` can show.
+ * CanvasImpl then suspends, React destroys its passive effects, and the teardown effect ran
+ * `unmountComponentAtNode` on the shared root.
+ *
+ * Reproducing it needs all three of:
+ *   1. StrictMode        — Next.js dev's default, and what makes React destroy the effects here
+ *   2. an outer Suspense — Next.js App Router wraps pages in one
+ *   3. a child that suspends with no inner <Suspense>
+ *
+ * Without StrictMode the root survives on its own, which is why this looked environment-specific.
+ */
+import * as React from 'react'
+import { act } from 'react'
+import { render } from '@testing-library/react'
+import * as THREE from 'three'
+import { suspend } from 'suspend-react'
+
+import { Canvas, extend, useStore } from '../src'
+import type { RootStore } from '../src'
+
+extend(THREE as any)
+
+/** A child that suspends until the returned `resolve` is called, like useTexture does. */
+function makeGate(key: string) {
+  let resolve: (v: unknown) => void = () => {}
+  function Gate() {
+    suspend(() => new Promise((res) => (resolve = res)), [key])
+    return null
+  }
+  return { Gate, resolve: (v: unknown = null) => resolve(v) }
+}
+
+/** Records the store it is mounted under, and stamps a marker to stand in for a GPU resource. */
+function makeOwner(seen: RootStore[]) {
+  return function Owner() {
+    const store = useStore()
+    seen.push(store)
+    if (!(store.getState() as any).__resource) {
+      store.setState({ __resource: { id: 'gpu-buffer' } } as any)
+    }
+    return null
+  }
+}
+
+describe('suspending inside <Canvas> (#3850)', () => {
+  it('keeps the renderer root alive across a suspension', async () => {
+    const { Gate, resolve } = makeGate('canvas-suspense-keep')
+    const seen: RootStore[] = []
+    const Owner = makeOwner(seen)
+    const created: unknown[] = []
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await act(async () => {
+      render(
+        <React.StrictMode>
+          <div style={{ width: 100, height: 100 }}>
+            <React.Suspense fallback={<span>outer</span>}>
+              <Canvas onCreated={(s) => created.push(s)}>
+                <Owner />
+                <Gate />
+              </Canvas>
+            </React.Suspense>
+          </div>
+        </React.StrictMode>,
+      )
+      await new Promise((r) => setTimeout(r, 50))
+    })
+
+    await act(async () => {
+      resolve()
+      await new Promise((r) => setTimeout(r, 50))
+    })
+
+    // The root was created exactly once. Previously the suspension tore it down and the reveal
+    // built a second one, which is what surfaced as "R3F.createRoot should only be called once!"
+    expect(created).toHaveLength(1)
+    expect(warn.mock.calls.filter((c) => String(c[0]).includes('createRoot'))).toHaveLength(0)
+
+    // Same store throughout — so anything registered on it survived.
+    expect(new Set(seen).size).toBe(1)
+    expect((seen[seen.length - 1].getState() as any).__resource).toEqual({ id: 'gpu-buffer' })
+
+    warn.mockRestore()
+  })
+
+  it('still releases the root on a real unmount', async () => {
+    // The other direction, and the one that would bite silently. The fix distinguishes "hidden"
+    // from "unmounted" by whether the canvas is still in the document; if that ever stopped
+    // holding, every root would leak instead.
+    const seen: RootStore[] = []
+    const Owner = makeOwner(seen)
+
+    let unmount!: () => void
+    await act(async () => {
+      const utils = render(
+        <div style={{ width: 100, height: 100 }}>
+          <Canvas>
+            <Owner />
+          </Canvas>
+        </div>,
+      )
+      unmount = utils.unmount
+      await new Promise((r) => setTimeout(r, 50))
+    })
+
+    const store = seen[seen.length - 1]
+    expect(store).toBeDefined()
+    expect(store.getState().internal.active).toBe(true)
+
+    await act(async () => {
+      unmount()
+      await new Promise((r) => setTimeout(r, 20))
+    })
+
+    // `internal.active = false` is the first thing unmountComponentAtNode does, and it does it
+    // synchronously — the rest of the teardown (including the _roots delete) is deferred behind a
+    // 500ms timer, so this is the signal that actually pins "the teardown ran" without racing it.
+    expect(store.getState().internal.active).toBe(false)
+  })
+})


### PR DESCRIPTION
Fixes #3850.

Suspending inside `<Canvas>` destroyed and re-created the **entire renderer root**, silently discarding everything created inside it. For scenes that only draw that's an invisible flash; for anything accumulating state on the GPU (`useGPUStorage`) it's data loss, with `R3F.createRoot should only be called once!` as the only clue.

## What was actually wrong

A child suspending with no `<Suspense>` of its own renders `Block`, which lifts the promise out to the boundary *outside* the Canvas so the DOM-level `fallback` can show. **That lift is deliberate and I've kept it** — the issue identifies it correctly as intentional.

The problem was blast radius. The teardown effect ran `unmountComponentAtNode` whenever CanvasImpl's passive effects were destroyed — and React destroys those when a Suspense boundary merely **hides** a tree, not only when it unmounts. So the resource-owning root was torn down to display a fallback for one texture.

The root is now released only once the canvas has actually left the document.

## Why this looked environment-specific

Reproducing it needs all three of:

1. **StrictMode** — Next.js dev's default, and what makes React destroy the effects here
2. **an outer `<Suspense>`** — the App Router wraps pages in one
3. a child that suspends with no inner `<Suspense>`

Without StrictMode the root survives on its own. My first three reproduction attempts all passed on the broken build for exactly that reason; the test sets up all three deliberately.

## One thing worth flagging in review

Getting the hide-vs-unmount discriminator right needed measurement, not reasoning, and **my first attempt was wrong in a way that would have leaked every root.**

`_roots` looked like the obvious "was it released" signal, and the unmount test failed against it — which initially looked like the guard being broken. It wasn't: `_roots.delete` happens behind a `setTimeout(…, 500)` inside `unmountComponentAtNode`, and the test waited 20ms. `internal.active` is set synchronously at the top of teardown and is the signal that actually pins it.

Instrumenting the real thing gave a clean separation across all four teardowns in the suite:

| teardown | `isConnected` | case |
|---|---|---|
| #1, #2 | `true` | StrictMode / Suspense hide — must keep the root |
| #3, #4 | `false` | real unmount — must release it |

React detaches the host node before running these cleanups on a real unmount, which is what makes the check sound.

## Testing

Two tests, both directions:

- **`keeps the renderer root alive across a suspension`** — fails pre-fix with `onCreated` called twice (the root recreated). Also asserts a single store identity throughout and that a marker registered on it survives, which is the actual "GPU resources survive" property.
- **`still releases the root on a real unmount`** — passes both ways by design. It exists because a discriminator that ever answered "hidden" for a real unmount would leak every root, and that failure is silent.

- `pnpm test` ✅ 583 passed (was 581), 46 files — including the existing `canvas.test.tsx` and `hmr.test.ts`, which exercise the unmount path
- `pnpm typecheck` / `pnpm eslint` / `pnpm format` ✅

## On the issue's second suggestion

#3850 also asked for docs on the sharp edge. I've deliberately **not** added them: the sharp edge is gone, so documenting "suspending re-creates the renderer root and discards GPU resources" would now be describing behaviour that no longer exists. The reasoning lives in a comment at the fix site instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)