### PR TITLE
test(test-renderer): cover the equirect background path in the mock GL contract test

### DIFF
--- a/packages/test-renderer/src/__tests__/WebGL2RenderingContext.test.ts
+++ b/packages/test-renderer/src/__tests__/WebGL2RenderingContext.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import * as THREE from 'three'
 import { WebGL2RenderingContext } from '../WebGL2RenderingContext'
 
 /**
@@ -9,7 +10,8 @@ import { WebGL2RenderingContext } from '../WebGL2RenderingContext'
  * `TypeError: Invalid value used as weak map key` the first time anything bound a
  * framebuffer-backed render target (#3820). The symptom appeared as a flaky, unrelated-looking
  * failure in the PMREM background test, so the useful thing to pin here is the *contract* rather
- * than that one test's outcome.
+ * than that one test's outcome. The last case then renders an equirect background for real, which
+ * is the same path from the other end: it fails if a handle is unusable, whatever the reason.
  */
 describe('WebGL2RenderingContext mock', () => {
   const createContext = () => new WebGL2RenderingContext(document.createElement('canvas'))
@@ -60,5 +62,27 @@ describe('WebGL2RenderingContext mock', () => {
     // "create" in a later position must not be caught by it.
     expect(gl.bindFramebuffer()).toBeUndefined()
     expect(gl.drawBuffers()).toBeUndefined()
+  })
+
+  it('lets three render an equirectangular background', () => {
+    // Every assertion above pokes the mock directly. This one drives the path that actually broke:
+    // an equirect background is resolved through PMREMGenerator, which binds a framebuffer-backed
+    // render target, so three reaches WebGLState.drawBuffers() with a handle the mock produced.
+    // It is the end-to-end counterpart to the contract -- if the mock regresses in some way the
+    // direct assertions do not anticipate, three still has to be able to render.
+    const canvas = document.createElement('canvas')
+    canvas.width = 1280
+    canvas.height = 800
+
+    const renderer = new THREE.WebGLRenderer({ canvas })
+    const scene = new THREE.Scene()
+    const camera = new THREE.PerspectiveCamera()
+
+    const texture = new THREE.DataTexture(new Uint8Array([0, 0, 0, 255]), 1, 1)
+    texture.mapping = THREE.EquirectangularReflectionMapping
+    texture.needsUpdate = true
+    scene.background = texture
+
+    expect(() => renderer.render(scene, camera)).not.toThrow()
   })
 })


### PR DESCRIPTION
Closes #3845.

#3821's source change was superseded by #3822. This is the half you asked to keep.

**What it covers.** The existing assertions call the mock directly. This case renders an equirect background through three, which resolves through PMREMGenerator and binds a framebuffer-backed render target, so `WebGLState.drawBuffers()` receives a handle the mock actually produced.

**It discriminates.** Against the pre-#3822 `() => {}` stub it fails with `TypeError: Invalid value used as weak map key` — the #3820 error, raised synchronously rather than as a flake. It passes on current v10.

**Placement.** Added to `WebGL2RenderingContext.test.ts` rather than restoring `RTTR.webgl2.test.ts` as its own file. You offered either. The other two tests in my original file — WeakMap-keyability and distinct-per-call — are already covered by your contract test, so a separate file would have been mostly duplication. Happy to split it out if you'd rather it stand alone.

Full suite: 48 files, 606 passed. Coverage 81.32% lines, against the 78 threshold.

**Not fixed here:** `createVertexArrayOES` in the `getExtension` object still returns `undefined`. Same class of bug, different path, and the WebGL2 render path never reaches it — out of scope for this.
