### PR TITLE
fix(core): don't tear down a root remounted during the unmount grace period

### DIFF
--- a/.changeset/olive-toes-repeat.md
+++ b/.changeset/olive-toes-repeat.md
@@ -1,0 +1,7 @@
+---
+'@react-three/fiber': patch
+---
+
+fix: keep a root that was remounted during the unmount grace period alive.
+
+`unmountComponentAtNode` defers its teardown by 500ms. A `<StrictMode>` remount happens well inside that window and reuses the same root, store, scene and GL context, so the deferred callback destroyed a live root — `forceContextLoss()` is permanent, which left the canvas blank for the rest of the session. It now bails out when the root is active again.

--- a/packages/fiber/src/core/renderer.tsx
+++ b/packages/fiber/src/core/renderer.tsx
@@ -463,6 +463,13 @@ export function unmountComponentAtNode<TCanvas extends HTMLCanvasElement | Offsc
       if (state) {
         setTimeout(() => {
           try {
+            // A remount within the grace period — <StrictMode> in development
+            // does exactly this — reuses this canvas' root, store, scene and
+            // GL context, so tearing them down here would destroy a live root.
+            // `internal` is swapped for a fresh object on remount, hence the
+            // re-read from the store rather than from the captured `state`.
+            if (_roots.get(canvas)?.store.getState().internal.active) return
+
             state.events.disconnect?.()
             state.gl?.renderLists?.dispose?.()
             state.gl?.forceContextLoss?.()

--- a/packages/fiber/tests/canvas.test.tsx
+++ b/packages/fiber/tests/canvas.test.tsx
@@ -1,6 +1,6 @@
 import React, { act } from 'react'
 import { render } from '@testing-library/react'
-import { Canvas } from '../src'
+import { Canvas, RootState } from '../src'
 
 describe('web Canvas', () => {
   it('should correctly mount', async () => {
@@ -61,6 +61,33 @@ describe('web Canvas', () => {
     )
 
     expect(() => renderer.unmount()).not.toThrow()
+  })
+
+  it('should survive a StrictMode remount', async () => {
+    jest.useFakeTimers()
+
+    try {
+      let state!: RootState
+      await act(async () =>
+        render(
+          <React.StrictMode>
+            <Canvas onCreated={(created) => (state = created)}>
+              <group />
+            </Canvas>
+          </React.StrictMode>,
+        ),
+      )
+
+      // StrictMode already remounted the Canvas into the same root; the
+      // teardown deferred by the simulated unmount must not fire on it.
+      const forceContextLoss = jest.spyOn(state.gl, 'forceContextLoss')
+      await act(async () => void jest.advanceTimersByTime(1000))
+
+      expect(forceContextLoss).not.toHaveBeenCalled()
+      expect(state.get().internal.active).toBe(true)
+    } finally {
+      jest.useRealTimers()
+    }
   })
 
   it('plays nice with react SSR', async () => {


### PR DESCRIPTION
Fixes #3863.

Under `<StrictMode>`, a `<Canvas>` permanently loses its own WebGL context ~500 ms after mount in development: `THREE.WebGLRenderer: Context Lost.`, then the canvas stays blank.

```jsx
createRoot(document.getElementById('root')).render(
  <StrictMode>
    <Canvas>
      <mesh>
        <boxGeometry />
        <meshBasicMaterial />
      </mesh>
    </Canvas>
  </StrictMode>,
)
```

### Why

StrictMode runs the Canvas' mount effect → cleanup → effect again. The cleanup calls `unmountComponentAtNode`, which defers disposal by 500 ms. The remount happens immediately and reuses the same root, store, scene and GL context (`createRoot` keeps `prevStore`), so when the timer fires it tears down a *live* root:

- `forceContextLoss()` is permanent — nothing calls `restoreContext()`, and `getContext()` on that canvas keeps returning the lost context, so there is no recovery;
- `dispose(state.scene)` disposes the live scene's geometries and materials;
- `events.disconnect()` kills the live root's event handling;
- `_roots.delete(canvas)` unregisters it, so its real unmount later no-ops.

### Fix

Bail out of the deferred teardown when the root is active again. `internal` is swapped for a fresh object on remount, so the check re-reads it from the store rather than from the captured `state`.

### Test

`should survive a StrictMode remount` in `packages/fiber/tests/canvas.test.tsx` — red on `master` (`forceContextLoss` called), green with the fix. Full suite passes.
