### PR TITLE
docs: use the core texture hook in the v10 tutorial

### DIFF
--- a/docs/tutorials/loading-textures.mdx
+++ b/docs/tutorials/loading-textures.mdx
@@ -110,10 +110,10 @@ function Scene() {
 
 ## Using `useTexture`
 
-Another way to import these is using `useTexture` from [`@react-three/drei`](https://github.com/pmndrs/drei), that will make it slightly easier and there is no need to import the `TextureLoader`, our code would look like:
+In v10, `useTexture` is built into `@react-three/fiber`, so there is no need to import `TextureLoader` or install drei for this hook. The same textures can be loaded with:
 
 ```js
-import { useTexture } from "@react-three/drei"
+import { useTexture } from '@react-three/fiber'
 
 ...
 
@@ -125,6 +125,8 @@ const [colorMap, displacementMap, normalMap, roughnessMap, aoMap] = useTexture([
   'PavingStones092_1K_AmbientOcclusion.jpg',
 ])
 ```
+
+The `useTexture` hook from [`@react-three/drei`](https://github.com/pmndrs/drei) still works, but is not required for v10.
 
 You can also use object-notation which is the most convenient:
 


### PR DESCRIPTION
## Summary

Update the texture tutorial to import `useTexture` from `@react-three/fiber` in v10. Keep a short note that drei's hook still works, without implying that users need to install it for this example.

Fixes #3795.

## Verification

- Checked the import, array/record input forms and core export against the current v10 source.
- Parsed the complete MDX page with Prettier and the section's two code examples with TypeScript (omitting the existing `...` placeholder for syntax parsing).
- `git diff --check`.

Documentation only. Runtime tests, the embedded third-party sandbox and the hosted documentation build were not run. The existing texture-registry section is unchanged.