### PR TITLE
fix(webgpu): make a primary canvas own the renderer's default target

### DIFF
--- a/example/src/demos/index.tsx
+++ b/example/src/demos/index.tsx
@@ -41,6 +41,7 @@ const SVGRenderer = { Component: lazy(() => import('./legacy/SVGRenderer')) }
 // Examples showcasing WebGPU renderer with TSL
 const WebGPU = { Component: lazy(() => import('./webgpu/WebGPU')) }
 const WebGPUMultiCanvas = { Component: lazy(() => import('./webgpu/WebGPUMultiCanvas')) }
+const WebGPUPrimaryOnly = { Component: lazy(() => import('./webgpu/WebGPUPrimaryOnly')) }
 const WebGPUSharedUniforms = { Component: lazy(() => import('./webgpu/WebGPUSharedUniforms')) }
 const WebGPURagingSea = { Component: lazy(() => import('./webgpu/WebGPURagingSea')) }
 const WebGPUMotionBlur = { Component: lazy(() => import('./webgpu/WebGPUMotionBlur')) }
@@ -87,6 +88,7 @@ export {
   // WebGPU
   WebGPU,
   WebGPUMultiCanvas,
+  WebGPUPrimaryOnly,
   WebGPUSharedUniforms,
   WebGPURagingSea,
   WebGPUMotionBlur,

--- a/example/src/demos/webgpu/WebGPUPrimaryOnly.tsx
+++ b/example/src/demos/webgpu/WebGPUPrimaryOnly.tsx
@@ -36,6 +36,10 @@ function SizeReadout({ onChange }: { onChange: (text: string) => void }) {
   const last = useRef('')
   const buffer = useRef(new THREE.Vector2())
   useFrame(({ renderer, size, viewport }) => {
+    if (!('getCanvasTarget' in renderer)) {
+      if (last.current !== 'not a WebGPU renderer') onChange((last.current = 'not a WebGPU renderer'))
+      return
+    }
     renderer.getCanvasTarget().getDrawingBufferSize(buffer.current)
     const expected = `${Math.floor(size.width * viewport.dpr)}x${Math.floor(size.height * viewport.dpr)}`
     const actual = `${buffer.current.x}x${buffer.current.y}`
@@ -49,8 +53,10 @@ export default function WebGPUPrimaryOnly() {
   const [readout, setReadout] = useState('…')
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%' }}>
-      {/* The id is the trigger: it registers this canvas as a primary and gives it a canvas target. */}
-      <Canvas id="primary-only" dpr={[1, 2]} camera={{ position: [0, 0, 5] }}>
+      {/* The id is the trigger: it registers this canvas as a primary and gives it a canvas target.
+          `renderer` selects WebGPU: the examples app compiles the /webgpu entry with both build
+          flags on, where an absent renderer prop still means WebGL. */}
+      <Canvas id="primary-only" renderer dpr={[1, 2]} camera={{ position: [0, 0, 5] }}>
         <ambientLight intensity={0.6} />
         <directionalLight position={[3, 4, 5]} intensity={2} />
         <SpinningBox />

--- a/example/src/demos/webgpu/WebGPUPrimaryOnly.tsx
+++ b/example/src/demos/webgpu/WebGPUPrimaryOnly.tsx
@@ -1,0 +1,76 @@
+import { Canvas, useFrame } from '@react-three/fiber/webgpu'
+import { useRef, useState } from 'react'
+import * as THREE from 'three/webgpu'
+
+/**
+ * A lone `<Canvas id>` — a primary with no secondaries.
+ *
+ * Repro for the alpha.4 regression of #3847: giving a WebGPU canvas an id made R3F size a second
+ * CanvasTarget around the same element while the renderer kept drawing (and building its depth
+ * buffer) with its own. Without a secondary to trigger setCanvasTarget the two never met, so every
+ * frame raised:
+ *
+ *   GPUValidationError: The depth stencil attachment [depthBuffer] size (300, 150) does not match
+ *   the size of the other attachments' base plane (…)
+ *
+ * Expected: a spinning box, an empty console, and the readout below agreeing with the renderer's
+ * drawing buffer. Resize the window and check the readout follows.
+ */
+
+function SpinningBox() {
+  const ref = useRef<THREE.Mesh>(null!)
+  useFrame((_, delta) => {
+    ref.current.rotation.x += delta * 0.5
+    ref.current.rotation.y += delta
+  })
+  return (
+    <mesh ref={ref}>
+      <boxGeometry args={[1.5, 1.5, 1.5]} />
+      <meshStandardMaterial color="orange" />
+    </mesh>
+  )
+}
+
+/** Compares R3F's size with what the renderer actually draws into. They must agree. */
+function SizeReadout({ onChange }: { onChange: (text: string) => void }) {
+  const last = useRef('')
+  const buffer = useRef(new THREE.Vector2())
+  useFrame(({ renderer, size, viewport }) => {
+    renderer.getCanvasTarget().getDrawingBufferSize(buffer.current)
+    const expected = `${Math.floor(size.width * viewport.dpr)}x${Math.floor(size.height * viewport.dpr)}`
+    const actual = `${buffer.current.x}x${buffer.current.y}`
+    const text = `expected ${expected} · drawing buffer ${actual} · ${expected === actual ? 'OK' : 'MISMATCH'}`
+    if (text !== last.current) onChange((last.current = text))
+  })
+  return null
+}
+
+export default function WebGPUPrimaryOnly() {
+  const [readout, setReadout] = useState('…')
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+      {/* The id is the trigger: it registers this canvas as a primary and gives it a canvas target. */}
+      <Canvas id="primary-only" dpr={[1, 2]} camera={{ position: [0, 0, 5] }}>
+        <ambientLight intensity={0.6} />
+        <directionalLight position={[3, 4, 5]} intensity={2} />
+        <SpinningBox />
+        <SizeReadout onChange={setReadout} />
+      </Canvas>
+      <div
+        style={{
+          position: 'absolute',
+          left: 12,
+          bottom: 12,
+          padding: '6px 10px',
+          background: 'rgba(0,0,0,0.6)',
+          color: 'white',
+          fontFamily: 'monospace',
+          fontSize: 12,
+          borderRadius: 4,
+          pointerEvents: 'none',
+        }}>
+        {readout}
+      </div>
+    </div>
+  )
+}

--- a/packages/fiber/src/core/renderer.tsx
+++ b/packages/fiber/src/core/renderer.tsx
@@ -313,14 +313,19 @@ export function createRoot<TCanvas extends HTMLCanvasElement | OffscreenCanvas>(
               // Allows users to pass pre-initialized external renderers
               // @see https://github.com/pmndrs/react-three-fiber/issues/3651
               if (!renderer.hasInitialized?.()) {
-                // Set canvas dimensions before init to ensure depth buffer is created at correct size
-                // WebGPU creates GPU resources during init() based on canvas.width/height
-                // Without this, depth buffer uses default 300x150 causing size mismatch errors
+                // Size the renderer before init so its GPU resources are created at the right
+                // size. three sizes the depth/stencil and MSAA colour buffers from its *own*
+                // CanvasTarget (`renderer._canvasTarget`, `_width * _pixelRatio`), which reads the
+                // canvas element's width/height once at construction and never again. Writing
+                // canvas.width/height directly, as this used to, therefore only moved the swap
+                // chain: the target stayed at 300x150 and so did the depth buffer, and the first
+                // frame raised a GPUValidationError about mismatched attachment sizes.
+                // setSize goes through the target, so both stay in step. Before init the resize
+                // listener is a no-op, so this is safe to call here.
                 const size = computeInitialSize(canvas, propsSize)
                 if (size.width > 0 && size.height > 0) {
-                  const pixelRatio = calculateDpr(dpr)
-                  ;(canvas as HTMLCanvasElement).width = size.width * pixelRatio
-                  ;(canvas as HTMLCanvasElement).height = size.height * pixelRatio
+                  renderer.setPixelRatio(calculateDpr(dpr))
+                  renderer.setSize(size.width, size.height, false)
                 }
                 await renderer.init()
               }
@@ -337,10 +342,21 @@ export function createRoot<TCanvas extends HTMLCanvasElement | OffscreenCanvas>(
               state.set({ webGPUSupported: isWebGPUBackend, renderer: renderer, primaryStore: store })
 
               //* Register as Primary Canvas ==============================
-              // If this canvas has an id, register it so other canvases can target it
-              // Also create a CanvasTarget for when multi-canvas mode is enabled
+              // If this canvas has an id, register it so other canvases can target it.
+              //
+              // The primary's canvas target is the renderer's *own* default target, not a second
+              // CanvasTarget wrapped around the same element. The renderer only ever sizes,
+              // listens to, and builds GPU attachments for `renderer._canvasTarget`; a separate
+              // wrapper shares the element but none of that, so sizing it moved the swap chain
+              // while the renderer's depth buffer stayed at its construction size (300x150).
+              // Without a secondary to flip `isMultiCanvas`, nothing ever called setCanvasTarget
+              // on the wrapper, so a lone `<Canvas id>` rendered with mismatched attachments on
+              // every frame. One element, one target: whichever canvas is active, the target it
+              // sizes is the one the renderer draws with.
               if (canvasId && !state.internal.isSecondary) {
-                const canvasTarget = new THREE.CanvasTarget(canvas as HTMLCanvasElement)
+                // Optional-call: a mock or foreign renderer without canvas targets simply has
+                // none, and the store then sizes the renderer directly.
+                const canvasTarget = (renderer as WebGPURenderer).getCanvasTarget?.()
                 const unregisterPrimary = registerPrimary(canvasId, renderer as WebGPURenderer, store)
                 state.set((prev) => ({
                   internal: {
@@ -647,14 +663,19 @@ export function createRoot<TCanvas extends HTMLCanvasElement | OffscreenCanvas>(
           order: schedulerConfig?.order,
         })
 
-        // Register canvas target job - sets the canvas target for multi-canvas WebGPU rendering
+        // Register canvas target job - makes this root's canvas target the renderer's active one
         // Runs in 'start' phase so it's set before any other jobs (including user render jobs)
         const unregisterCanvasTarget = scheduler.register(
           () => {
             const state = store.getState()
-            if (state.internal.isMultiCanvas && state.internal.canvasTarget) {
+            const canvasTarget = state.internal.canvasTarget
+            if (canvasTarget) {
               const renderer = state.internal.actualRenderer as WebGPURenderer
-              renderer.setCanvasTarget(state.internal.canvasTarget)
+              // A lone primary owns the renderer's default target, which is already active; only
+              // swap when some other canvas (a secondary, or the primary after one) left it
+              // pointed elsewhere. setCanvasTarget also moves the resize listener, so skipping
+              // the no-op swap keeps that listener untouched on the common single-canvas path.
+              if (renderer.getCanvasTarget() !== canvasTarget) renderer.setCanvasTarget(canvasTarget)
 
               // Flush a pending resize for THIS root, now that its target is the active one.
               //
@@ -894,9 +915,11 @@ export function unmountComponentAtNode<TCanvas extends HTMLCanvasElement | Offsc
             const unregisterPrimary = state.internal.unregisterPrimary
             if (unregisterPrimary) unregisterPrimary()
 
-            // Dispose CanvasTarget for secondary canvases
+            // Dispose the CanvasTarget we created. A primary's target is the renderer's own
+            // default target, which the renderer owns and which may outlive this root (an
+            // external renderer reused across mounts), so only secondaries dispose theirs.
             const canvasTarget = state.internal.canvasTarget
-            if (canvasTarget?.dispose) canvasTarget.dispose()
+            if (state.internal.isSecondary && canvasTarget?.dispose) canvasTarget.dispose()
 
             state.events.disconnect?.()
             // Clean up occlusion system and helper group

--- a/packages/fiber/src/core/store.ts
+++ b/packages/fiber/src/core/store.ts
@@ -392,7 +392,7 @@ export const createStore = (
       if (viewport.dpr > 0) resizeTarget.setPixelRatio(viewport.dpr)
       resizeTarget.setSize(size.width, size.height, false)
 
-      // Invalidate this root's cached render pass descriptor on the next frame.
+      // Invalidate this root's cached render pass descriptor on the next frame, if three didn't.
       //
       // WebGPUBackend caches the depth-stencil attachment view per canvas and only rebuilds it
       // when the sample count changes, while the colour attachment is pulled fresh from the swap
@@ -405,7 +405,12 @@ export const createStore = (
       // one, so it cannot be called safely from here. The flush happens in the canvas-target job
       // (see renderer.tsx), which runs in the `start` phase where our own target is guaranteed
       // active. See #3847.
-      internal.canvasTargetSizeDirty = true
+      //
+      // When our target *is* the active one (a lone primary owns the renderer's default target,
+      // so this is the whole single-canvas path) the listener already ran inside setSize and a
+      // second flush would only reconfigure the swap chain again for nothing.
+      const activeTarget = (actualRenderer as Partial<{ getCanvasTarget(): unknown }>).getCanvasTarget?.()
+      if (!canvasTarget || activeTarget !== canvasTarget) internal.canvasTargetSizeDirty = true
     }
 
     // Update viewport and frustum once the camera changes

--- a/packages/fiber/tests/multicanvas-resize.test.tsx
+++ b/packages/fiber/tests/multicanvas-resize.test.tsx
@@ -21,6 +21,7 @@
  * bug is about *which object gets called*, not what the GPU does with it.
  */
 import * as THREE from 'three'
+import { CanvasTarget } from 'three/webgpu'
 
 import { createStore } from '../src/core/store'
 import type { RootStore } from '../src'
@@ -133,4 +134,92 @@ describe('multi-canvas resize (#3847)', () => {
   // The flush itself — canvas-target job calls setCanvasTarget then backend.updateSize(), and
   // the depth attachment stops mismatching the colour attachment — needs a real device.
   it.todo('covered by Tier 2: a secondary resizing while inactive no longer raises GPUValidationError')
+})
+
+/**
+ * A stand-in for three's Renderer that keeps its *real* contract with CanvasTarget: sizing is
+ * target-implicit (forwards to `_canvasTarget`), the drawing buffer -- and so the depth buffer --
+ * is read from that same target, and the resize listener rides along with setCanvasTarget.
+ */
+function makeForwardingRenderer(canvas: HTMLCanvasElement) {
+  const backend = { updateSize: vi.fn() }
+  const onResize = () => backend.updateSize()
+  const defaultTarget = new CanvasTarget(canvas)
+  defaultTarget.addEventListener('resize', onResize)
+  const renderer = {
+    backend,
+    _canvasTarget: defaultTarget,
+    getCanvasTarget: () => renderer._canvasTarget,
+    setCanvasTarget(target: CanvasTarget) {
+      renderer._canvasTarget.removeEventListener('resize', onResize)
+      renderer._canvasTarget = target
+      target.addEventListener('resize', onResize)
+    },
+    setSize: (w: number, h: number, updateStyle?: boolean) => renderer._canvasTarget.setSize(w, h, updateStyle),
+    setPixelRatio: (dpr: number) => renderer._canvasTarget.setPixelRatio(dpr),
+    getDrawingBufferSize: () => renderer._canvasTarget.getDrawingBufferSize(new THREE.Vector2()),
+  }
+  return { renderer, defaultTarget }
+}
+
+function makeStoreFor(renderer: object, canvasTarget: CanvasTarget, extra: Record<string, unknown> = {}) {
+  const store: RootStore = createStore(noop, noop)
+  store.setState((state) => ({
+    camera: new THREE.PerspectiveCamera() as any,
+    internal: { ...state.internal, actualRenderer: renderer as any, canvasTarget, ...extra },
+  }))
+  return store
+}
+
+describe('a lone primary owns the renderer default target (alpha.4 regression of #3847)', () => {
+  // The alpha.4 fix routed a primary's resize to `internal.canvasTarget`, which was a *second*
+  // CanvasTarget wrapped around the same element. three only sizes, listens to and builds the
+  // depth buffer for its own `_canvasTarget`; with no secondary to flip isMultiCanvas nothing
+  // ever made the wrapper active, so the swap chain followed the layout while the renderer's
+  // depth buffer stayed at the element's construction size (300x150):
+  //   "The depth stencil attachment size (300, 150) does not match the size of the other
+  //    attachments (1288, 1196)".
+  // The primary's target is now the renderer's own default target, so there is nothing to
+  // desync.
+  it("a resize on the primary's target is a resize of the renderer's drawing buffer", () => {
+    const canvas = document.createElement('canvas')
+    const { renderer, defaultTarget } = makeForwardingRenderer(canvas)
+    const store = makeStoreFor(renderer, defaultTarget)
+
+    store.setState((state) => ({ viewport: { ...state.viewport, dpr: 2 } }))
+    store.setState((state) => ({ size: { ...state.size, width: 644, height: 598 } }))
+
+    // The depth buffer is sized from exactly this call. (The element's own width/height are
+    // pinned by the test canvas mock, so the target's drawing buffer is the observable here.)
+    expect(renderer.getDrawingBufferSize()).toEqual(new THREE.Vector2(1288, 1196))
+  })
+
+  it('does not flag a descriptor flush the renderer already performed', () => {
+    const canvas = document.createElement('canvas')
+    const { renderer, defaultTarget } = makeForwardingRenderer(canvas)
+    const store = makeStoreFor(renderer, defaultTarget)
+
+    store.setState((state) => ({ size: { ...state.size, width: 640, height: 480 } }))
+
+    // Our target was the active one, so three's own resize listener flushed synchronously.
+    expect(renderer.backend.updateSize).toHaveBeenCalled()
+    expect(store.getState().internal.canvasTargetSizeDirty).toBeFalsy()
+  })
+
+  it('still flags the flush when some other canvas holds the renderer', () => {
+    const canvas = document.createElement('canvas')
+    const { renderer, defaultTarget } = makeForwardingRenderer(canvas)
+    const store = makeStoreFor(renderer, defaultTarget, { isMultiCanvas: true })
+    // A secondary rendered last frame and left its target active, as they do.
+    renderer.setCanvasTarget(new CanvasTarget(document.createElement('canvas')))
+    renderer.backend.updateSize.mockClear()
+
+    store.setState((state) => ({ size: { ...state.size, width: 640, height: 480 } }))
+
+    // Nobody heard the resize, and the secondary's target was left alone (#3847 bug 1).
+    expect(renderer.backend.updateSize).not.toHaveBeenCalled()
+    expect(store.getState().internal.canvasTargetSizeDirty).toBe(true)
+    expect(defaultTarget.getDrawingBufferSize(new THREE.Vector2())).toEqual(new THREE.Vector2(640, 480))
+    expect(renderer.getDrawingBufferSize()).toEqual(new THREE.Vector2(1280, 800))
+  })
 })

--- a/packages/fiber/tests/primary-canvas-target.test.tsx
+++ b/packages/fiber/tests/primary-canvas-target.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * A `<Canvas id>` with no secondaries — the ownership of the renderer's canvas target.
+ *
+ * Regression for the alpha.4 form of #3847. The multi-canvas resize fix made a primary size
+ * `internal.canvasTarget` instead of the renderer, which was right for the target and wrong for
+ * what the target was: a second `CanvasTarget` wrapped around the same element as the renderer's
+ * own. three sizes its depth buffer from `renderer._canvasTarget`, listens for resizes on it and
+ * only swaps it in `setCanvasTarget` — which R3F only called once a secondary had flipped
+ * `isMultiCanvas`. So a lone primary sized a target the renderer never drew with: the swap chain
+ * followed the layout, the depth buffer stayed at the element's construction size, and every
+ * frame raised
+ *
+ *   GPUValidationError: The depth stencil attachment [depthBuffer] size (300, 150) does not
+ *   match the size of the other attachments' base plane (1288, 1196).
+ *
+ * The primary's target is now the renderer's own default target, so there is one target per
+ * canvas element and sizing it is sizing the renderer.
+ *
+ * No GPU: the renderer is a mock, but one that keeps three's real contract with CanvasTarget
+ * (target-implicit sizing, the drawing buffer read from the active target, the resize listener
+ * moving with `setCanvasTarget`), because the bug lives entirely in that contract.
+ */
+import * as React from 'react'
+import { act } from 'react'
+import * as THREE from 'three'
+import { CanvasTarget } from 'three/webgpu'
+import { vi } from 'vitest'
+import { getScheduler, Scheduler } from '@pmndrs/scheduler'
+import { createCanvas } from '../../test-renderer/src/createTestCanvas'
+
+import { createRoot, extend } from '../src'
+
+extend(THREE as any)
+
+//* Mock Renderer ==============================
+
+class MockWebGPURenderer {
+  canvas: HTMLCanvasElement
+  /** What the renderer's own target measured at the moment GPU resources would be created. */
+  sizeAtInit: { width: number; height: number; dpr: number } | null = null
+  backend = { isWebGPUBackend: true, updateSize: vi.fn() }
+  shadowMap = { enabled: false, type: THREE.PCFSoftShadowMap }
+  outputColorSpace = THREE.SRGBColorSpace
+  toneMapping = THREE.ACESFilmicToneMapping
+  renderLists = { dispose: () => {} }
+  xr = {
+    enabled: false,
+    isPresenting: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    setAnimationLoop: () => {},
+  }
+  private _initialized = false
+  private _canvasTarget: CanvasTarget
+
+  constructor(params: { canvas: HTMLCanvasElement }) {
+    this.canvas = params.canvas
+    // As three's Renderer constructor does: one target around the element, flagged as default.
+    this._canvasTarget = new CanvasTarget(params.canvas)
+    ;(this._canvasTarget as any).isDefaultCanvasTarget = true
+    this._canvasTarget.addEventListener('resize', this._onCanvasTargetResize)
+  }
+
+  private _onCanvasTargetResize = () => {
+    if (this._initialized) this.backend.updateSize()
+  }
+
+  async init() {
+    const size = this._canvasTarget.getSize(new THREE.Vector2())
+    this.sizeAtInit = { width: size.x, height: size.y, dpr: this._canvasTarget.getPixelRatio() }
+    this._initialized = true
+    this.backend.updateSize()
+  }
+
+  hasInitialized() {
+    return this._initialized
+  }
+
+  getCanvasTarget() {
+    return this._canvasTarget
+  }
+
+  setCanvasTarget = vi.fn((target: CanvasTarget) => {
+    this._canvasTarget.removeEventListener('resize', this._onCanvasTargetResize)
+    this._canvasTarget = target
+    this._canvasTarget.addEventListener('resize', this._onCanvasTargetResize)
+  })
+
+  setSize(width: number, height: number, updateStyle?: boolean) {
+    this._canvasTarget.setSize(width, height, updateStyle)
+  }
+
+  setPixelRatio(value: number) {
+    this._canvasTarget.setPixelRatio(value)
+  }
+
+  getDrawingBufferSize() {
+    return this._canvasTarget.getDrawingBufferSize(new THREE.Vector2())
+  }
+
+  render() {}
+  dispose() {}
+  forceContextLoss() {}
+}
+
+//* Test Helpers ==============================
+
+type TestRoot = ReturnType<typeof createRoot>
+
+describe('a primary canvas owns the renderer default target', () => {
+  const roots: TestRoot[] = []
+  let testRun = 0
+  let testPrefix: string
+
+  beforeEach(() => {
+    Scheduler.reset()
+    testPrefix = `primary-target-${++testRun}`
+  })
+
+  afterEach(async () => {
+    await act(async () => {
+      for (const root of roots) root.unmount()
+    })
+    roots.length = 0
+    Scheduler.reset()
+    vi.restoreAllMocks()
+  })
+
+  /** A canvas the size of the reported repro (1288x1196 at dpr 2). */
+  const size = { width: 644, height: 598, top: 0, left: 0 }
+
+  async function mountPrimary(id: string) {
+    const canvas = createCanvas()
+    const renderer = new MockWebGPURenderer({ canvas })
+    const root = createRoot(canvas)
+    roots.push(root)
+    const store = await act(async () =>
+      (await root.configure({ id, renderer, size, dpr: 2, frameloop: 'never' })).render(<mesh />),
+    )
+    return { canvas, renderer, root, store }
+  }
+
+  async function mountSecondary(primaryCanvas: string, id: string) {
+    const canvas = createCanvas()
+    const root = createRoot(canvas)
+    roots.push(root)
+    // As <Canvas renderer={{ primaryCanvas }}> arrives after parseRendererConfig: the bag is
+    // peeled, and the original prop stays as the (truthy, unused) renderer config.
+    const rendererProp = { primaryCanvas }
+    const store = await act(async () =>
+      (
+        await root.configure({
+          id,
+          primaryCanvas,
+          renderer: rendererProp as any,
+          size: { width: 320, height: 240, top: 0, left: 0 },
+          dpr: 1,
+          frameloop: 'never',
+          scheduler: { after: primaryCanvas },
+        })
+      ).render(<mesh />),
+    )
+    return { canvas, root, store }
+  }
+
+  it("uses the renderer's own default target as its canvas target, not a second wrapper", async () => {
+    const { renderer, store } = await mountPrimary(`${testPrefix}-main`)
+
+    const { canvasTarget } = store.getState().internal
+    expect(canvasTarget).toBe(renderer.getCanvasTarget())
+    expect((canvasTarget as any).isDefaultCanvasTarget).toBe(true)
+  })
+
+  it('sizes the renderer, not just the element, before init creates GPU resources', async () => {
+    const { renderer } = await mountPrimary(`${testPrefix}-main`)
+
+    // The depth buffer is allocated from the target's logical size x pixel ratio. Writing
+    // canvas.width/height directly, as the pre-init step used to, left this at 300x150 / 1.
+    expect(renderer.sizeAtInit).toEqual({ width: 644, height: 598, dpr: 2 })
+  })
+
+  it('lands the initial size on the drawing buffer the depth attachment is built from', async () => {
+    const { renderer } = await mountPrimary(`${testPrefix}-main`)
+
+    // (The element's own width/height are pinned by the test canvas mock, so the target's
+    // drawing buffer is the observable here -- and it is what three sizes the depth buffer from.)
+    expect(renderer.getDrawingBufferSize()).toEqual(new THREE.Vector2(1288, 1196))
+  })
+
+  it('resizes through the renderer and lets three flush its descriptor synchronously', async () => {
+    const { renderer, store } = await mountPrimary(`${testPrefix}-main`)
+    renderer.backend.updateSize.mockClear()
+
+    await act(async () => {
+      store.getState().setSize(700, 500)
+    })
+
+    expect(renderer.getDrawingBufferSize()).toEqual(new THREE.Vector2(1400, 1000))
+    expect(renderer.backend.updateSize).toHaveBeenCalled()
+    // Heard by three's own listener, so no deferred flush is owed.
+    expect(store.getState().internal.canvasTargetSizeDirty).toBeFalsy()
+  })
+
+  it('never swaps targets while it is the only canvas', async () => {
+    const { renderer } = await mountPrimary(`${testPrefix}-main`)
+
+    getScheduler().step(1000)
+    getScheduler().step(1016)
+
+    // The default target is already active; a redundant setCanvasTarget would only churn the
+    // resize listener.
+    expect(renderer.setCanvasTarget).not.toHaveBeenCalled()
+  })
+
+  it('takes the renderer back from a secondary each frame, then flushes a resize it missed', async () => {
+    const mainId = `${testPrefix}-main`
+    const { renderer, store } = await mountPrimary(mainId)
+    const secondary = await mountSecondary(mainId, `${testPrefix}-sec`)
+    const secondaryTarget = secondary.store.getState().internal.canvasTarget!
+
+    // The secondary got its own target around its own element.
+    expect(secondaryTarget).not.toBe(renderer.getCanvasTarget())
+    expect(secondaryTarget.domElement).toBe(secondary.canvas)
+
+    // The secondary runs after the primary and leaves its target active.
+    getScheduler().step(1000)
+    expect(renderer.getCanvasTarget()).toBe(secondaryTarget)
+
+    // Resizing the primary while inactive: nothing hears it, so a flush is owed ...
+    renderer.backend.updateSize.mockClear()
+    await act(async () => {
+      store.getState().setSize(700, 500)
+    })
+    expect(store.getState().internal.canvasTargetSizeDirty).toBe(true)
+    expect(renderer.backend.updateSize).not.toHaveBeenCalled()
+    // ... and the secondary's target was not resized to the primary's dimensions (#3847 bug 1).
+    expect(store.getState().internal.canvasTarget!.getDrawingBufferSize(new THREE.Vector2())).toEqual(
+      new THREE.Vector2(1400, 1000),
+    )
+    expect(secondaryTarget.getDrawingBufferSize(new THREE.Vector2())).toEqual(new THREE.Vector2(320, 240))
+
+    // ... which the primary's start-phase job pays, right after making its target active.
+    getScheduler().step(1016)
+    expect(renderer.setCanvasTarget).toHaveBeenCalledWith(store.getState().internal.canvasTarget)
+    expect(renderer.backend.updateSize).toHaveBeenCalled()
+    expect(store.getState().internal.canvasTargetSizeDirty).toBe(false)
+  })
+})

--- a/packages/fiber/types/store.d.ts
+++ b/packages/fiber/types/store.d.ts
@@ -202,8 +202,13 @@ export interface InternalState {
   /** Container for child attachment (scene for root, original container for portals) */
   container?: THREE.Object3D
   /**
-   * CanvasTarget for multi-canvas WebGPU rendering.
-   * Created for all WebGPU canvases to support renderer sharing.
+   * The CanvasTarget this root sizes and renders through.
+   *
+   * A primary (`<Canvas id>`) owns the renderer's default target -- the one three itself built
+   * around the canvas element -- so sizing it is sizing the renderer. A secondary owns a target
+   * R3F created for its own element. Either way there is exactly one target per canvas element,
+   * and the canvas-target job makes it the renderer's active one before this root renders.
+   * Absent on WebGL and on an id-less WebGPU canvas, where the renderer is sized directly.
    * @see https://threejs.org/docs/#api/en/renderers/common/CanvasTarget
    */
   canvasTarget?: CanvasTarget


### PR DESCRIPTION
## Problem

A WebGPU `<Canvas id>` with no secondaries raised on every frame:

```
THREE.WebGPURenderer: Uncaptured WebGPU GPUValidationError: The depth stencil attachment
[TextureView of Texture "depthBuffer"] size (width: 300, height: 150) does not match the
size of the other attachments' base plane (width: 1288, height: 1196).
```

three's `Renderer` builds its own default `CanvasTarget` around the canvas at construction and sizes the depth buffer from that target's logical size × pixel ratio. R3F wrapped the same element in a **second** `CanvasTarget` for any primary with an id, and #3847 (alpha.4) routed the primary's resize to that wrapper. The renderer only adopted the wrapper in the start-phase job once `isMultiCanvas` was true, which only a mounted secondary sets. So a lone primary sized a target the renderer never drew with: the swap chain followed the layout while the depth buffer stayed at 300×150. With secondaries the same gap was a startup race, since the first frames run before a secondary flips the flag.

The pre-init step had the same flaw: writing `canvas.width/height` moved the swap chain but not the target's `_width/_height`, which is what `init()` allocates from.

## Fix

- The primary's `internal.canvasTarget` is the renderer's own default target. One element, one target: sizing it is sizing the renderer.
- Pre-init sizing goes through `renderer.setPixelRatio` / `renderer.setSize`.
- The canvas-target job runs whenever a root owns a target and only calls `setCanvasTarget` when the active target differs, so the single-canvas path never churns the resize listener.
- `canvasTargetSizeDirty` is only set when three's own listener did not already hear the resize.
- Only secondaries dispose their target on unmount; the primary's belongs to the renderer.

## Verification

- Five new Tier 1 tests (`primary-canvas-target.test.tsx`, `multicanvas-resize.test.tsx`) fail on the unpatched source and pass here. The renderer mock keeps three's real `CanvasTarget` contract: target-implicit sizing, drawing buffer read from the active target, resize listener moving with `setCanvasTarget`.
- Full fiber suite: 43 files, 540 passed.
- Browser repro: `pnpm examples` → **WebGPUPrimaryOnly**. On v10 it throws the error above; here it should render with an empty console and the readout showing `OK`. Resize the window and the readout should keep agreeing.

## Notes

- Downstream: the workshop's `DepthAttachmentSync` workaround should be removed once this lands. Its layout-effect `renderer.setSize` on the primary is target-implicit, so in multi-canvas mode it can resize whichever secondary was last active (#3847 bug 1 reintroduced).
- `pnpm typecheck` has 5 pre-existing errors from #3901 (`useRenderPipeline.tsx`, `webgpu/index.tsx`, one test); v10 CI is already red on them. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
