### PR TITLE
fix(fiber): reapply stable math props on updates

### DIFF
--- a/docs/API/objects.mdx
+++ b/docs/API/objects.mdx
@@ -50,7 +50,7 @@ All properties whose underlying object has a `.set()` method can directly receiv
 ```
 
 > [!NOTE]
-> If you do link up an existing object to a property, for instance a THREE.Vector3() to a position, be aware that this will end up copying the object in most cases as it calls .copy() on the target. This only applies to objects that expose both .set() and .copy() (Vectors, Eulers, Matrix, ...). If you link up an existing material or geometry on the other hand, it will overwrite, because more these objects do not have a .set() method.
+> If you do link up an existing object to a property, for instance a THREE.Vector3() to a position, be aware that this will end up copying the object in most cases as it calls .copy() on the target. This only applies to objects that expose both .set() and .copy() (Vectors, Eulers, Matrix, ...). These values are copied again on each committed update, even when their reference is unchanged. If you link up an existing material or geometry on the other hand, it will overwrite, because these objects do not have a .set() method.
 
 ### SetScalar
 

--- a/packages/fiber/src/core/utils/props.ts
+++ b/packages/fiber/src/core/utils/props.ts
@@ -189,8 +189,13 @@ export function diffProps<T = any>(instance: Instance<T>, newProps: Instance<T>[
   for (const prop in newProps) {
     // Skip reserved keys
     if (RESERVED_PROPS.includes(prop)) continue
-    // Skip if props match
-    if (is.equ(newProps[prop], instance.props[prop])) continue
+    // Reapply math objects even when their reference is unchanged.
+    if (is.equ(newProps[prop], instance.props[prop])) {
+      const value = newProps[prop]
+      if (!isCopyable(value)) continue
+      const { target } = resolve(instance.object, prop)
+      if (!isCopyable(target) || target.constructor !== value.constructor) continue
+    }
 
     // Props changed, add them
     changedProps[prop] = newProps[prop]

--- a/packages/fiber/tests/renderer.test.tsx
+++ b/packages/fiber/tests/renderer.test.tsx
@@ -56,6 +56,42 @@ describe('renderer', () => {
   })
   afterEach(async () => act(async () => root.unmount()))
 
+  it('should copy a stable position on each committed rerender', async () => {
+    const position = new THREE.Vector3(1, 2, 3)
+    const ref = React.createRef<THREE.Group>()
+    const Component = () => <group ref={ref} position={position} />
+
+    await act(async () => root.render(<Component />))
+    const object = ref.current!
+    const target = object.position
+    expect(target).not.toBe(position)
+    expect(target.toArray()).toEqual([1, 2, 3])
+
+    position.set(4, 5, 6)
+    await act(async () => root.render(<Component />))
+    expect(ref.current).toBe(object)
+    expect(object.position).toBe(target)
+    expect(target.toArray()).toEqual([4, 5, 6])
+
+    target.set(7, 8, 9)
+    await act(async () => root.render(<Component />))
+    expect(target.toArray()).toEqual([4, 5, 6])
+    expect(position.toArray()).toEqual([4, 5, 6])
+  })
+
+  it('should preserve pierced overrides when copying a stable position again', async () => {
+    const position = new THREE.Vector3(1, 2, 3)
+    const ref = React.createRef<THREE.Group>()
+    const Component = () => <group ref={ref} position={position} position-x={10} />
+
+    await act(async () => root.render(<Component />))
+    expect(ref.current!.position.toArray()).toEqual([10, 2, 3])
+
+    position.set(4, 5, 6)
+    await act(async () => root.render(<Component />))
+    expect(ref.current!.position.toArray()).toEqual([10, 5, 6])
+  })
+
   it('should render empty JSX', async () => {
     const store = await act(async () => root.render(null))
     const { scene } = store.getState()

--- a/packages/fiber/tests/utils.test.ts
+++ b/packages/fiber/tests/utils.test.ts
@@ -314,6 +314,29 @@ describe('attach / detach', () => {
 })
 
 describe('diffProps', () => {
+  it.each([
+    new THREE.Vector2(),
+    new THREE.Vector3(),
+    new THREE.Vector4(),
+    new THREE.Euler(),
+    new THREE.Quaternion(),
+    new THREE.Matrix3(),
+    new THREE.Matrix4(),
+    new THREE.Color(),
+  ])('should reapply stable copied math objects (%s)', (value) => {
+    const props = { value }
+    const instance = prepare({ value: value.clone() }, store, '', props)
+
+    expect(diffProps(instance, props)).toStrictEqual(props)
+  })
+
+  it('should still skip stable objects that are assigned directly', () => {
+    const props = { material: new THREE.MeshBasicMaterial(), userData: { value: 1 } }
+    const instance = prepare(new THREE.Mesh(), store, '', props)
+
+    expect(diffProps(instance, props)).toStrictEqual({})
+  })
+
   it('should filter changed props', () => {
     const instance = prepare({}, store, '', { foo: true })
     const newProps = { foo: true, bar: false }


### PR DESCRIPTION
Mutating a stable `Vector3` passed to `position` currently has no effect on subsequent React updates because prop diffing skips the unchanged reference. This looks like an error and I could not find any reasoning why it should apply once and never again. I have multiple patterns I use where the object is stable and mutations trigger a rerender. This changes that behavior.

As a corollary, it is no longer safe to both have a value controlled by props and mutate it via its ref. But I think this is good, a controlled value means React owns the prop.

Pierced property overrides are preserved such as `position-x`.