### PR TITLE
chore(release): prepare v10.0.0-alpha.5

### DIFF
--- a/CHANGELOG-ALPHA.md
+++ b/CHANGELOG-ALPHA.md
@@ -4,10 +4,12 @@ This changelog tracks changes during the v10 alpha period. For the full per-pack
 
 ---
 
-## Unreleased
+## 10.0.0-alpha.5
 
-Type and reconciler cleanup ahead of the next alpha, driven by what strict-TypeScript consumers
-of the WebGPU entry hit in practice.
+Alpha 5 is a types release. The WebGPU resource hooks now carry three's exact node generics, the
+stale TSL augmentations are gone, and the built declarations are compiled by a strict consumer
+fixture on every build. Alongside it: the reconciler oddities that strict-TypeScript consumers
+surfaced while working around the old types, and the single-canvas depth-attachment fix.
 
 ### Types
 
@@ -58,6 +60,21 @@ of the WebGPU entry hit in practice.
   sibling wrapped are declarative: `lightsNode={fromRef(lightRef, (l) => lights([l]))}`.
 - Six-file `.hdr` cube sets load through `HDRCubeTextureLoader` in `useEnvironment`,
   `<Environment>` and the Canvas `background` prop, with linear color space.
+- A lone primary `<Canvas id>` owns the renderer's default canvas target, so its depth attachment
+  follows the layout instead of the element's construction size
+  ([#3905](https://github.com/pmndrs/react-three-fiber/pull/3905)).
+- Canvas honors the `resize.debounce` prop after the initial measurement
+  ([#3881](https://github.com/pmndrs/react-three-fiber/pull/3881)).
+- `useRenderPipeline` callbacks receive a `WebGPURenderer`-typed state, may not return the
+  hook-owned `scenePass`, and the hook's return narrows `renderPipeline` on `isReady`
+  ([#3901](https://github.com/pmndrs/react-three-fiber/pull/3901)).
+- The Pointcloud example's fragment shader handles point colors correctly.
+
+### Examples
+
+- The demo registry is the one table of contents; the app derives its groups from it. Adds
+  `WebGPUFog` and `WebGPUPrimaryOnly`, drops stale entries, and the examples cleanup from
+  [#3883](https://github.com/pmndrs/react-three-fiber/pull/3883).
 
 ### eslint-plugin
 

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @react-three/eslint-plugin
 
-## Unreleased
+## 1.0.0-alpha.5
 
 ### Patch Changes
 

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-three/eslint-plugin",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.5",
   "description": "An ESLint plugin which provides lint rules for @react-three/fiber.",
   "keywords": [
     "react",

--- a/packages/fiber/CHANGELOG.md
+++ b/packages/fiber/CHANGELOG.md
@@ -1,8 +1,9 @@
 # @react-three/fiber
 
-## Unreleased
+## 10.0.0-alpha.5
 
-Full detail is in [`CHANGELOG-ALPHA.md`](../../CHANGELOG-ALPHA.md#unreleased) at the repo root.
+Full detail is in
+[`CHANGELOG-ALPHA.md`](../../CHANGELOG-ALPHA.md#1000-alpha5) at the repo root.
 
 ### Types
 
@@ -21,6 +22,9 @@ Full detail is in [`CHANGELOG-ALPHA.md`](../../CHANGELOG-ALPHA.md#unreleased) at
   arguments.
 - `fromRef(ref, transform)` maps the resolved sibling before assignment.
 - Six-file `.hdr` cube sets load through `HDRCubeTextureLoader`.
+- A lone primary `<Canvas id>` owns the renderer's default canvas target (#3905).
+- Canvas honors the `resize.debounce` prop after the initial measurement (#3881).
+- `useRenderPipeline` callbacks get WebGPU-typed state and a return narrowed on `isReady` (#3901).
 
 ## 10.0.0-alpha.4
 

--- a/packages/fiber/package.json
+++ b/packages/fiber/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-three/fiber",
-  "version": "10.0.0-alpha.4",
+  "version": "10.0.0-alpha.5",
   "description": "A React renderer for Threejs",
   "keywords": [
     "react",

--- a/packages/test-renderer/CHANGELOG.md
+++ b/packages/test-renderer/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @react-three/test-renderer
 
+## 10.0.0-alpha.5
+
+### Patch Changes
+
+- Tracks `@react-three/fiber@10.0.0-alpha.5`. There are no package-specific runtime changes in this
+  release. See [Fiber's changelog](../fiber/CHANGELOG.md) and the
+  [full Alpha 5 notes](../../CHANGELOG-ALPHA.md#1000-alpha5).
+
 ## 10.0.0-alpha.4
 
 ### Patch Changes

--- a/packages/test-renderer/package.json
+++ b/packages/test-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-three/test-renderer",
-  "version": "10.0.0-alpha.4",
+  "version": "10.0.0-alpha.5",
   "description": "Test Renderer for react-three-fiber",
   "author": "Josh Ellis",
   "license": "MIT",


### PR DESCRIPTION
Release prep for alpha.5, following the alpha.4 shape: the Unreleased changelog sections become `10.0.0-alpha.5` (fiber, test-renderer, root `CHANGELOG-ALPHA.md`) and `1.0.0-alpha.5` (eslint-plugin), and the three package versions are bumped to match. No source changes.

Feature and fix content shipped in #3911, #3901, #3905, #3881, #3882, #3883.

After merge: `pnpm run ci` on `v10`, then `pnpm release` (the script derives the `alpha` dist-tag from the versions), then tag `v10.0.0-alpha.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)