### PR TITLE
fix(fiber): bail out of deferred context-loss when root was re-activated

### DIFF
--- a/packages/fiber/src/core/renderer.tsx
+++ b/packages/fiber/src/core/renderer.tsx
@@ -462,6 +462,12 @@ export function unmountComponentAtNode<TCanvas extends HTMLCanvasElement | Offsc
     reconciler.updateContainer(null, fiber, null, () => {
       if (state) {
         setTimeout(() => {
+          // A StrictMode/dev remount re-claimed this canvas within the grace
+          // period; the store, scene and GL context are shared with the live
+          // root, so disposing them now would destroy the mounted view. The
+          // state must be re-read from the store since the remount replaced it.
+          const currentRoot = _roots.get(canvas)
+          if (currentRoot && currentRoot.store.getState().internal.active) return
           try {
             state.events.disconnect?.()
             state.gl?.renderLists?.dispose?.()


### PR DESCRIPTION
Fixes #3863

Under StrictMode in dev, the Canvas mount effect runs cleanup then effect again. The cleanup schedules disposal on a 500 ms timeout which then force-loses the WebGL context of the *remounted* root, since both share the same store and canvas.

The deferred callback now re-reads the current root from `_roots` and bails out if it was re-activated within the grace period (`internal.active === true`). Normal unmounts still dispose exactly as before; production is unaffected since StrictMode does not double-invoke there.

This is the exact approach suggested in the issue (the reporter confirmed it works as a patch-package patch).