### PR TITLE
docs: give useTexture/useTextures a dedicated page

### DIFF
--- a/docs/tutorials/loading-textures.mdx
+++ b/docs/tutorials/loading-textures.mdx
@@ -149,98 +149,11 @@ You can play with the sandbox and see how it looks:
 
 <Codesandbox id="rusfd" />
 
-## The texture registry with `useTextures` (experimental)
+## The texture registry with `useTextures`
 
-> **Experimental (A5).** The `useTextures` API may change before it's stabilized.
+In v10, `useTexture` is built into `@react-three/fiber` and, by default, enrolls what it loads into a
+global texture registry. `useTextures()` lets you reach those textures from anywhere and manage their
+GPU lifetime, without threading refs through your component tree.
 
-In v10, `useTexture` is built into `@react-three/fiber` (no need for drei) and, by default, enrolls what it loads into a global **texture registry** — a `Map` of plain `Texture` objects keyed by URL. `useTextures()` lets you reach those textures from anywhere and manage their GPU lifetime, without threading refs through your component tree.
-
-`useTexture` does the **loading**; `useTextures` does the **access and lifecycle**. They're separate jobs on purpose.
-
-### Enrolling textures
-
-Loading registers automatically, so other components can read it back by URL:
-
-```jsx
-import { useTexture, useTextures } from '@react-three/fiber'
-
-function Floor() {
-  // Load once, anywhere in the tree — registered by default
-  useTexture({
-    map: 'PavingStones092_1K_Color.jpg',
-    normalMap: 'PavingStones092_1K_Normal.jpg',
-    roughnessMap: 'PavingStones092_1K_Roughness.jpg',
-  })
-  return null
-}
-
-function Wall() {
-  // Reach the same textures from a different component — the record form
-  // mirrors its input, so it drops straight into a material
-  const { map, normalMap, roughnessMap } = useTextures().get({
-    map: 'PavingStones092_1K_Color.jpg',
-    normalMap: 'PavingStones092_1K_Normal.jpg',
-    roughnessMap: 'PavingStones092_1K_Roughness.jpg',
-  })
-  return (
-    <mesh>
-      <planeGeometry />
-      <meshStandardMaterial map={map} normalMap={normalMap} roughnessMap={roughnessMap} />
-    </mesh>
-  )
-}
-```
-
-Pass `{ cache: false }` to opt a one-off texture out of the registry. Note that registry reads in `useTexture` happen **once at mount** — a mounted `useTexture` does not re-render when the registry changes (loading texture A never re-renders a component using texture B). To react to registry changes, use the selector form below.
-
-You can also register textures that have no URL — render targets or procedural textures — with `add`, and free GPU memory deliberately with `dispose` (refcount-aware: it won't free a texture still in use by a mounted `useTexture` consumer unless you pass `{ force: true }`):
-
-```jsx
-const textures = useTextures()
-textures.add('rt-main', renderTarget.texture) // register a render target
-textures.dispose('rt-main') // free its GPU memory + remove from the registry
-textures.disposeAll() // scene teardown
-```
-
-### When is the registry reactive? (and the flip-flop pattern)
-
-There are three distinct situations, and only one of them wants React reactivity:
-
-| Use case | Tool | Reactive? |
-| --- | --- | --- |
-| Load an asset by URL | `useTexture(url)` | No — the object never changes |
-| **Swap** which texture lives under a key (occasionally) | `useTextures(s => s.get(key))` | Yes — scoped to that one key |
-| Swap a texture **every frame** (ping-pong) | `registry.get(key)` inside `useFrame` | No — read it imperatively |
-
-Loading a URL never needs reactivity (the texture instance is stable), and a render target being drawn into updates *inside* three.js (`needsUpdate`) without changing the JS object — so neither involves React.
-
-The one case that does is a **flip-flop / ping-pong**: you keep two textures and swap which one a material reads. For an *occasional* swap (e.g. toggling an output on some event), subscribe to just that key with the selector form — only this component re-renders, and only when the slot actually changes:
-
-```jsx
-function Output() {
-  // Re-renders only when the texture under 'finalOutput' is swapped
-  const tex = useTextures((s) => s.get('finalOutput'))
-  return (
-    <mesh>
-      <planeGeometry />
-      <meshBasicMaterial map={tex} />
-    </mesh>
-  )
-}
-
-// Elsewhere, swap the slot — the Output component picks up texB
-useTextures().add('finalOutput', texB)
-```
-
-For a **per-frame** ping-pong, don't make React re-render every frame — read the current texture imperatively in the loop instead:
-
-```jsx
-function PingPong({ material }) {
-  const textures = useTextures()
-  useFrame((state) => {
-    const even = Math.floor(state.elapsed * 60) % 2 === 0
-    material.map = textures.get(even ? 'a' : 'b')
-  })
-  return null
-}
-```
+See [Textures](/webgpu/textures) for the registry API, the `cache` option, refcounted disposal, and
+when the registry is reactive.

--- a/docs/webgpu/overview.mdx
+++ b/docs/webgpu/overview.mdx
@@ -256,10 +256,11 @@ This means no duplicate GPU allocations, shared state across the component tree,
 - [TSL Hooks](./tsl-hooks) - `useUniform`, `useUniforms`, `useNodes`, `useLocalNodes`, ScopedStore
 - [Render Pipeline](./render-pipeline) - `useRenderPipeline`, MRT, custom passes
 - [Compute (Buffers & Storage)](./compute) - `useBuffers`, `useGPUStorage`
+- [Textures](./textures) - `useTexture`, `useTextures`, the texture registry
 - [Multi-Canvas](./multi-canvas) - sharing a renderer across canvases
 - [TSL HMR](./hmr) - what rebuilds on hot reload
 
-> Building GPU pipelines often pairs with the **texture registry** (`useTexture`/`useTextures`). Those are core hooks that work with any renderer — see [Loading Textures → the texture registry](/tutorials/loading-textures#the-texture-registry-with-usetextures-experimental).
+> Building GPU pipelines often pairs with the **texture registry** (`useTexture`/`useTextures`). Those are core hooks that work with any renderer — see [Textures](./textures).
 
 ## External Resources
 

--- a/docs/webgpu/textures.mdx
+++ b/docs/webgpu/textures.mdx
@@ -1,0 +1,186 @@
+---
+title: Textures
+description: Load textures with useTexture and manage them with the reactive useTextures registry - enrollment, refcounted disposal, and when the registry re-renders.
+nav: 17
+---
+
+`useTexture` loads textures through three.js's `TextureLoader` with Suspense support. `useTextures` is a reactive registry that lets you reach those textures from anywhere in the tree and manage their GPU lifetime.
+
+`useTexture` does the **loading**; `useTextures` does the **access and lifecycle**. They're separate jobs on purpose.
+
+Both are exported from `@react-three/fiber` and work under either renderer, so the `@react-three/drei` `useTexture` is no longer required.
+
+> **Experimental (A5).** The `useTextures` API may change before it's stabilized.
+
+## useTexture
+
+```tsx
+import { useTexture } from '@react-three/fiber'
+
+// Single
+const diffuse = useTexture('/diffuse.png')
+
+// Array
+const [diffuse, normal] = useTexture(['/diffuse.png', '/normal.png'])
+
+// Record - the most convenient form, since it spreads into a material
+const props = useTexture({ map: '/diffuse.png', normalMap: '/normal.png' })
+return <meshStandardMaterial {...props} />
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `input` | `string \| string[] \| Record<string, string>` | URL, list of URLs, or a name to URL map. The return value mirrors the input shape. |
+| `options.onLoad` | `(texture) => void` | Called once when the texture(s) finish loading. Not called on a registry hit. |
+| `options.cache` | `boolean` | Enroll the result in the registry. Defaults to `true`. |
+
+Passing a bare function instead of `options` still works and is treated as `onLoad`:
+
+```tsx
+const floor = useTexture('/floor.jpg', (t) => {
+  t.wrapS = t.wrapT = THREE.RepeatWrapping
+})
+```
+
+### Registry enrollment
+
+`cache` defaults to `true`, so loading enrolls into the registry automatically. The same URL then returns the **same** `Texture` object everywhere, and that object outlives its last consumer.
+
+```tsx
+const diffuse = useTexture('/diffuse.png')
+diffuse.colorSpace = THREE.SRGBColorSpace
+
+// Elsewhere: the same object, with colorSpace already set
+const same = useTexture('/diffuse.png')
+```
+
+Pass `{ cache: false }` to skip registry enrollment for a texture:
+
+```tsx
+const scratch = useTexture('/scratch.png', { cache: false })
+```
+
+Registry reads in `useTexture` happen **once at mount**. A mounted `useTexture` does not re-render when the registry changes, so loading texture A never re-renders a component using texture B. To react to registry changes, use the selector form of `useTextures`.
+
+## useTextures
+
+`useTextures` returns a handle onto the registry, a `Map` of plain `Texture` objects keyed by URL (or by any key you choose for textures you register yourself).
+
+Calling `useTextures()` with no selector subscribes to the whole registry, so the component re-renders whenever a key is added or disposed. Pass a selector to narrow that to a single key. Reading with `get()` inside `useFrame` is live either way and needs no subscription.
+
+### Return value
+
+| Member | Type | Description |
+| --- | --- | --- |
+| `all` | `Map<string, Texture>` | The live registry. Treat as read-only. |
+| `get(input)` | `Texture \| undefined` (mirrors input shape) | Read one key, an array of keys, or a name to key map. |
+| `has(key)` | `boolean` | Whether a key exists. |
+| `add(key, texture)` | `void` | Register a texture that has no URL. Also accepts a record. |
+| `dispose(key, options?)` | `boolean` | Free GPU resources and remove the key. Refcount-aware. |
+| `disposeAll()` | `void` | Dispose everything and clear the registry. |
+
+### Reading textures
+
+```tsx
+import { useTexture, useTextures } from '@react-three/fiber'
+
+function Floor() {
+  // Load once, anywhere in the tree — registered by default
+  useTexture({
+    map: '/PavingStones092_1K_Color.jpg',
+    normalMap: '/PavingStones092_1K_Normal.jpg',
+  })
+  return null
+}
+
+function Wall() {
+  // Reach the same textures from a different component — the record form
+  // mirrors its input, so it drops straight into a material
+  const { map, normalMap } = useTextures().get({
+    map: '/PavingStones092_1K_Color.jpg',
+    normalMap: '/PavingStones092_1K_Normal.jpg',
+  })
+  return (
+    <mesh>
+      <planeGeometry />
+      <meshStandardMaterial map={map} normalMap={normalMap} />
+    </mesh>
+  )
+}
+```
+
+### Registering textures without a URL
+
+Render targets and procedural textures have no URL to key off, so register them yourself:
+
+```tsx
+const textures = useTextures()
+textures.add('rt-main', renderTarget.texture)
+```
+
+## Lifecycle and disposal
+
+Each mounted `useTexture` consumer holds a reference on the keys it uses, and releases it on unmount.
+
+`dispose(key)` is refcount-aware. If the key is still referenced by a mounted consumer, it **warns to the console, skips the disposal, and returns `false`**:
+
+```tsx
+const textures = useTextures()
+
+textures.dispose('/diffuse.png') // false if still in use, and nothing is freed
+textures.dispose('/diffuse.png', { force: true }) // disposes regardless
+textures.disposeAll() // scene teardown
+```
+
+> **A reference count of zero does not free anything.** Unmounting the last consumer only releases the reference. The texture stays in the registry and keeps its GPU memory until `dispose` or `disposeAll` is called. That is deliberate: leaving a scene and coming back should not re-upload its textures. It does mean a long-lived app has to dispose the keys it is finished with.
+
+## When is the registry reactive? (and the flip-flop pattern)
+
+There are three distinct situations, and only one of them wants React reactivity:
+
+| Use case | Tool | Reactive? |
+| --- | --- | --- |
+| Load an asset by URL | `useTexture(url)` | No — the object never changes |
+| **Swap** which texture lives under a key (occasionally) | `useTextures(s => s.get(key))` | Yes — scoped to that one key |
+| Swap a texture **every frame** (ping-pong) | `registry.get(key)` inside `useFrame` | No — read it imperatively |
+
+Loading a URL never needs reactivity (the texture instance is stable), and a render target being drawn into updates *inside* three.js (`needsUpdate`) without changing the JS object — so neither involves React.
+
+The one case that does is a **flip-flop / ping-pong**: you keep two textures and swap which one a material reads. For an *occasional* swap (e.g. toggling an output on some event), subscribe to just that key with the selector form — only this component re-renders, and only when the slot actually changes:
+
+```tsx
+function Output() {
+  // Re-renders only when the texture under 'finalOutput' is swapped
+  const tex = useTextures((s) => s.get('finalOutput'))
+  return (
+    <mesh>
+      <planeGeometry />
+      <meshBasicMaterial map={tex} />
+    </mesh>
+  )
+}
+
+// Elsewhere, from an event handler or effect (never during render,
+// since add() sets store state) — the Output component picks up texB
+useTextures().add('finalOutput', texB)
+```
+
+For a **per-frame** ping-pong, don't make React re-render every frame — read the current texture imperatively in the loop instead:
+
+```tsx
+function PingPong({ material }) {
+  const textures = useTextures()
+  useFrame((state) => {
+    const even = Math.floor(state.elapsed * 60) % 2 === 0
+    material.map = textures.get(even ? 'a' : 'b')
+  })
+  return null
+}
+```
+
+## Related
+
+- [Loading Textures](/tutorials/loading-textures) - tutorial introduction to texture loading
+- [Render Targets](/scene/render-targets) - creating the render targets you can register here


### PR DESCRIPTION
Closes #3838

New page at `docs/webgpu/textures.mdx`. I used `nav: 17` since that slot was open between Compute and Multi-Canvas. It covers `useTexture` and `useTextures` together: the `cache` default, refcounted `dispose()`, why a texture sticks around after its last consumer unmounts, and when the registry actually re-renders.

`loading-textures.mdx` links to it now instead of repeating it. I kept the moved prose as close to verbatim as I could so the diff reads as a move. One thing I did change: the flip-flop `add()` snippet now says it has to run from an event handler or effect. `add()` calls `setState` and the old version read like render-phase code.

`overview.mdx` gets two small edits. It was pointing at the `#the-texture-registry-with-usetextures-experimental` anchor that this PR deletes, and I added the new page to its Sections list.

A few things I wasn't sure about:

**Placement.** Both hooks live in `core/hooks/` now, and `webgpu/hooks/useTextures.tsx` is just a back-compat re-export. `overview.mdx` itself calls them core hooks that work with any renderer. I put the page under `docs/webgpu/` because that's what the issue asked for, but happy to move it.

**preload/clear.** These are `useLoader` aliases and don't touch the registry, so I left them off rather than sit them next to `dispose()` and imply they're related. `ChangeTexture.tsx` does use `preload` though, so if it should be documented somewhere, is that here or on the `useLoader` side?