### PR TITLE
fix: guard events.connect against null target

### DIFF
--- a/packages/fiber/src/web/events.ts
+++ b/packages/fiber/src/web/events.ts
@@ -38,6 +38,7 @@ export function createPointerEvents(store: RootStore): EventManager<HTMLElement>
       if (internal.lastEvent?.current && events.handlers) events.handlers.onPointerMove(internal.lastEvent.current)
     },
     connect: (target: HTMLElement) => {
+      if (!target) return
       const { set, events } = store.getState()
       events.disconnect?.()
       set((state) => ({ events: { ...state.events, connected: target } }))


### PR DESCRIPTION
## Summary

`events.connect(target)` does `target.addEventListener(...)` with no null guard. `disconnect` already checks `if (events.connected)`, but `connect` does not.

When a `<Canvas>` subtree is DOM-reparented via `appendChild` during a spring animation, r3f calls `events.connect(eventSource)` with `target == null`, crashing with:

```
TypeError: Cannot read properties of null (reading "addEventListener")
```

This happens 23+ times per fullscreen entry/exit with a common `Fullscreenable` pattern.

## Fix

Add `if (!target) return` at the top of the `connect` method in `packages/fiber/src/web/events.ts`, matching the defensive style already used in `disconnect`.

Fixes #3754