### PR TITLE
Harden render and node types

### DIFF
--- a/docs/webgpu/render-pipeline.mdx
+++ b/docs/webgpu/render-pipeline.mdx
@@ -48,8 +48,8 @@ const { renderPipeline, passes } = useRenderPipeline()
 Both callbacks receive the full RootState (uniforms, nodes, scene, camera, etc.). Returning an object from either callback registers those passes into `state.passes`.
 
 ```typescript
-type RenderPipelineMainCallback = (state: RootState) => PassRecord | void
-type RenderPipelineSetupCallback = (state: RootState) => PassRecord | void
+type RenderPipelineMainCallback = (state: RenderPipelineCallbackState) => PassRecord | void
+type RenderPipelineSetupCallback = (state: RenderPipelineCallbackState) => PassRecord | void
 ```
 
 ### Return Value
@@ -211,16 +211,25 @@ Passes live in `state.passes`:
 
 ```typescript
 interface PassRecord {
-  scenePass: PassNode // Always created automatically
+  scenePass?: PassNode // three's PassNode, created automatically by the hook
   [key: string]: any // Custom passes you register
 }
 ```
 
-Access them from a callback, from `useThree()`, or from `useRenderPipeline()`:
+Inside `mainCB` and `setupCB`, `passes.scenePass` is typed as required: the hook installs it before either callback runs, so no guard or cast is needed:
+
+```tsx
+useRenderPipeline(({ renderPipeline, passes }) => {
+  const beauty = passes.scenePass.getTextureNode() // PassNode, no cast
+  renderPipeline.outputNode = bloom(beauty)
+})
+```
+
+From `useThree()` or `useRenderPipeline()` it is optional, since `state.passes` is empty before the pipeline exists and after `reset()` or `clearPasses()`:
 
 ```tsx
 const { passes } = useThree()
-console.log(passes.scenePass)
+passes.scenePass?.getTextureNode()
 ```
 
 ## Manual Control

--- a/docs/webgpu/render-pipeline.mdx
+++ b/docs/webgpu/render-pipeline.mdx
@@ -212,8 +212,15 @@ Passes live in `state.passes`:
 ```typescript
 interface PassRecord {
   scenePass?: PassNode // three's PassNode, created automatically by the hook
-  [key: string]: any // Custom passes you register
+  [key: string]: Node // Anything you register: texture reads, effect nodes, extra passes
 }
+```
+
+Registered entries are typed as three's `Node`. Narrow them at the call site when you need a specific member:
+
+```tsx
+const { passes } = useThree()
+const velocity = passes.velocity as TextureNode
 ```
 
 Inside `mainCB` and `setupCB`, `passes.scenePass` is typed as required: the hook installs it before either callback runs, so no guard or cast is needed:

--- a/docs/webgpu/render-pipeline.mdx
+++ b/docs/webgpu/render-pipeline.mdx
@@ -56,14 +56,19 @@ type RenderPipelineSetupCallback = (state: RenderPipelineCallbackState) => Regis
 ### Return Value
 
 ```typescript
-interface UseRenderPipelineReturn {
+type UseRenderPipelineReturn = {
   passes: PassRecord // All registered passes
-  renderPipeline: RenderPipeline | null
   clearPasses: () => void // Clear all passes
   reset: () => void // Reset the RenderPipeline instance
   rebuild: () => void // Force callbacks to re-run
-  isReady: boolean // True once RenderPipeline is configured
-}
+} & ({ isReady: true; renderPipeline: RenderPipeline } | { isReady: false; renderPipeline: null })
+```
+
+The return is discriminated on `isReady`, so checking it narrows `renderPipeline` to non-null:
+
+```tsx
+const { isReady, renderPipeline } = useRenderPipeline()
+if (isReady) renderPipeline.needsUpdate = true // RenderPipeline, not RenderPipeline | null
 ```
 
 ## You must set outputNode

--- a/docs/webgpu/render-pipeline.mdx
+++ b/docs/webgpu/render-pipeline.mdx
@@ -45,11 +45,12 @@ const { renderPipeline, passes } = useRenderPipeline()
 | `mainCB`  | `RenderPipelineMainCallback`  | Configure `outputNode` and create effect passes |
 | `setupCB` | `RenderPipelineSetupCallback` | Optional. Configure MRT on the scene pass     |
 
-Both callbacks receive the full RootState (uniforms, nodes, scene, camera, etc.). Returning an object from either callback registers those passes into `state.passes`.
+Both callbacks receive the full RootState (uniforms, nodes, scene, camera, etc.). Returning an object from either callback registers those passes into `state.passes`. The `scenePass` key is reserved for the hook's own pass and cannot be returned.
 
 ```typescript
-type RenderPipelineMainCallback = (state: RenderPipelineCallbackState) => PassRecord | void
-type RenderPipelineSetupCallback = (state: RenderPipelineCallbackState) => PassRecord | void
+type RegisteredPasses = Record<string, Node> & { scenePass?: never }
+type RenderPipelineMainCallback = (state: RenderPipelineCallbackState) => RegisteredPasses | void
+type RenderPipelineSetupCallback = (state: RenderPipelineCallbackState) => RegisteredPasses | void
 ```
 
 ### Return Value

--- a/example/src/demos/webgpu/WebGPUMotionBlur.tsx
+++ b/example/src/demos/webgpu/WebGPUMotionBlur.tsx
@@ -39,7 +39,7 @@ function RenderPipelineManager() {
       const vel = passes.scenePass.getTextureNode('velocity')
 
       // Use blurAmount from uniforms (or from outer scope via closure)
-      const blurNode = uniforms.blurAmount ?? blurAmount
+      const blurNode = (uniforms.blurAmount ?? blurAmount) as UniformNode<number>
       const mBlur = motionBlur(beauty, vel.mul(blurNode))
 
       // Add vignette effect for polish

--- a/packages/fiber/src/webgpu/hooks/useNodes.tsx
+++ b/packages/fiber/src/webgpu/hooks/useNodes.tsx
@@ -5,22 +5,16 @@ import { clearResourceEntries, rebuildResource, removeResourceEntries } from '..
 import { createLazyCreatorState, type CreatorState } from './ScopedStore'
 import { useScopedResource } from './useScopedResource'
 import { scopedNodeName } from './utils'
+import type { NodeLike } from '../../../types/store'
 
 //* Types ==============================
 
 /**
- * Minimal interface for TSL nodes.
- * Used instead of Three.js's Node type because the @types/three definitions
- * have inconsistencies where OperatorNode, ConstNode, etc. don't properly
- * extend Node with all required properties.
+ * Minimal interface for TSL nodes. The definition lives with the store types as `NodeLike`, so
+ * the shape creators may return and the shape `state.nodes` holds are the same type by
+ * construction. See `NodeLike` for why this is structural rather than three's `Node`.
  */
-export interface TSLNodeLike {
-  uuid?: string
-  nodeType?: string | null
-  /** label method for chaining - sets the node's label and returns self */
-  label?: ((label: string) => TSLNodeLike) | string
-  setName?: (name: string) => this
-}
+export type TSLNodeLike = NodeLike
 
 /** TSL node type - alias for compatibility */
 export type TSLNode = TSLNodeLike

--- a/packages/fiber/src/webgpu/hooks/useRenderPipeline.tsx
+++ b/packages/fiber/src/webgpu/hooks/useRenderPipeline.tsx
@@ -6,6 +6,7 @@ import { pass } from '#three/tsl'
 // Types are declared globally in types/renderPipeline.d.ts:
 // - ScenePassNode
 // - PassRecord
+// - RegisteredPasses
 // - RenderPipelineCallbackState
 // - RenderPipelineSetupCallback
 // - RenderPipelineMainCallback

--- a/packages/fiber/src/webgpu/hooks/useRenderPipeline.tsx
+++ b/packages/fiber/src/webgpu/hooks/useRenderPipeline.tsx
@@ -4,6 +4,7 @@ import * as THREE from '#three'
 import { pass } from '#three/tsl'
 
 // Types are declared globally in types/renderPipeline.d.ts:
+// - ScenePassNode
 // - PassRecord
 // - RenderPipelineCallbackState
 // - RenderPipelineSetupCallback
@@ -66,7 +67,7 @@ export function useRenderPipeline(
 
   // Track the scene/camera used for the current scenePass to avoid unnecessary recreation
   // Recreating scenePass triggers TSL node graph rebuild which can corrupt SkinningNode refs
-  const scenePassCacheRef = useRef<{ sceneUuid: string; cameraUuid: string; scenePass: any } | null>(null)
+  const scenePassCacheRef = useRef<{ sceneUuid: string; cameraUuid: string; scenePass: ScenePassNode } | null>(null)
 
   // Force scenePass recreation on the next effect run, without dropping the reference to the
   // outgoing pass. Clearing scenePassCacheRef directly would strand it: three does not free
@@ -107,7 +108,7 @@ export function useRenderPipeline(
     })
     // Safe to dispose synchronously here: the pipeline is torn down in the same tick, so nothing
     // is left referencing the pass. This is explicit user-requested cleanup.
-    scenePassCacheRef.current?.scenePass?.dispose?.()
+    scenePassCacheRef.current?.scenePass.dispose()
     callbacksRanRef.current = false
     scenePassCacheRef.current = null
     forceScenePassRebuildRef.current = false
@@ -140,7 +141,7 @@ export function useRenderPipeline(
 
     try {
       let pipeline = state.renderPipeline
-      let currentPasses = { ...state.passes } as PassRecord
+      let currentPasses: PassRecord = { ...state.passes }
 
       //* Create RenderPipeline if needed ==============================
       let justCreatedPipeline = false
@@ -160,9 +161,9 @@ export function useRenderPipeline(
 
       // The pass being replaced, if any. Disposed at the end of this effect, once the new graph
       // is installed -- never before, or the pipeline would render against a freed target.
-      let outgoingScenePass: any = null
+      let outgoingScenePass: ScenePassNode | null = null
 
-      let scenePass
+      let scenePass: ScenePassNode
       if (cacheValid) {
         scenePass = scenePassCacheRef.current!.scenePass
       } else {
@@ -203,7 +204,7 @@ export function useRenderPipeline(
         if (setupCBRef.current) {
           const freshState: RenderPipelineCallbackState = Object.assign({}, store.getState(), {
             renderPipeline: pipeline,
-            passes: currentPasses,
+            passes: { ...currentPasses, scenePass },
           })
           const setupResult = setupCBRef.current(freshState)
 
@@ -217,7 +218,7 @@ export function useRenderPipeline(
         if (mainCBRef.current) {
           const freshState: RenderPipelineCallbackState = Object.assign({}, store.getState(), {
             renderPipeline: pipeline,
-            passes: currentPasses,
+            passes: { ...currentPasses, scenePass },
           })
           const mainResult = mainCBRef.current(freshState)
 
@@ -245,7 +246,7 @@ export function useRenderPipeline(
       // Now that the new graph is installed and compiled, the replaced pass is unreachable.
       // three does not free render-target GPU memory on GC, so without this every rebuild()
       // stranded a full-screen target per MRT attachment. See #3854.
-      if (outgoingScenePass && outgoingScenePass !== scenePass) outgoingScenePass.dispose?.()
+      if (outgoingScenePass && outgoingScenePass !== scenePass) outgoingScenePass.dispose()
     } catch (error) {
       // Surfaced rather than rethrown: throwing here would take down the whole tree for what is
       // usually a recoverable pass-configuration mistake. Logged loudly so a failed pipeline

--- a/packages/fiber/src/webgpu/hooks/useRenderPipeline.tsx
+++ b/packages/fiber/src/webgpu/hooks/useRenderPipeline.tsx
@@ -10,6 +10,7 @@ import { pass } from '#three/tsl'
 // - RenderPipelineCallbackState
 // - RenderPipelineSetupCallback
 // - RenderPipelineMainCallback
+// - UseRenderPipelineActions
 // - UseRenderPipelineReturn
 
 //* Hook Implementation ==============================
@@ -274,15 +275,12 @@ export function useRenderPipeline(
   const passes = useThree((s) => s.passes)
   const renderPipeline = useThree((s) => s.renderPipeline)
 
-  return {
-    passes,
-    renderPipeline,
-    clearPasses,
-    reset,
-    rebuild,
-    // isReady indicates if RenderPipeline is configured and ready for rendering
-    isReady: renderPipeline !== null,
-  }
+  const actions: UseRenderPipelineActions = { passes, clearPasses, reset, rebuild }
+
+  // Two explicit literals rather than `isReady: renderPipeline !== null`, so the discriminated
+  // union in UseRenderPipelineReturn is built from a narrowed value instead of asserted.
+  if (renderPipeline) return { ...actions, isReady: true, renderPipeline }
+  return { ...actions, isReady: false, renderPipeline: null }
 }
 
 export default useRenderPipeline

--- a/packages/fiber/src/webgpu/hooks/useRenderPipeline.tsx
+++ b/packages/fiber/src/webgpu/hooks/useRenderPipeline.tsx
@@ -137,6 +137,12 @@ export function useRenderPipeline(
 
     if (!renderer || !scene || !camera) return
 
+    // Narrow the renderer union to WebGPURenderer. `isLegacy` above is the user-facing check;
+    // this one is what lets the type system follow. Only reachable if the two disagree.
+    if (!('isWebGPURenderer' in renderer)) {
+      throw new Error('useRenderPipeline: renderer is not a WebGPURenderer but isLegacy is false.')
+    }
+
     const state = store.getState()
     const set = store.setState
 
@@ -147,7 +153,7 @@ export function useRenderPipeline(
       //* Create RenderPipeline if needed ==============================
       let justCreatedPipeline = false
       if (!pipeline) {
-        pipeline = new THREE.RenderPipeline(renderer as THREE.WebGPURenderer)
+        pipeline = new THREE.RenderPipeline(renderer)
         justCreatedPipeline = true
       }
 
@@ -206,6 +212,8 @@ export function useRenderPipeline(
           const freshState: RenderPipelineCallbackState = Object.assign({}, store.getState(), {
             renderPipeline: pipeline,
             passes: { ...currentPasses, scenePass },
+            renderer,
+            isLegacy: false as const,
           })
           const setupResult = setupCBRef.current(freshState)
 
@@ -220,6 +228,8 @@ export function useRenderPipeline(
           const freshState: RenderPipelineCallbackState = Object.assign({}, store.getState(), {
             renderPipeline: pipeline,
             passes: { ...currentPasses, scenePass },
+            renderer,
+            isLegacy: false as const,
           })
           const mainResult = mainCBRef.current(freshState)
 

--- a/packages/fiber/tests/webgpu/webgpu-hooks-lifecycle.test.tsx
+++ b/packages/fiber/tests/webgpu/webgpu-hooks-lifecycle.test.tsx
@@ -552,9 +552,10 @@ describe('useRenderPipeline — pipeline wiring against the store', () => {
   function seedRenderer(store: RootStore) {
     const scene = new THREE.Scene()
     const camera = new THREE.PerspectiveCamera()
-    // A bare object is enough: the render pipeline only stores the renderer reference;
-    // it does not touch the GPU until .render() (Tier 2).
-    const renderer = {} as any
+    // A near-bare object is enough: the render pipeline only stores the renderer reference;
+    // it does not touch the GPU until .render() (Tier 2). The brand is what the hook narrows
+    // the renderer union on, so the fake must carry it like a real WebGPURenderer does.
+    const renderer = { isWebGPURenderer: true } as any
     store.setState({ scene, camera, renderer, isLegacy: false } as any)
     return { scene, camera, renderer }
   }

--- a/packages/fiber/tests/webgpu/webgpu-hooks-lifecycle.test.tsx
+++ b/packages/fiber/tests/webgpu/webgpu-hooks-lifecycle.test.tsx
@@ -695,12 +695,12 @@ describe('useRenderPipeline — pipeline wiring against the store', () => {
 
   it('rebuild(): disposes the replaced scenePass instead of stranding its render target', async () => {
     const { store, api } = await mountPipeline()
-    const firstPass = store.getState().passes.scenePass as any
+    const firstPass = store.getState().passes.scenePass!
     const disposeSpy = vi.spyOn(firstPass, 'dispose')
 
     await act(async () => api().rebuild())
 
-    const secondPass = store.getState().passes.scenePass as any
+    const secondPass = store.getState().passes.scenePass!
     expect(secondPass).not.toBe(firstPass)
     expect(disposeSpy).toHaveBeenCalledTimes(1)
   })
@@ -711,12 +711,12 @@ describe('useRenderPipeline — pipeline wiring against the store', () => {
     // render target -- worse than the leak being fixed.
     const { store, api } = await mountPipeline()
     const pipeline = store.getState().renderPipeline as any
-    const firstPass = store.getState().passes.scenePass as any
+    const firstPass = store.getState().passes.scenePass!
     expect(pipeline.outputNode).toBe(firstPass)
 
     await act(async () => api().rebuild())
 
-    const secondPass = store.getState().passes.scenePass as any
+    const secondPass = store.getState().passes.scenePass!
     expect(pipeline.outputNode).toBe(secondPass)
     expect(pipeline.outputNode).not.toBe(firstPass)
   })
@@ -732,7 +732,7 @@ describe('useRenderPipeline — pipeline wiring against the store', () => {
     await act(async () => {
       ;({ rerender } = withStore(store, <Comp />))
     })
-    const scenePass = store.getState().passes.scenePass as any
+    const scenePass = store.getState().passes.scenePass!
     const disposeSpy = vi.spyOn(scenePass, 'dispose')
 
     await act(async () =>
@@ -749,7 +749,7 @@ describe('useRenderPipeline — pipeline wiring against the store', () => {
 
   it('reset(): disposes the scenePass it drops', async () => {
     const { store, api } = await mountPipeline()
-    const scenePass = store.getState().passes.scenePass as any
+    const scenePass = store.getState().passes.scenePass!
     const disposeSpy = vi.spyOn(scenePass, 'dispose')
 
     await act(async () => api().reset())

--- a/packages/fiber/tests/webgpu/webgpu-hooks-lifecycle.test.tsx
+++ b/packages/fiber/tests/webgpu/webgpu-hooks-lifecycle.test.tsx
@@ -576,6 +576,11 @@ describe('useRenderPipeline — pipeline wiring against the store', () => {
     expect(typeof (state.renderPipeline as any).render).toBe('function')
     expect(state.passes.scenePass).toBeDefined()
     expect(api.isReady).toBe(true)
+    // Type-level: isReady discriminates the return, narrowing renderPipeline to non-null.
+    if (api.isReady) {
+      const pipeline: THREE.RenderPipeline = api.renderPipeline
+      expect(pipeline).toBe(state.renderPipeline)
+    }
   })
 
   it('setupCB + mainCB run and their returned passes land on the store', async () => {

--- a/packages/fiber/tests/webgpu/webgpu-hooks-lifecycle.test.tsx
+++ b/packages/fiber/tests/webgpu/webgpu-hooks-lifecycle.test.tsx
@@ -747,6 +747,14 @@ describe('useRenderPipeline — pipeline wiring against the store', () => {
     expect(disposeSpy).not.toHaveBeenCalled()
   })
 
+  it('type: a callback cannot return scenePass, the hook owns that entry', () => {
+    // Compile-time only. If this line stops erroring, the reserved-key guard on
+    // RegisteredPasses has regressed and a callback could swap out the pass the hook disposes.
+    // @ts-expect-error scenePass is reserved
+    const cb: RenderPipelineMainCallback = ({ passes }) => ({ scenePass: passes.scenePass })
+    expect(cb).toBeTypeOf('function')
+  })
+
   it('reset(): disposes the scenePass it drops', async () => {
     const { store, api } = await mountPipeline()
     const scenePass = store.getState().passes.scenePass!

--- a/packages/fiber/types/renderPipeline.d.ts
+++ b/packages/fiber/types/renderPipeline.d.ts
@@ -42,10 +42,15 @@ declare global {
    *
    * `passes.scenePass` is required here: the hook installs the default scene pass before either
    * callback runs, so callbacks can use it without a guard or a cast.
+   *
+   * `renderer` is narrowed to `WebGPURenderer` and `isLegacy` to `false`: the hook throws under
+   * the legacy renderer before either callback can run, so a callback never sees WebGL.
    */
   type RenderPipelineCallbackState = RootState & {
     renderPipeline: ThreeRenderPipeline
     passes: PassRecord & { scenePass: ScenePassNode }
+    renderer: import('three/webgpu').WebGPURenderer
+    isLegacy: false
   }
 
   /**

--- a/packages/fiber/types/renderPipeline.d.ts
+++ b/packages/fiber/types/renderPipeline.d.ts
@@ -48,11 +48,21 @@ declare global {
     passes: PassRecord & { scenePass: ScenePassNode }
   }
 
+  /**
+   * What a callback may return to register entries into `state.passes`.
+   *
+   * `scenePass` is reserved. The hook owns that entry and its lifecycle: it caches the pass it
+   * created, and `rebuild()` / `reset()` dispose that cached pass. A callback overwriting the
+   * store entry would leave the store pointing at a node the hook never disposes, and the hook
+   * disposing a pass nothing references. So returning it is a type error.
+   */
+  type RegisteredPasses = Record<string, import('three/webgpu').Node> & { scenePass?: never }
+
   /** Setup callback - runs first to configure MRT, create additional passes */
-  type RenderPipelineSetupCallback = (state: RenderPipelineCallbackState) => PassRecord | void
+  type RenderPipelineSetupCallback = (state: RenderPipelineCallbackState) => RegisteredPasses | void
 
   /** Main callback - runs second to configure outputNode, create effect passes */
-  type RenderPipelineMainCallback = (state: RenderPipelineCallbackState) => PassRecord | void
+  type RenderPipelineMainCallback = (state: RenderPipelineCallbackState) => RegisteredPasses | void
 
   /** Return type for useRenderPipeline hook */
   interface UseRenderPipelineReturn {

--- a/packages/fiber/types/renderPipeline.d.ts
+++ b/packages/fiber/types/renderPipeline.d.ts
@@ -12,12 +12,35 @@ declare global {
    */
   type ThreeRenderPipeline = import('three/webgpu').RenderPipeline
 
-  /** Pass record - stores TSL pass nodes for render pipeline */
-  type PassRecord = Record<string, any>
+  /**
+   * The pass `useRenderPipeline` creates for you: three's own `PassNode`, as returned by
+   * `pass(scene, camera)` from `three/tsl`. Referenced from three so members like
+   * `getTextureNode`, `setMRT` and `dispose` track the installed version.
+   */
+  type ScenePassNode = import('three/webgpu').PassNode
 
-  /** State passed to pipeline callbacks after the active pipeline has been created */
+  /**
+   * Pass record - stores TSL pass nodes for render pipeline.
+   *
+   * `scenePass` is the only key the library owns. It is optional here because this is also the
+   * shape of `state.passes`, which is `{}` before the pipeline exists and again after `reset()`
+   * or `clearPasses()`. Inside the callbacks it is always present; see
+   * {@link RenderPipelineCallbackState}. Every other key is user-registered and stays open.
+   */
+  interface PassRecord {
+    scenePass?: ScenePassNode
+    [key: string]: any
+  }
+
+  /**
+   * State passed to pipeline callbacks after the active pipeline has been created.
+   *
+   * `passes.scenePass` is required here: the hook installs the default scene pass before either
+   * callback runs, so callbacks can use it without a guard or a cast.
+   */
   type RenderPipelineCallbackState = RootState & {
     renderPipeline: ThreeRenderPipeline
+    passes: PassRecord & { scenePass: ScenePassNode }
   }
 
   /** Setup callback - runs first to configure MRT, create additional passes */

--- a/packages/fiber/types/renderPipeline.d.ts
+++ b/packages/fiber/types/renderPipeline.d.ts
@@ -25,11 +25,16 @@ declare global {
    * `scenePass` is the only key the library owns. It is optional here because this is also the
    * shape of `state.passes`, which is `{}` before the pipeline exists and again after `reset()`
    * or `clearPasses()`. Inside the callbacks it is always present; see
-   * {@link RenderPipelineCallbackState}. Every other key is user-registered and stays open.
+   * {@link RenderPipelineCallbackState}.
+   *
+   * Every other key is user-registered, via a callback's return value. Those are TSL nodes of
+   * any kind, not only passes: texture reads of an MRT attachment, effect nodes, extra
+   * `pass()` instances. `Node` is the common base, so that is the bound. Narrow at the call
+   * site when you need a member, e.g. `passes.velocity as TextureNode`.
    */
   interface PassRecord {
     scenePass?: ScenePassNode
-    [key: string]: any
+    [key: string]: import('three/webgpu').Node
   }
 
   /**

--- a/packages/fiber/types/renderPipeline.d.ts
+++ b/packages/fiber/types/renderPipeline.d.ts
@@ -69,19 +69,38 @@ declare global {
   /** Main callback - runs second to configure outputNode, create effect passes */
   type RenderPipelineMainCallback = (state: RenderPipelineCallbackState) => RegisteredPasses | void
 
-  /** Return type for useRenderPipeline hook */
-  interface UseRenderPipelineReturn {
+  /** The imperative half of useRenderPipeline's return value, present in every state */
+  interface UseRenderPipelineActions {
     /** Current passes from state */
     passes: PassRecord
-    /** RenderPipeline instance (null if not initialized) */
-    renderPipeline: ThreeRenderPipeline | null
     /** Clear all passes from state */
     clearPasses: () => void
     /** Reset RenderPipeline entirely (clears PP + passes) */
     reset: () => void
     /** Re-run setup/main callbacks with current closure values */
     rebuild: () => void
-    /** True when RenderPipeline is configured and ready */
-    isReady: boolean
   }
+
+  /**
+   * Return type for useRenderPipeline hook, discriminated on `isReady`.
+   *
+   * `if (isReady)` narrows `renderPipeline` to non-null, which is what the docs already tell
+   * callers to check. `passes.scenePass` deliberately stays optional in the ready branch:
+   * `clearPasses()` empties the record while leaving the pipeline in place.
+   */
+  type UseRenderPipelineReturn = UseRenderPipelineActions &
+    (
+      | {
+          /** True when RenderPipeline is configured and ready */
+          isReady: true
+          /** RenderPipeline instance */
+          renderPipeline: ThreeRenderPipeline
+        }
+      | {
+          /** False until the pipeline has been created */
+          isReady: false
+          /** Not initialized yet, or torn down by reset() */
+          renderPipeline: null
+        }
+    )
 }

--- a/packages/fiber/types/store.d.ts
+++ b/packages/fiber/types/store.d.ts
@@ -313,7 +313,7 @@ export interface RootState {
   /** WebGPU RenderPipeline instance - use useRenderPipeline() hook */
   renderPipeline: ThreeRenderPipeline | null
   /** Global TSL pass nodes for render pipeline - use useRenderPipeline() hook */
-  passes: Record<string, any>
+  passes: PassRecord
   /** Internal version counter for HMR - incremented by rebuildNodes/rebuildUniforms to bust memoization */
   _hmrVersion: number
   /** Internal: whether setSize() has taken ownership of canvas dimensions */

--- a/packages/fiber/types/store.d.ts
+++ b/packages/fiber/types/store.d.ts
@@ -42,6 +42,33 @@ export type BufferRecord = Record<string, BufferLike>
  */
 export type BufferStore = Record<string, BufferLike | BufferRecord>
 
+//* Node Types (useNodes) ========================================
+
+/**
+ * Structural shape of a TSL node as stored on `state.nodes`.
+ *
+ * Deliberately minimal rather than three's nominal `Node`: in @types/three several node classes
+ * TSL hands back (OperatorNode, ConstNode, ...) do not extend `Node` cleanly, so a `Node` bound
+ * would reject values `useNodes` creators legitimately return. This is the same shape
+ * `useNodes` already constrains creators to (`TSLNodeLike`).
+ */
+export interface NodeLike {
+  uuid?: string
+  nodeType?: string | null
+  /** label method for chaining - sets the node's label and returns self */
+  label?: ((label: string) => NodeLike) | string
+  setName?: (name: string) => this
+}
+
+/** Flat record of TSL nodes (no nested scopes) */
+export type NodeRecord = Record<string, NodeLike>
+
+/**
+ * Node store that can contain both root-level nodes and scoped node objects.
+ * Structure: { wobble: OperatorNode, fx: { blur: ShaderCallable } }
+ */
+export type NodeStore = Record<string, NodeLike | NodeRecord>
+
 //* Storage Types (useGPUStorage) ========================================
 
 /**
@@ -301,7 +328,7 @@ export interface RootState {
   /** Global TSL uniform nodes - root-level uniforms + scoped sub-objects. Use useUniforms() hook */
   uniforms: UniformStore
   /** Global TSL nodes - root-level nodes + scoped sub-objects. Use useNodes() hook */
-  nodes: Record<string, any>
+  nodes: NodeStore
   /** Global TSL buffer nodes - root-level buffers + scoped sub-objects. Use useBuffers() hook */
   buffers: BufferStore
   /** Global GPU storage (textures, etc.) - root-level storage + scoped sub-objects. Use useGPUStorage() hook */

--- a/packages/fiber/types/tsl.d.ts
+++ b/packages/fiber/types/tsl.d.ts
@@ -26,7 +26,33 @@ declare global {
    * ergonomics. The result is three's structural type, so members stay in sync with the
    * installed three instead of needing to be mirrored by hand.
    */
-  type UniformNode<T = unknown> = import('three/webgpu').UniformNode<unknown, T>
+  type UniformNode<T = unknown> = import('three/webgpu').UniformNode<UniformNodeTypeFor<T>, T>
+
+  /**
+   * three's node type name for a uniform value type, mirroring the `uniform()` overloads.
+   * A `UniformNode<number>` is a `Node<'float'>`, so TSL math (`.mul`, `.add`, ...) accepts it.
+   * Unknown or unlisted value types resolve to `unknown`, which TSL math rejects: narrow with
+   * `as UniformNode<number>` (or the matching value type) at the call site.
+   */
+  type UniformNodeTypeFor<T> = T extends number
+    ? 'float'
+    : T extends boolean
+      ? 'bool'
+      : T extends import('three/webgpu').Color
+        ? 'color'
+        : T extends import('three/webgpu').Vector2
+          ? 'vec2'
+          : T extends import('three/webgpu').Vector3
+            ? 'vec3'
+            : T extends import('three/webgpu').Vector4
+              ? 'vec4'
+              : T extends import('three/webgpu').Matrix2
+                ? 'mat2'
+                : T extends import('three/webgpu').Matrix3
+                  ? 'mat3'
+                  : T extends import('three/webgpu').Matrix4
+                    ? 'mat4'
+                    : unknown
 
   /**
    * ShaderCallable - the return type of Fn()


### PR DESCRIPTION
Hard types `scenePass` and adds the generic `Node` type to the `passes` record along with various other hardenings:

- Reserve `scenePass` in callback return values (`RegisteredPasses`), with a compile-time test.
- Narrow `renderer` to `WebGPURenderer` and `isLegacy` to `false` inside callbacks. The hook narrows on `isWebGPURenderer` rather than casting, adding a guard that only fires if the two disagree.
- Type `state.nodes` as `NodeStore`, the last registry that was `Record<string, any>`.
- Discriminate `useRenderPipeline`'s return on `isReady`.
