### PR TITLE
fix(webgpu): resolve v10 CI type errors

### DIFF
--- a/packages/fiber/src/webgpu/hooks/useNodes.tsx
+++ b/packages/fiber/src/webgpu/hooks/useNodes.tsx
@@ -5,7 +5,9 @@ import { clearResourceEntries, rebuildResource, removeResourceEntries } from '..
 import { createLazyCreatorState, type CreatorState } from './ScopedStore'
 import { useScopedResource } from './useScopedResource'
 import { scopedNodeName } from './utils'
-import type { NodeLike } from '../../../types/store'
+import type { NodeLike, NodeRecord } from '../../../types/store'
+
+export type { NodeRecord } from '../../../types/store'
 
 //* Types ==============================
 
@@ -18,12 +20,6 @@ export type TSLNodeLike = NodeLike
 
 /** TSL node type - alias for compatibility */
 export type TSLNode = TSLNodeLike
-
-/**
- * A record of TSL nodes - allows mixed node types (OperatorNode, ConstNode, etc.)
- * Uses TSLNodeLike for broader compatibility with Three.js's TSL type definitions.
- */
-export type NodeRecord<T extends TSLNodeLike = TSLNodeLike> = Record<string, T>
 
 /**
  * Creator function that returns a record of nodes.

--- a/packages/fiber/tests/webgpu/webgpu-hooks-lifecycle.test.tsx
+++ b/packages/fiber/tests/webgpu/webgpu-hooks-lifecycle.test.tsx
@@ -29,7 +29,7 @@ import * as React from 'react'
 import { act } from 'react'
 import { render } from '@testing-library/react'
 import * as THREE from 'three/webgpu'
-import { color, vec3, float, instancedArray, uniform } from 'three/tsl'
+import { color, vec3, float, instancedArray, uniform, pass } from 'three/tsl'
 
 import { createStore, context } from '../../src/core/store'
 import {
@@ -586,26 +586,26 @@ describe('useRenderPipeline — pipeline wiring against the store', () => {
   it('setupCB + mainCB run and their returned passes land on the store', async () => {
     const store = makeStore()
     const { scene, camera } = seedRenderer(store)
+    const setupPass = pass(scene, camera)
+    const extraPass = pass(scene, camera)
     let mainRan = false
     function Comp() {
       useRenderPipeline(
         () => {
           mainRan = true
-          return { extraPass: (globalThis as any).__x ?? { marker: true } }
+          return { extraPass }
         },
-        () => ({ setupPass: { marker: true } }),
+        () => ({ setupPass }),
       )
       return null
     }
     await act(async () => withStore(store, <Comp />))
 
     expect(mainRan).toBe(true)
-    expect(store.getState().passes.setupPass).toBeDefined()
-    expect(store.getState().passes.extraPass).toBeDefined()
+    expect(store.getState().passes.setupPass).toBe(setupPass)
+    expect(store.getState().passes.extraPass).toBe(extraPass)
     // scenePass still keyed off the seeded scene/camera
     expect(store.getState().passes.scenePass).toBeDefined()
-    void scene
-    void camera
   })
 
   it('reset(): tears the pipeline + passes back down to null/empty', async () => {

--- a/packages/fiber/types/store.d.ts
+++ b/packages/fiber/types/store.d.ts
@@ -61,7 +61,7 @@ export interface NodeLike {
 }
 
 /** Flat record of TSL nodes (no nested scopes) */
-export type NodeRecord = Record<string, NodeLike>
+export type NodeRecord<T extends NodeLike = NodeLike> = Record<string, T>
 
 /**
  * Node store that can contain both root-level nodes and scoped node objects.


### PR DESCRIPTION
Both React 19.0.0 and latest CI jobs stop at typechecking because the WebGPU entry exports two distinct `NodeRecord` declarations and a render-pipeline lifecycle test returns a plain object instead of a Three.js node.

Share the generic `NodeRecord` declaration between the store and node hooks, preserving existing import paths and generic usage. Update the lifecycle test to return real pass nodes and verify that the exact nodes reach the store.

Validation: `pnpm run ci` passes locally, including build, bundle/type verification, typechecking, lint, 641 passing tests (9 TODOs), coverage thresholds, and formatting.
